### PR TITLE
feat(core): Add expected parsing for CA IO

### DIFF
--- a/Examples/ca_io_expected_example.cc
+++ b/Examples/ca_io_expected_example.cc
@@ -1,0 +1,103 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file ca_io_expected_example.cc
+ * @brief Parsing CA patterns without exceptions via the `try_read_*` overloads.
+ *
+ * The `try_read_*` readers in `ca-io.H` return `Aleph::expected<Result,
+ * std::string>` instead of throwing. This is convenient when the input is
+ * untrusted (a user-supplied file): an invalid pattern is an ordinary result,
+ * not an exceptional condition, and the call site reads as a simple branch.
+ *
+ * Build & run:
+ *   cmake --build build --target ca_io_expected_example
+ *   ./build/Examples/ca_io_expected_example
+ */
+
+#include <cstddef>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <ca-io.H>
+
+using namespace Aleph;
+using namespace Aleph::CA;
+
+namespace
+{
+
+void load_rle(const std::string &label, const std::string &text)
+{
+  // No try/catch: the error is a value we inspect.
+  auto result = try_read_rle_string(text);
+  std::cout << "  " << label << ": ";
+  if (result)
+    std::cout << "ok — " << result->width << "x" << result->height << " grid, "
+              << result->alive.size() << " live cell(s)\n";
+  else
+    std::cout << "rejected — " << result.error() << '\n';
+}
+
+}  // namespace
+
+int main()
+{
+  std::cout << "Parsing RLE patterns with try_read_rle_string (no exceptions):\n";
+
+  load_rle("glider", "x = 3, y = 3, rule = B3/S23\nbob$2bo$3o!\n");
+  load_rle("blinker", "x = 3, y = 1, rule = B3/S23\n3o!\n");
+  load_rle("garbage", "this is not a pattern @@@");
+  load_rle("truncated", "x = 5, y = 5, rule = B3/S23\n");
+
+  // A pipeline that loads from one of several formats, recovering on failure.
+  std::cout << "\nFalling back across formats with or_else:\n";
+  const std::string maybe_life = "#Life 1.06\n0 0\n1 0\n2 0\n";
+
+  std::istringstream rle_in(maybe_life);
+  auto cells =
+      try_read_rle(rle_in)                         // try RLE first...
+          .transform([](const RLE_Pattern &p) { return p.alive.size(); })
+          .or_else(
+              [&](const std::string &) -> expected<std::size_t, std::string>
+              {
+                // ...not RLE; fall back to Life 1.06.
+                std::istringstream life_in(maybe_life);
+                return try_read_life_106(life_in).transform(
+                    [](const Binary_Cell_Pattern &p) { return p.alive.size(); });
+              });
+
+  if (cells)
+    std::cout << "  parsed " << *cells << " live cell(s) after fallback\n";
+  else
+    std::cout << "  every format failed: " << cells.error() << '\n';
+
+  return 0;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -455,6 +455,7 @@ set(TEST_PROGRAMS
     tpl_ca_continuous_rules_test
     tpl_ca_hashlife_test
     ca_io_test
+    ca_io_expected_test
     ca_tikz_frame_stream_test
     ca_visual_sinks_test
     ca_animation_sinks_test

--- a/Tests/ca_io_expected_test.cc
+++ b/Tests/ca_io_expected_test.cc
@@ -71,6 +71,28 @@ TEST(CaIoExpected, RleIstreamOverload)
   EXPECT_EQ(r->alive.size(), 3u);
 }
 
+TEST(CaIoExpected, RleEmptyInputFails)
+{
+  auto r = try_read_rle_string("");
+  ASSERT_FALSE(r.has_value());
+  EXPECT_FALSE(r.error().empty());
+}
+
+// --- Plaintext -------------------------------------------------------------
+
+TEST(CaIoExpected, PlaintextSuccessAndError)
+{
+  std::istringstream ok("!Blinker\nOOO\n");
+  auto a = try_read_plaintext(ok);
+  ASSERT_TRUE(a.has_value()) << (a.has_value() ? "" : a.error());
+  EXPECT_EQ(a->alive.size(), 3u);
+
+  std::istringstream bad("!Comment\nO@O\n");  // '@' is invalid
+  auto b = try_read_plaintext(bad);
+  ASSERT_FALSE(b.has_value());
+  EXPECT_FALSE(b.error().empty());
+}
+
 // --- Life ------------------------------------------------------------------
 
 TEST(CaIoExpected, Life105SuccessAndError)
@@ -99,6 +121,19 @@ TEST(CaIoExpected, Life106SuccessAndError)
   EXPECT_FALSE(b.error().empty());
 }
 
+TEST(CaIoExpected, LifeEmptyInputFails)
+{
+  std::istringstream empty105("");
+  auto a = try_read_life_105(empty105);
+  ASSERT_FALSE(a.has_value());
+  EXPECT_FALSE(a.error().empty());
+
+  std::istringstream empty106("");
+  auto b = try_read_life_106(empty106);
+  ASSERT_FALSE(b.has_value());
+  EXPECT_FALSE(b.error().empty());
+}
+
 // --- CSV -------------------------------------------------------------------
 
 TEST(CaIoExpected, CsvSuccessAndError)
@@ -115,12 +150,29 @@ TEST(CaIoExpected, CsvSuccessAndError)
   EXPECT_FALSE(b.error().empty());
 }
 
+TEST(CaIoExpected, CsvEmptyInputHandled)
+{
+  std::istringstream empty("");
+  auto r = try_read_csv_snapshot<int>(empty);
+  ASSERT_TRUE(r.has_value()) << (r.has_value() ? "" : r.error());
+  EXPECT_EQ(r->height, 0u);  // empty CSV is valid: 0 rows
+}
+
 // --- The throwing readers are unchanged ------------------------------------
 
 TEST(CaIoExpected, ThrowingReadersStillThrow)
 {
   EXPECT_ANY_THROW((void) read_rle_string("not an RLE @@@"));
 
-  std::istringstream bad("garbage\n");
-  EXPECT_ANY_THROW((void) read_life_105(bad));
+  std::istringstream bad_plaintext("O@O\n");  // '@' invalid
+  EXPECT_ANY_THROW((void) read_plaintext(bad_plaintext));
+
+  std::istringstream bad_life105("garbage\n");
+  EXPECT_ANY_THROW((void) read_life_105(bad_life105));
+
+  std::istringstream bad_life106("#Life 1.06\nnot two integers\n");
+  EXPECT_ANY_THROW((void) read_life_106(bad_life106));
+
+  std::istringstream bad_csv("1,2,3\n1,2\n");  // ragged rows
+  EXPECT_ANY_THROW((void) read_csv_snapshot<int>(bad_csv));
 }

--- a/Tests/ca_io_expected_test.cc
+++ b/Tests/ca_io_expected_test.cc
@@ -1,0 +1,126 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file ca_io_expected_test.cc
+ * @brief Tests for the non-throwing `try_read_*` parser overloads (ca-io.H).
+ *
+ * Each try_read_* must return a value on valid input and an error message on
+ * invalid input, while the corresponding throwing reader keeps throwing.
+ */
+
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <ca-io.H>
+
+using namespace Aleph;
+using namespace Aleph::CA;
+
+// --- RLE -------------------------------------------------------------------
+
+TEST(CaIoExpected, RleSuccess)
+{
+  auto r = try_read_rle_string("x = 3, y = 3, rule = B3/S23\nbob$2bo$3o!\n");
+  ASSERT_TRUE(r.has_value()) << (r.has_value() ? "" : r.error());
+  EXPECT_EQ(r->width, 3u);
+  EXPECT_EQ(r->height, 3u);
+  EXPECT_EQ(r->alive.size(), 5u);  // glider
+}
+
+TEST(CaIoExpected, RleErrorCarriesMessage)
+{
+  auto r = try_read_rle_string("this is not an RLE file @@@");
+  ASSERT_FALSE(r.has_value());
+  EXPECT_FALSE(r.error().empty());
+}
+
+TEST(CaIoExpected, RleIstreamOverload)
+{
+  std::istringstream in("x = 3, y = 1, rule = B3/S23\n3o!\n");
+  auto r = try_read_rle(in);
+  ASSERT_TRUE(r.has_value()) << (r.has_value() ? "" : r.error());
+  EXPECT_EQ(r->alive.size(), 3u);
+}
+
+// --- Life ------------------------------------------------------------------
+
+TEST(CaIoExpected, Life105SuccessAndError)
+{
+  std::istringstream ok("#Life 1.05\n#P 0 0\n***\n");
+  auto a = try_read_life_105(ok);
+  ASSERT_TRUE(a.has_value()) << (a.has_value() ? "" : a.error());
+  EXPECT_EQ(a->alive.size(), 3u);
+
+  std::istringstream bad("garbage without a header\n");
+  auto b = try_read_life_105(bad);
+  ASSERT_FALSE(b.has_value());
+  EXPECT_FALSE(b.error().empty());
+}
+
+TEST(CaIoExpected, Life106SuccessAndError)
+{
+  std::istringstream ok("#Life 1.06\n0 0\n1 0\n2 0\n");
+  auto a = try_read_life_106(ok);
+  ASSERT_TRUE(a.has_value()) << (a.has_value() ? "" : a.error());
+  EXPECT_EQ(a->alive.size(), 3u);
+
+  std::istringstream bad("#Life 1.06\nnot two integers\n");
+  auto b = try_read_life_106(bad);
+  ASSERT_FALSE(b.has_value());
+  EXPECT_FALSE(b.error().empty());
+}
+
+// --- CSV -------------------------------------------------------------------
+
+TEST(CaIoExpected, CsvSuccessAndError)
+{
+  std::istringstream ok("0,1,0\n0,1,0\n0,1,0\n");
+  auto a = try_read_csv_snapshot<int>(ok);
+  ASSERT_TRUE(a.has_value()) << (a.has_value() ? "" : a.error());
+  EXPECT_EQ(a->height, 3u);
+  EXPECT_EQ(a->width, 3u);
+
+  std::istringstream ragged("0,1,0\n1,1\n");  // inconsistent width
+  auto b = try_read_csv_snapshot<int>(ragged);
+  ASSERT_FALSE(b.has_value());
+  EXPECT_FALSE(b.error().empty());
+}
+
+// --- The throwing readers are unchanged ------------------------------------
+
+TEST(CaIoExpected, ThrowingReadersStillThrow)
+{
+  EXPECT_ANY_THROW((void) read_rle_string("not an RLE @@@"));
+
+  std::istringstream bad("garbage\n");
+  EXPECT_ANY_THROW((void) read_life_105(bad));
+}

--- a/ca-io.H
+++ b/ca-io.H
@@ -481,10 +481,10 @@ inline T parse_scalar(const std::string &token, const char *format)
   std::istringstream in(trim_copy(token));
   T value{};
   in >> value;
-  ah_domain_error_if(not in) << format << ": cannot parse scalar '" << token << "'";
+  ah_domain_error_unless(in) << format << ": cannot parse scalar '" << token << "'";
   std::string rest;
   in >> rest;
-  ah_domain_error_if(not rest.empty())
+  ah_domain_error_unless(rest.empty())
     << format << ": trailing characters in scalar '" << token << "'";
   return value;
 }
@@ -768,7 +768,6 @@ template <typename Lattice>
               break;
             }
           else
-            // white space is accepted between tokens
             ah_domain_error_unless(std::isspace(static_cast<unsigned char>(ch)))
               << "read_rle: invalid body character '" << ch << "'";
         }
@@ -936,14 +935,11 @@ template <typename Lattice>
         }
       std::string row;
       for (const char c : line)
-        {
-          if (c == 'O' or c == 'o' or c == '*' or c == '.')
-            row.push_back(c);
-          else
-            // white space is acceped netween tokens
-            ah_domain_error_unless(std::isspace(static_cast<unsigned char>(c)))
-              << "read_plaintext: invalid character '" << c << "'";
-        }
+        if (c == 'O' or c == 'o' or c == '*' or c == '.')
+          row.push_back(c);
+        else
+          ah_domain_error_unless(std::isspace(static_cast<unsigned char>(c)))
+            << "read_plaintext: invalid character '" << c << "'";
       rows.append(std::move(row));
     }
 
@@ -1052,7 +1048,7 @@ inline void write_life_106(std::ostream &out,
         }
     }
 
-  ah_domain_error_if(not header_seen) << "read_life_106: missing #Life 1.06 header";
+  ah_domain_error_unless(header_seen) << "read_life_106: missing #Life 1.06 header";
   ca_io_detail::finalise_absolute_pattern(pattern, absolute, have, min_r, min_c, max_r, max_c);
   return pattern;
 }
@@ -1168,7 +1164,7 @@ inline void write_life_105(std::ostream &out,
           continue;
         }
 
-      ah_domain_error_if(not in_block) << "read_life_105: pattern row before #P block";
+      ah_domain_error_unless(in_block) << "read_life_105: pattern row before #P block";
       ca_index_t local_col = 0;
       for (const char c : line)
         {
@@ -1181,13 +1177,14 @@ inline void write_life_105(std::ostream &out,
                 absolute.append(Coord_Vec<2>{row, col});
               ++local_col;
             }
-          ah_domain_error_unless(std::isspace(static_cast<unsigned char>(c)))
-            << "read_life_105: invalid row character '" << c << "'";
+          else
+            ah_domain_error_unless(std::isspace(static_cast<unsigned char>(c)))
+              << "read_life_105: invalid row character '" << c << "'";
         }
       ++local_row;
     }
 
-  ah_domain_error_if(not header_seen) << "read_life_105: missing #Life 1.05 header";
+  ah_domain_error_unless(header_seen) << "read_life_105: missing #Life 1.05 header";
   ca_io_detail::finalise_absolute_pattern(pattern, absolute, have_extent, min_r, min_c, max_r, max_c);
   return pattern;
 }
@@ -1632,7 +1629,6 @@ public:
   }
 };
 
-// ---------------------------------------------------------------------------
 // Non-throwing parser overloads.
 //
 // Each `try_read_*` wraps the corresponding throwing reader above and returns

--- a/ca-io.H
+++ b/ca-io.H
@@ -66,6 +66,7 @@
 #include <type_traits>
 #include <utility>
 
+#include <ah-cpp-compat.H>
 #include <ah-errors.H>
 #include <tpl_array.H>
 
@@ -86,7 +87,7 @@ struct RGB8
   std::uint8_t g = 0;  ///< green channel
   std::uint8_t b = 0;  ///< blue channel
 
-  friend constexpr bool operator==(RGB8, RGB8) noexcept = default;
+  friend constexpr bool operator == (RGB8, RGB8) noexcept = default;
 };
 
 /** @brief Binary pattern shared by RLE, plaintext and Life formats.
@@ -101,12 +102,12 @@ struct RGB8
  */
 struct Binary_Cell_Pattern
 {
-  ca_size_t width = 0;                ///< number of columns
-  ca_size_t height = 0;               ///< number of rows
-  ca_index_t origin_row = 0;          ///< original row offset before normalisation
-  ca_index_t origin_col = 0;          ///< original column offset before normalisation
-  std::string rule;                   ///< optional rule string, e.g. `B3/S23`
-  std::string name;                   ///< optional pattern name
+  ca_size_t width = 0;          ///< number of columns
+  ca_size_t height = 0;         ///< number of rows
+  ca_index_t origin_row = 0;    ///< original row offset before normalisation
+  ca_index_t origin_col = 0;    ///< original column offset before normalisation
+  std::string rule;             ///< optional rule string, e.g. `B3/S23`
+  std::string name;             ///< optional pattern name
   Array<std::string> comments;  ///< format comments without marker prefixes
   Array<Coord_Vec<2>> alive;    ///< live cells as `{row, col}`
 };
@@ -226,7 +227,7 @@ struct Binary_Gray_Mapper
    *  @param[in] v cell value.
    *  @return grayscale byte.
    */
-  [[nodiscard]] std::uint8_t operator()(const State &v) const
+  [[nodiscard]] std::uint8_t operator () (const State &v) const
   {
     return v == dead ? dead_value : alive_value;
   }
@@ -250,7 +251,7 @@ struct Binary_RGB_Mapper
    *  @param[in] v cell value.
    *  @return RGB byte triplet.
    */
-  [[nodiscard]] RGB8 operator()(const State &v) const
+  [[nodiscard]] RGB8 operator () (const State &v) const
   {
     return v == dead ? dead_colour : alive_colour;
   }
@@ -628,13 +629,13 @@ inline void write_rle(std::ostream &out,
     {
       for (ca_size_t r = r0; r < r1; ++r)
         {
-          bool run_alive
-            = frame.at(coord_t{static_cast<ca_index_t>(r), static_cast<ca_index_t>(c0)}) != dead;
+          bool run_alive =
+            frame.at(coord_t{static_cast<ca_index_t>(r), static_cast<ca_index_t>(c0)}) != dead;
           ca_size_t run = 0;
           for (ca_size_t c = c0; c < c1; ++c)
             {
-              const bool alive
-                = frame.at(coord_t{static_cast<ca_index_t>(r), static_cast<ca_index_t>(c)}) != dead;
+              const bool alive =
+                frame.at(coord_t{static_cast<ca_index_t>(r), static_cast<ca_index_t>(c)}) != dead;
               if (alive == run_alive)
                 ++run;
               else
@@ -664,10 +665,10 @@ inline void write_rle(std::ostream &out,
  *  @return RLE document.
  */
 template <typename Lattice>
-[[nodiscard]] inline std::string write_rle_string(const Lattice &frame,
-                                                  const RLE_Write_Options &opts = {},
-                                                  const typename Lattice::state_type &dead
-                                                  = typename Lattice::state_type{})
+[[nodiscard]] inline std::string write_rle_string(
+  const Lattice &frame,
+  const RLE_Write_Options &opts = {},
+  const typename Lattice::state_type &dead = typename Lattice::state_type{})
 {
   std::ostringstream out;
   write_rle(out, frame, opts, dead);
@@ -766,12 +767,10 @@ template <typename Lattice>
               run = 0;
               break;
             }
-          else if (std::isspace(static_cast<unsigned char>(ch)))
-            {
-              // whitespace is accepted between tokens
-            }
           else
-            ah_domain_error_if(true) << "read_rle: invalid body character '" << ch << "'";
+            // white space is accepted between tokens
+            ah_domain_error_unless(std::isspace(static_cast<unsigned char>(ch)))
+              << "read_rle: invalid body character '" << ch << "'";
         }
     }
 
@@ -808,21 +807,20 @@ template <typename Lattice>
  *  O(frame cells + live cells).
  */
 template <typename Lattice>
-inline void load_binary_pattern(const Binary_Cell_Pattern &pattern,
-                                Lattice &frame,
-                                const typename Lattice::state_type &alive
-                                = static_cast<typename Lattice::state_type>(1),
-                                const typename Lattice::state_type &dead
-                                = typename Lattice::state_type{},
-                                const ca_index_t origin_row = 0,
-                                const ca_index_t origin_col = 0)
+inline void load_binary_pattern(
+  const Binary_Cell_Pattern &pattern,
+  Lattice &frame,
+  const typename Lattice::state_type &alive = static_cast<typename Lattice::state_type>(1),
+  const typename Lattice::state_type &dead = typename Lattice::state_type{},
+  const ca_index_t origin_row = 0,
+  const ca_index_t origin_col = 0)
 {
   ca_io_detail::require_rank2<Lattice>("load_binary_pattern");
   using coord_t = typename Lattice::coord_type;
   ah_domain_error_if(origin_row < 0 or origin_col < 0)
     << "load_binary_pattern: negative destination origin";
-  ah_domain_error_if(static_cast<ca_size_t>(origin_row) + pattern.height > frame.size(0)
-                     or static_cast<ca_size_t>(origin_col) + pattern.width > frame.size(1))
+  ah_domain_error_if(static_cast<ca_size_t>(origin_row) + pattern.height > frame.size(0) or
+                     static_cast<ca_size_t>(origin_col) + pattern.width > frame.size(1))
     << "load_binary_pattern: pattern " << pattern.height << "x" << pattern.width
     << " does not fit in frame " << frame.size(0) << "x" << frame.size(1);
 
@@ -843,11 +841,10 @@ inline void load_binary_pattern(const Binary_Cell_Pattern &pattern,
  *  O(pattern area + live cells).
  */
 template <typename Lattice>
-[[nodiscard]] inline Lattice make_lattice_from_pattern(const Binary_Cell_Pattern &pattern,
-                                                       const typename Lattice::state_type &alive
-                                                       = static_cast<typename Lattice::state_type>(1),
-                                                       const typename Lattice::state_type &dead
-                                                       = typename Lattice::state_type{})
+[[nodiscard]] inline Lattice make_lattice_from_pattern(
+  const Binary_Cell_Pattern &pattern,
+  const typename Lattice::state_type &alive = static_cast<typename Lattice::state_type>(1),
+  const typename Lattice::state_type &dead = typename Lattice::state_type{})
 {
   ca_io_detail::require_rank2<Lattice>("make_lattice_from_pattern");
   Lattice frame({pattern.height, pattern.width}, dead);
@@ -898,10 +895,10 @@ inline void write_plaintext(std::ostream &out,
  *  @return plaintext document.
  */
 template <typename Lattice>
-[[nodiscard]] inline std::string write_plaintext_string(const Lattice &frame,
-                                                        const Plaintext_Write_Options &opts = {},
-                                                        const typename Lattice::state_type &dead
-                                                        = typename Lattice::state_type{})
+[[nodiscard]] inline std::string write_plaintext_string(
+  const Lattice &frame,
+  const Plaintext_Write_Options &opts = {},
+  const typename Lattice::state_type &dead = typename Lattice::state_type{})
 {
   std::ostringstream out;
   write_plaintext(out, frame, opts, dead);
@@ -942,11 +939,10 @@ template <typename Lattice>
         {
           if (c == 'O' or c == 'o' or c == '*' or c == '.')
             row.push_back(c);
-          else if (std::isspace(static_cast<unsigned char>(c)))
-            {
-            }
           else
-            ah_domain_error_if(true) << "read_plaintext: invalid character '" << c << "'";
+            // white space is acceped netween tokens
+            ah_domain_error_unless(std::isspace(static_cast<unsigned char>(c)))
+              << "read_plaintext: invalid character '" << c << "'";
         }
       rows.append(std::move(row));
     }
@@ -1123,21 +1119,21 @@ inline void write_life_105(std::ostream &out,
   bool have_extent = false;
 
   auto touch_extent = [&](ca_index_t row, ca_index_t col)
-  {
-    if (not have_extent)
-      {
-        min_r = max_r = row;
-        min_c = max_c = col;
-        have_extent = true;
-      }
-    else
-      {
-        min_r = std::min(min_r, row);
-        min_c = std::min(min_c, col);
-        max_r = std::max(max_r, row);
-        max_c = std::max(max_c, col);
-      }
-  };
+    {
+      if (not have_extent)
+        {
+          min_r = max_r = row;
+          min_c = max_c = col;
+          have_extent = true;
+        }
+      else
+        {
+          min_r = std::min(min_r, row);
+          min_c = std::min(min_c, col);
+          max_r = std::max(max_r, row);
+          max_c = std::max(max_c, col);
+        }
+    };
 
   while (std::getline(in, line))
     {
@@ -1185,11 +1181,8 @@ inline void write_life_105(std::ostream &out,
                 absolute.append(Coord_Vec<2>{row, col});
               ++local_col;
             }
-          else if (std::isspace(static_cast<unsigned char>(c)))
-            {
-            }
-          else
-            ah_domain_error_if(true) << "read_life_105: invalid row character '" << c << "'";
+          ah_domain_error_unless(std::isspace(static_cast<unsigned char>(c)))
+            << "read_life_105: invalid row character '" << c << "'";
         }
       ++local_row;
     }
@@ -1519,10 +1512,10 @@ inline void write_ppm(std::ostream &out,
   for (ca_size_t r = 0; r < frame.size(0); ++r)
     for (ca_size_t c = 0; c < frame.size(1); ++c)
       {
-        const RGB8 rgb
-          = mapper(frame.at(coord_t{static_cast<ca_index_t>(r), static_cast<ca_index_t>(c)}));
-        const char bytes[3]
-          = {static_cast<char>(rgb.r), static_cast<char>(rgb.g), static_cast<char>(rgb.b)};
+        const RGB8 rgb =
+          mapper(frame.at(coord_t{static_cast<ca_index_t>(r), static_cast<ca_index_t>(c)}));
+        const char bytes[3] = {static_cast<char>(rgb.r), static_cast<char>(rgb.g),
+                               static_cast<char>(rgb.b)};
         out.write(bytes, 3);
       }
   ca_io_detail::ensure_stream_ok(out, "write_ppm");
@@ -1576,7 +1569,7 @@ public:
   }
 
   JSON_Frame_Stream_Writer(const JSON_Frame_Stream_Writer &) = delete;
-  JSON_Frame_Stream_Writer &operator=(const JSON_Frame_Stream_Writer &) = delete;
+  JSON_Frame_Stream_Writer &operator = (const JSON_Frame_Stream_Writer &) = delete;
 
   /** @brief Finish the JSON document if it is still open.
    *
@@ -1638,6 +1631,98 @@ public:
     ca_io_detail::ensure_stream_ok(*out_, "JSON_Frame_Stream_Writer::close");
   }
 };
+
+// ---------------------------------------------------------------------------
+// Non-throwing parser overloads.
+//
+// Each `try_read_*` wraps the corresponding throwing reader above and returns
+// `Aleph::expected<Result, std::string>`: the parsed value on success, or the
+// error message on failure. Useful when parsing untrusted input where an
+// invalid file is an expected outcome rather than an exceptional one. The
+// throwing readers are unchanged.
+// ---------------------------------------------------------------------------
+
+namespace ca_io_detail {
+
+/// Invoke a parser, translating any thrown exception into the error channel of
+/// `expected`. The Aleph error macros (`ah_*_error`) throw types deriving from
+/// `std::exception`, so their message is preserved.
+template <class F>
+[[nodiscard]] auto try_parse(F &&parse, const char *context)
+  -> expected<std::invoke_result_t<F &>, std::string>
+{
+  try
+    {
+      return parse();
+    }
+  catch (const std::exception &e)
+    {
+      return unexpected<std::string>(std::string(e.what()));
+    }
+  catch (...)
+    {
+      return unexpected<std::string>(std::string(context) + ": unknown error");
+    }
+}
+
+}  // namespace ca_io_detail
+
+/// Non-throwing variant of `read_rle`.
+[[nodiscard]] inline expected<RLE_Pattern, std::string> try_read_rle(std::istream &in)
+{
+  return ca_io_detail::try_parse([&]
+    {
+      return read_rle(in);
+    }, "try_read_rle");
+}
+
+/// Non-throwing variant of `read_rle_string`.
+[[nodiscard]] inline expected<RLE_Pattern, std::string> try_read_rle_string(const std::string &s)
+{
+  return ca_io_detail::try_parse([&]
+    {
+      return read_rle_string(s);
+    }, "try_read_rle_string");
+}
+
+/// Non-throwing variant of `read_plaintext`.
+[[nodiscard]] inline expected<Binary_Cell_Pattern, std::string> try_read_plaintext(std::istream &in)
+{
+  return ca_io_detail::try_parse([&]
+    {
+      return read_plaintext(in);
+    }, "try_read_plaintext");
+}
+
+/// Non-throwing variant of `read_life_105`.
+[[nodiscard]] inline expected<Binary_Cell_Pattern, std::string> try_read_life_105(std::istream &in)
+{
+  return ca_io_detail::try_parse([&]
+    {
+      return read_life_105(in);
+    }, "try_read_life_105");
+}
+
+/// Non-throwing variant of `read_life_106`.
+[[nodiscard]] inline expected<Binary_Cell_Pattern, std::string> try_read_life_106(std::istream &in)
+{
+  return ca_io_detail::try_parse([&]
+    {
+      return read_life_106(in);
+    }, "try_read_life_106");
+}
+
+/// Non-throwing variant of `read_csv_snapshot`.
+template <class T>
+[[nodiscard]] inline expected<Grid_Snapshot<T>, std::string> try_read_csv_snapshot(
+  std::istream &in,
+  const CSV_Options &opts = {})
+{
+  return ca_io_detail::try_parse([&]
+    {
+      return read_csv_snapshot<T>(in, opts);
+    }, "try_read_csv_snapshot");
+}
 
 }  // namespace CA
 }  // namespace Aleph

--- a/ca-io.H
+++ b/ca-io.H
@@ -1653,7 +1653,7 @@ template <class F>
     }
   catch (const std::exception &e)
     {
-      return unexpected<std::string>(std::string(e.what()));
+      return unexpected<std::string>(std::string(context) + ": " + e.what());
     }
   catch (...)
     {
@@ -1663,7 +1663,20 @@ template <class F>
 
 }  // namespace ca_io_detail
 
-/// Non-throwing variant of `read_rle`.
+/** @brief Non-throwing variant of `read_rle`.
+ *
+ *  Reads a Conway RLE pattern from the stream. Returns the parsed pattern on
+ *  success or an error message on failure. Unlike `read_rle`, this function
+ *  never throws.
+ *
+ *  @param[in,out] in input stream.
+ *  @return `expected<RLE_Pattern, std::string>`: pattern on success, error message on failure.
+ *
+ *  @par Complexity
+ *  O(number of RLE tokens + live cells).
+ *  @par Thread-safety
+ *  Reentrant.
+ */
 [[nodiscard]] inline expected<RLE_Pattern, std::string> try_read_rle(std::istream &in)
 {
   return ca_io_detail::try_parse([&]
@@ -1672,7 +1685,20 @@ template <class F>
     }, "try_read_rle");
 }
 
-/// Non-throwing variant of `read_rle_string`.
+/** @brief Non-throwing variant of `read_rle_string`.
+ *
+ *  Parses a Conway RLE pattern from a string. Returns the parsed pattern on
+ *  success or an error message on failure. Unlike `read_rle_string`, this
+ *  function never throws.
+ *
+ *  @param[in] s RLE document.
+ *  @return `expected<RLE_Pattern, std::string>`: pattern on success, error message on failure.
+ *
+ *  @par Complexity
+ *  O(number of RLE tokens + live cells).
+ *  @par Thread-safety
+ *  Reentrant.
+ */
 [[nodiscard]] inline expected<RLE_Pattern, std::string> try_read_rle_string(const std::string &s)
 {
   return ca_io_detail::try_parse([&]
@@ -1681,7 +1707,20 @@ template <class F>
     }, "try_read_rle_string");
 }
 
-/// Non-throwing variant of `read_plaintext`.
+/** @brief Non-throwing variant of `read_plaintext`.
+ *
+ *  Reads a Life plaintext pattern from the stream. Returns the parsed pattern
+ *  on success or an error message on failure. Unlike `read_plaintext`, this
+ *  function never throws.
+ *
+ *  @param[in,out] in input stream.
+ *  @return `expected<Binary_Cell_Pattern, std::string>`: pattern on success, error message on failure.
+ *
+ *  @par Complexity
+ *  O(input characters + live cells).
+ *  @par Thread-safety
+ *  Reentrant.
+ */
 [[nodiscard]] inline expected<Binary_Cell_Pattern, std::string> try_read_plaintext(std::istream &in)
 {
   return ca_io_detail::try_parse([&]
@@ -1690,7 +1729,20 @@ template <class F>
     }, "try_read_plaintext");
 }
 
-/// Non-throwing variant of `read_life_105`.
+/** @brief Non-throwing variant of `read_life_105`.
+ *
+ *  Reads a Life 1.05 pattern from the stream. Returns the parsed pattern on
+ *  success or an error message on failure. Unlike `read_life_105`, this
+ *  function never throws.
+ *
+ *  @param[in,out] in input stream.
+ *  @return `expected<Binary_Cell_Pattern, std::string>`: pattern on success, error message on failure.
+ *
+ *  @par Complexity
+ *  O(input characters + live cells).
+ *  @par Thread-safety
+ *  Reentrant.
+ */
 [[nodiscard]] inline expected<Binary_Cell_Pattern, std::string> try_read_life_105(std::istream &in)
 {
   return ca_io_detail::try_parse([&]
@@ -1699,7 +1751,20 @@ template <class F>
     }, "try_read_life_105");
 }
 
-/// Non-throwing variant of `read_life_106`.
+/** @brief Non-throwing variant of `read_life_106`.
+ *
+ *  Reads a Life 1.06 pattern from the stream. Returns the parsed pattern on
+ *  success or an error message on failure. Unlike `read_life_106`, this
+ *  function never throws.
+ *
+ *  @param[in,out] in input stream.
+ *  @return `expected<Binary_Cell_Pattern, std::string>`: pattern on success, error message on failure.
+ *
+ *  @par Complexity
+ *  O(live cells).
+ *  @par Thread-safety
+ *  Reentrant.
+ */
 [[nodiscard]] inline expected<Binary_Cell_Pattern, std::string> try_read_life_106(std::istream &in)
 {
   return ca_io_detail::try_parse([&]
@@ -1708,7 +1773,22 @@ template <class F>
     }, "try_read_life_106");
 }
 
-/// Non-throwing variant of `read_csv_snapshot`.
+/** @brief Non-throwing variant of `read_csv_snapshot`.
+ *
+ *  Reads a numeric CSV snapshot from the stream. Returns the parsed snapshot
+ *  on success or an error message on failure. Unlike `read_csv_snapshot`, this
+ *  function never throws.
+ *
+ *  @tparam T target scalar type.
+ *  @param[in,out] in input stream.
+ *  @param[in] opts CSV parsing options.
+ *  @return `expected<Grid_Snapshot<T>, std::string>`: snapshot on success, error message on failure.
+ *
+ *  @par Complexity
+ *  O(input cells).
+ *  @par Thread-safety
+ *  Reentrant.
+ */
 template <class T>
 [[nodiscard]] inline expected<Grid_Snapshot<T>, std::string> try_read_csv_snapshot(
   std::istream &in,


### PR DESCRIPTION
Introduce ca_io_expected_example.cc and ca_io_expected_test.cc to support expected parsing functionalities. Update ca-io.H with related changes and modify CMakeLists.txt to include new test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas funciones**
  * Se añadieron lectores “sin excepciones” (`try_read_*`) para RLE, Life 1.05/1.06, texto plano y snapshots CSV, devolviendo errores como valores.
* **Mejoras**
  * Se ajustó la validación de caracteres permitidos y el tratamiento de espacios en blanco para detectar mejor entradas inválidas.
  * Se facilita el *fallback* entre formatos usando el canal de fallo.
* **Ejemplos**
  * Se incorporó un ejemplo nuevo que muestra `try_read_*` y el *fallback*.
* **Pruebas**
  * Se añadieron pruebas automáticas para casos válidos/invalidos y verificación de que las variantes “lanzan” siguen lanzando excepciones.
* **Chores**
  * Se registró el nuevo ejecutable de tests en la configuración de compilación.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->