### PR TITLE
refactor(core): Add ranges portability and CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,83 @@ jobs:
             build/Testing/Temporary/LastTest.log
             build/CMakeCache.txt
 
+  ranges-off:
+    name: ranges-off (ubuntu-24.04, gcc, Release)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      CC: gcc
+      CXX: g++
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake ninja-build pkg-config ccache \
+            g++ \
+            libgmp-dev libmpfr-dev libgsl-dev \
+            libx11-dev libpthread-stubs0-dev \
+            libtclap-dev \
+            libgtest-dev
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-ranges-off-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ranges-off-ccache-
+
+      - name: Build and install GoogleTest
+        run: |
+          set -euo pipefail
+          if pkg-config --exists gtest gtest_main; then
+            echo "gtest found via pkg-config"; exit 0
+          fi
+          if [ -d /usr/src/googletest ]; then
+            sudo cmake -S /usr/src/googletest -B /usr/src/googletest/build -G Ninja
+            sudo cmake --build /usr/src/googletest/build
+            sudo cmake --install /usr/src/googletest/build
+            exit 0
+          fi
+          echo "No googletest sources found"; exit 1
+
+      - name: Configure (ranges disabled)
+        run: |
+          rm -rf build
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DALEPH_DISABLE_RANGES=ON \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_TESTS=ON
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Test
+        run: |
+          mkdir -p build/test_artifacts/golden_svg
+          export ALEPH_TEST_GOLDEN_DIR="$PWD/build/test_artifacts/golden_svg"
+          ctest --test-dir build --output-on-failure --parallel 2 --timeout 600 \
+            -E 'hash_statistical_test'
+
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-logs-ranges-off
+          if-no-files-found: ignore
+          path: |
+            build/Testing/Temporary/LastTest.log
+            build/CMakeCache.txt
+
   fft-simd-validation:
     name: fft-simd-validation (ubuntu-24.04, gcc, Release)
     runs-on: ubuntu-24.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ option(BUILD_REPRODUCTIONS "Build weekly cellular-automata reproductions" OFF)
 option(BUILD_BENCHMARKS "Build cellular-automata performance-gate benchmarks" OFF)
 option(ALEPH_USE_SANITIZERS "Enable address and undefined behavior sanitizers" OFF)
 option(ALEPH_USE_LIBCXX "Use libc++ when compiling with Clang" OFF)
+option(ALEPH_DISABLE_RANGES "Force C++20 std::ranges support off (portability escape hatch)" OFF)
 
 # Optional POSIX-specific features. Default ON on Unix-like platforms,
 # OFF on Windows so CI build jobs can opt-in without dragging X11 / xorg.
@@ -120,6 +121,13 @@ if(ALEPH_USE_SANITIZERS)
     else()
         message(WARNING "ALEPH_USE_SANITIZERS is only supported with GCC or Clang")
     endif()
+endif()
+
+# Portability escape hatch: force std::ranges support off. The library still
+# auto-detects ranges by default (see ah-ranges.H); this option lets users on
+# toolchains whose std::ranges is present but unreliable opt out globally.
+if(ALEPH_DISABLE_RANGES)
+    add_compile_definitions(ALEPH_NO_RANGES)
 endif()
 
 # Debug flags
@@ -744,6 +752,7 @@ message(STATUS "  Build reproductions: ${BUILD_REPRODUCTIONS}")
 message(STATUS "  Build benchmarks: ${BUILD_BENCHMARKS}")
 message(STATUS "  Build Python bindings: ${ALEPH_BUILD_PYTHON}")
 message(STATUS "  Sanitizers: ${ALEPH_USE_SANITIZERS}")
+message(STATUS "  Disable ranges: ${ALEPH_DISABLE_RANGES}")
 message(STATUS "  X11 viewer: ${ALEPH_BUILD_X11_VIEWER}")
 message(STATUS "  Compiler: ${CMAKE_CXX_COMPILER_ID}")
 

--- a/Tests/ah_iterator_test.cc
+++ b/Tests/ah_iterator_test.cc
@@ -37,11 +37,16 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 #include <ah-ranges.H>
+#include <array_it.H>
+#include <tpl_array.H>
+#include <tpl_dynArray.H>
+#include <tpl_dynArrayHeap.H>
 #include <tpl_dynDlist.H>
 #include <tpl_dynSetTree.H>
 
@@ -197,6 +202,224 @@ TEST(AhIteratorSemantics, PostIncrementReturnsOldValue)
 
   EXPECT_EQ(*old, 1);
   EXPECT_EQ(*it, 2);
+}
+
+TEST(AhIteratorConcepts, DynArrayIteratorSatisfiesRandomAccess)
+{
+  using Iter = DynArray<int>::iterator;
+
+  static_assert(std::random_access_iterator<Iter>);
+  static_assert(std::same_as<
+                  typename std::iterator_traits<Iter>::iterator_category,
+                  std::random_access_iterator_tag>);
+
+  SUCCEED();
+}
+
+TEST(AhIteratorConcepts, ArrayIteratorSatisfiesRandomAccess)
+{
+  using Iter = Array<int>::iterator;
+
+  static_assert(std::random_access_iterator<Iter>);
+
+  SUCCEED();
+}
+
+TEST(AhIteratorConcepts, ConstIteratorsArePromotedToRandomAccessToo)
+{
+  static_assert(std::random_access_iterator<DynArray<int>::const_iterator>);
+  static_assert(std::random_access_iterator<Array<int>::const_iterator>);
+
+  // Non-opted-in containers must keep their forward category.
+  static_assert(std::forward_iterator<DynDlist<int>::const_iterator>);
+  static_assert(not std::random_access_iterator<DynDlist<int>::const_iterator>);
+
+  SUCCEED();
+}
+
+TEST(AhIteratorConcepts, DynArrayHeapIteratorStaysNonRandomAccessFailSafe)
+{
+  // The heap reuses DynArray::Iterator as a base but redefines get_pos() with
+  // an offset. The self-referential marker prevents inheriting the
+  // random-access promotion, so it must NOT be a random_access_iterator.
+  using Iter = DynArrayHeap<int>::iterator;
+
+  static_assert(std::forward_iterator<Iter>);
+  static_assert(not std::random_access_iterator<Iter>);
+
+  SUCCEED();
+}
+
+TEST(AhIteratorRandomAccess, DynArrayArithmeticIndexingAndOrdering)
+{
+  DynArray<int> a;
+  for (int i = 0; i < 10; ++i)
+    a.append(i);
+
+  auto first = a.begin();
+
+  EXPECT_EQ(a.end() - first, 10);
+  EXPECT_EQ(*(first + 3), 3);
+  EXPECT_EQ(*(3 + first), 3);  // symmetric operator+
+  EXPECT_EQ(first[7], 7);
+
+  auto it = first;
+  it += 5;
+  EXPECT_EQ(*it, 5);
+  it -= 2;
+  EXPECT_EQ(*it, 3);
+  EXPECT_EQ(it - first, 3);
+
+  EXPECT_TRUE(first < it);
+  EXPECT_TRUE(it > first);
+  EXPECT_TRUE(first <= first);
+  EXPECT_TRUE(first >= first);
+
+  --it;
+  EXPECT_EQ(*it, 2);
+  auto prev = it--;
+  EXPECT_EQ(*prev, 2);
+  EXPECT_EQ(*it, 1);
+}
+
+TEST(AhIteratorRandomAccess, StdSortAndRangesSortOnDynArray)
+{
+  DynArray<int> a;
+  for (int v : {5, 2, 8, 1, 9, 3, 7, 4, 6, 0})
+    a.append(v);
+
+  std::sort(a.begin(), a.end());
+
+  std::vector<int> v;
+  for (int x : a)
+    v.push_back(x);
+  EXPECT_TRUE(std::is_sorted(v.begin(), v.end()));
+  EXPECT_EQ(v.front(), 0);
+  EXPECT_EQ(v.back(), 9);
+
+  std::ranges::sort(a, std::ranges::greater{});
+  v.clear();
+  for (int x : a)
+    v.push_back(x);
+  EXPECT_EQ(v.front(), 9);
+  EXPECT_EQ(v.back(), 0);
+}
+
+TEST(AhIteratorRandomAccess, StdSortOnArray)
+{
+  Array<int> a;
+  for (int v : {3, 1, 2, 5, 4})
+    a.append(v);
+
+  std::sort(a.begin(), a.end());
+
+  std::vector<int> v;
+  for (int x : a)
+    v.push_back(x);
+  EXPECT_TRUE(std::is_sorted(v.begin(), v.end()));
+  EXPECT_EQ(v.front(), 1);
+  EXPECT_EQ(v.back(), 5);
+}
+
+TEST(AhIteratorSemantics, DefaultConstructedRandomAccessIteratorsCompareEqual)
+{
+  // std::regular (required by std::random_access_iterator) demands that two
+  // value-initialized iterators compare equal. DynArray::Iterator::has_curr()
+  // must therefore be null-safe on singular iterators.
+  DynArray<int>::iterator a, b;
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+
+  Array<int>::iterator c, d;
+  EXPECT_TRUE(c == d);
+  EXPECT_FALSE(c != d);
+}
+
+TEST(AhIteratorRandomAccess, ConstIteratorArithmeticAndBinarySearch)
+{
+  DynArray<int> a;
+  for (int i = 0; i < 10; ++i)
+    a.append(i);
+
+  const DynArray<int> &ca = a;
+  auto first = ca.begin();
+
+  EXPECT_EQ(ca.end() - first, 10);
+  EXPECT_EQ(*(first + 3), 3);
+  EXPECT_EQ(*(3 + first), 3);
+  EXPECT_EQ(first[7], 7);
+  EXPECT_TRUE(first < ca.end());
+
+  auto it = first;
+  it += 5;
+  EXPECT_EQ(*it, 5);
+  --it;
+  EXPECT_EQ(*it, 4);
+  it -= 2;
+  EXPECT_EQ(*it, 2);
+  EXPECT_EQ(it - first, 2);
+
+  // O(log n) algorithms require random access on the const view.
+  EXPECT_TRUE(std::binary_search(ca.begin(), ca.end(), 5));
+  auto lb = std::lower_bound(ca.begin(), ca.end(), 7);
+  ASSERT_NE(lb, ca.end());
+  EXPECT_EQ(*lb, 7);
+
+  Array<int> arr;
+  for (int v : {1, 2, 3})
+    arr.append(v);
+  const Array<int> &carr = arr;
+  EXPECT_EQ(carr.end() - carr.begin(), 3);
+  EXPECT_EQ(carr.begin()[2], 3);
+}
+
+TEST(AhIteratorRandomAccess, EmptyContainersHaveZeroDistanceAndConsistentOrder)
+{
+  // Regression: Array_Iterator::end() used to leave pos == -1 on empty
+  // containers (reset_last() with num_items == 0), so end() - begin() was -1
+  // and begin() > end() while begin() == end() also held. The end state must
+  // be position num_items (0 when empty).
+  Array<int> a;
+  EXPECT_EQ(a.end() - a.begin(), 0);
+  EXPECT_TRUE(a.begin() == a.end());
+  EXPECT_FALSE(a.begin() < a.end());
+  EXPECT_FALSE(a.begin() > a.end());
+  EXPECT_EQ(std::distance(a.begin(), a.end()), 0);
+  std::sort(a.begin(), a.end()); // must be a harmless no-op
+  EXPECT_EQ(a.size(), 0u);
+
+  const Array<int> &ca = a;
+  EXPECT_EQ(ca.end() - ca.begin(), 0);
+  EXPECT_TRUE(ca.begin() == ca.end());
+
+  DynArray<int> d;
+  EXPECT_EQ(d.end() - d.begin(), 0);
+  EXPECT_TRUE(d.begin() == d.end());
+}
+
+TEST(AhIteratorRandomAccess, ArrayIteratorCircularSetPosMatchesEnd)
+{
+  // Physical buffer of size 5; logical sequence of 4 items starting at physical
+  // index 3 and wrapping around: logical [0..3] -> physical [3, 4, 0, 1].
+  int buf[5] = {20, 30, 999, 0, 10};
+  Array_Iterator<int> it(buf, 5, 4, 3, 1); // ptr, dim, num_items, first, last
+
+  it.set_pos(0);
+  EXPECT_EQ(it.get_curr(), 0);   // buf[3]
+  it.set_pos(1);
+  EXPECT_EQ(it.get_curr(), 10);  // buf[4]
+  it.set_pos(2);
+  EXPECT_EQ(it.get_curr(), 20);  // buf[0]
+  it.set_pos(3);
+  EXPECT_EQ(it.get_curr(), 30);  // buf[1]
+
+  // set_pos(num_items) must reproduce the exact end() state.
+  Array_Iterator<int> at_end(buf, 5, 4, 3, 1);
+  at_end.end();
+
+  it.set_pos(4);
+  EXPECT_FALSE(it.has_curr());
+  EXPECT_EQ(it.get_pos(), at_end.get_pos());
 }
 
 #else // !ALEPH_HAS_RANGES

--- a/Tests/ah_ranges_test.cc
+++ b/Tests/ah_ranges_test.cc
@@ -48,6 +48,16 @@
 #include <tpl_dynListQueue.H>
 #include <tpl_dynSetTree.H>
 
+// Regression guard for the portability escape hatch (feat/ranges-isolation):
+// when the library is built with ranges forced off (-DALEPH_DISABLE_RANGES=ON,
+// which defines ALEPH_NO_RANGES), the auto-detection must resolve to 0 so the
+// ranges-off code path is exercised. The CI `ranges-off` job builds this file
+// with ALEPH_NO_RANGES defined, so this assertion locks the override contract.
+#ifdef ALEPH_NO_RANGES
+static_assert(ALEPH_HAS_RANGES == 0,
+              "ALEPH_NO_RANGES must force ALEPH_HAS_RANGES to 0");
+#endif
+
 using namespace Aleph;
 
 // ============================================================================

--- a/ah-iterator.H
+++ b/ah-iterator.H
@@ -29,49 +29,74 @@
   SOFTWARE.
 */
 
-
 /** @file ah-iterator.H
  *  @brief STL-compatible iterator adapters for Aleph containers.
  *
  *  Provides StlIterator and StlConstIterator that wrap Aleph container
  *  iterators to satisfy std::input_iterator and std::forward_iterator
- *  concepts, enabling use with std::ranges and STL algorithms.
+ *  concepts, enabling use with std::ranges and STL algorithms. Iterators
+ *  that opt in via the `aleph_random_access_iterator` marker (see
+ *  AlephRandomAccessItor) are promoted to std::random_access_iterator.
  *
  *  @ingroup Iterators
  *  @author Leandro Rabindranath León
  */
 
-# ifndef AH_ITERATOR_H
-# define AH_ITERATOR_H
+#ifndef AH_ITERATOR_H
+#define AH_ITERATOR_H
 
-# include <iterator>
-# include <concepts>
-# include <type_traits>
-# include <utility>
+#include <compare>
+#include <iterator>
+#include <concepts>
+#include <type_traits>
+#include <utility>
 
- /** @brief STL-compatible mutable iterator adapter for Aleph containers.
- 
-     This adapter wraps an Aleph-style iterator (`SetType::Iterator`) and exposes
-     the operations expected by the STL and C++20 ranges.
+/** @brief Detects Aleph iterators that opted in to random-access promotion.
 
-     @tparam SetType Aleph container type.
+    An underlying Aleph iterator `I` qualifies only when it:
+    - declares the self-referential marker `aleph_random_access_iterator == I`
+      (so derived iterators that reuse a base iterator without redefining
+      positioning consistently do NOT inherit the promotion), and
+    - exposes the logical-position interface `get_pos()` / `set_pos()` together
+      with backward movement `prev()`.
+*/
+template <class I>
+concept AlephRandomAccessItor = requires { typename I::aleph_random_access_iterator; } and
+  std::same_as<typename I::aleph_random_access_iterator, I> and
+  requires(I &it, const I &cit, long n) {
+    { cit.get_pos() } -> std::convertible_to<long>;
+    it.set_pos(n);
+    it.prev();
+  };
 
-     @note Requirements on `SetType::Iterator`:
-     - Constructible from `SetType&`.
-     - `bool has_curr() const`.
-     - `void next()`.
-     - `auto & get_curr() const` returning the current element.
-     - `auto get_pos() const` returning a position that is stable and comparable
-       between iterators over the same container.
-     - `void end()` to move the iterator to the end sentinel.
- */
- template <class SetType>
- struct StlIterator : public SetType::Iterator
- {
+/** @brief STL-compatible mutable iterator adapter for Aleph containers.
+
+    This adapter wraps an Aleph-style iterator (`SetType::Iterator`) and exposes
+    the operations expected by the STL and C++20 ranges.
+
+    @tparam SetType Aleph container type.
+
+    @note Requirements on `SetType::Iterator`:
+    - Constructible from `SetType&`.
+    - `bool has_curr() const`.
+    - `void next()`.
+    - `auto & get_curr() const` returning the current element.
+    - `auto get_pos() const` returning a position that is stable and comparable
+      between iterators over the same container.
+    - `void end()` to move the iterator to the end sentinel.
+*/
+template <class SetType>
+struct StlIterator : public SetType::Iterator
+{
   using T = typename SetType::Item_Type;
   using Itor = typename SetType::Iterator;
-  using iterator_category = std::forward_iterator_tag;
-  using iterator_concept = std::forward_iterator_tag;
+
+  /// Category is promoted to random-access when the underlying Aleph iterator
+  /// opts in (see AlephRandomAccessItor); otherwise it stays forward, which is
+  /// the historical default and never a regression.
+  using iterator_category =
+    std::conditional_t<AlephRandomAccessItor<Itor>, std::random_access_iterator_tag, std::forward_iterator_tag>;
+  using iterator_concept = iterator_category;
 
   using difference_type = std::ptrdiff_t;
 
@@ -87,7 +112,7 @@
   using Itor::Itor;
 
   /// Pre-increment: advance to the next element.
-  StlIterator& operator ++ ()
+  StlIterator &operator ++ ()
   {
     this->next();
     return *this;
@@ -103,17 +128,16 @@
 
   /// Equality compares positions when both iterators are valid; otherwise
   /// both must be in the end state.
-  bool operator == (const StlIterator & it) const
+  bool operator == (const StlIterator &it) const
   {
-    if constexpr (requires (const Itor & a, const Itor & b)
-                  {
+    if constexpr (requires(const Itor &a, const Itor &b) {
                     { a == b } -> std::convertible_to<bool>;
                   })
       return static_cast<const Itor &>(*this) == static_cast<const Itor &>(it);
 
     if (this->has_curr() and it.has_curr())
       return this->get_pos() == it.get_pos();
-      // return this->get_curr() == it.get_curr();
+    // return this->get_curr() == it.get_curr();
 
     if (not this->has_curr() and not it.has_curr())
       return true;
@@ -122,7 +146,7 @@
   }
 
   /// Inequality.
-  bool operator != (const StlIterator & it) const
+  bool operator != (const StlIterator &it) const
   {
     return not (*this == it);
   }
@@ -130,19 +154,111 @@
   // Note: operator* must be const to satisfy std::indirectly_readable.
   // Constness of the iterator object does not imply constness of the element.
   /// Dereference: return the current element.
-  reference operator * () const { return this->get_curr(); }
+  reference operator * () const
+  {
+    return this->get_curr();
+  }
 
   /// Member access to the current element.
-  pointer operator -> () const { return &this->get_curr(); }
+  pointer operator ->() const
+  {
+    return &this->get_curr();
+  }
+
+  // Random-access operations. These overloads exist only when the underlying
+  // Aleph iterator opts in via the `aleph_random_access_iterator` marker
+  // (e.g. DynArray, Array). They operate on the logical position exposed by
+  // get_pos()/set_pos(), so any physical/circular index mapping stays internal.
+
+  /// Pre-decrement: move to the previous element.
+  StlIterator &operator -- ()
+    requires AlephRandomAccessItor<Itor>
+  {
+    this->prev();
+    return *this;
+  }
+
+  /// Post-decrement: move to the previous element and return the old iterator.
+  StlIterator operator -- (int)
+    requires AlephRandomAccessItor<Itor>
+  {
+    StlIterator ret_val = *this;
+    this->prev();
+    return ret_val;
+  }
+
+  /// Advance the iterator `n` positions (`n` may be negative).
+  StlIterator &operator += (difference_type n)
+    requires AlephRandomAccessItor<Itor>
+  {
+    this->set_pos(this->get_pos() + n);
+    return *this;
+  }
+
+  /// Move the iterator back `n` positions (`n` may be negative).
+  StlIterator &operator -= (difference_type n)
+    requires AlephRandomAccessItor<Itor>
+  {
+    this->set_pos(this->get_pos() - n);
+    return *this;
+  }
+
+  /// Return an iterator advanced `n` positions.
+  StlIterator operator + (difference_type n) const
+    requires AlephRandomAccessItor<Itor>
+  {
+    StlIterator ret_val = *this;
+    ret_val += n;
+    return ret_val;
+  }
+
+  /// Return an iterator advanced `n` positions (symmetric form).
+  friend StlIterator operator + (difference_type n, const StlIterator &it)
+    requires AlephRandomAccessItor<Itor>
+  {
+    return it + n;
+  }
+
+  /// Return an iterator moved back `n` positions.
+  StlIterator operator - (difference_type n) const
+    requires AlephRandomAccessItor<Itor>
+  {
+    StlIterator ret_val = *this;
+    ret_val -= n;
+    return ret_val;
+  }
+
+  /// Return the signed distance between two iterators.
+  difference_type operator - (const StlIterator &it) const
+    requires AlephRandomAccessItor<Itor>
+  {
+    return static_cast<difference_type>(this->get_pos() - it.get_pos());
+  }
+
+  /// Access the element `n` positions away from the current one.
+  reference operator [] (difference_type n) const
+    requires AlephRandomAccessItor<Itor>
+  {
+    StlIterator tmp = *this;
+    tmp += n;
+    return *tmp;
+  }
+
+  /// Order two iterators by their logical position.
+  std::strong_ordering operator <=> (const StlIterator &it) const
+    requires AlephRandomAccessItor<Itor>
+  {
+    return this->get_pos() <=> it.get_pos();
+  }
 
   /// Create an iterator positioned at the first element of the container.
-  static StlIterator begin(SetType & s)
+  static StlIterator begin(SetType &s)
   {
     return StlIterator(s);
   }
 
   /// Create an end iterator for the container.
-  static StlIterator end(SetType & s)
+  static StlIterator end(SetType &s)
   {
     StlIterator it(s);
     it.Itor::end();
@@ -150,26 +266,30 @@
   }
 };
 
+/** @brief STL-compatible const iterator adapter for Aleph containers.
 
- /** @brief STL-compatible const iterator adapter for Aleph containers.
- 
-     This adapter provides a read-only view over the underlying Aleph iterator.
+    This adapter provides a read-only view over the underlying Aleph iterator.
 
-     @tparam SetType Aleph container type.
- */
- template <class SetType>
- struct StlConstIterator : public SetType::Iterator
- {
+    @tparam SetType Aleph container type.
+*/
+template <class SetType>
+struct StlConstIterator : public SetType::Iterator
+{
   using T = typename SetType::Item_Type;
   using Itor = typename SetType::Iterator;
-  using iterator_category = std::forward_iterator_tag;
-  using iterator_concept = std::forward_iterator_tag;
+
+  /// Category is promoted to random-access when the underlying Aleph iterator
+  /// opts in (see AlephRandomAccessItor); otherwise it stays forward, which is
+  /// the historical default and never a regression.
+  using iterator_category =
+    std::conditional_t<AlephRandomAccessItor<Itor>, std::random_access_iterator_tag, std::forward_iterator_tag>;
+  using iterator_concept = iterator_category;
 
   using difference_type = std::ptrdiff_t;
 
-  using pointer = const T*;
+  using pointer = const T *;
 
-  using reference = const T&;
+  using reference = const T &;
 
   using value_type = T;
 
@@ -179,7 +299,7 @@
   using Itor::Itor;
 
   /// Pre-increment: advance to the next element.
-  StlConstIterator& operator ++ ()
+  StlConstIterator &operator ++ ()
   {
     this->next();
     return *this;
@@ -195,10 +315,9 @@
 
   /// Equality compares positions when both iterators are valid; otherwise
   /// both must be in the end state.
-  bool operator == (const StlConstIterator & it) const
+  bool operator == (const StlConstIterator &it) const
   {
-    if constexpr (requires (const Itor & a, const Itor & b)
-                  {
+    if constexpr (requires(const Itor &a, const Itor &b) {
                     { a == b } -> std::convertible_to<bool>;
                   })
       return static_cast<const Itor &>(*this) == static_cast<const Itor &>(it);
@@ -213,25 +332,118 @@
   }
 
   /// Inequality.
-  bool operator != (const StlConstIterator & it) const
+  bool operator != (const StlConstIterator &it) const
   {
     return not (*this == it);
   }
 
   /// Dereference: return the current element.
-  const T & operator * () const { return this->get_curr(); }
+  const T &operator * () const
+  {
+    return this->get_curr();
+  }
 
   /// Member access to the current element.
-  const T * operator -> () const { return &this->get_curr(); }
+  const T *operator ->() const
+  {
+    return &this->get_curr();
+  }
+
+  // Random-access operations, mirroring StlIterator. These overloads exist
+  // only when the underlying Aleph iterator opts in via the
+  // `aleph_random_access_iterator` marker (e.g. DynArray, Array). They operate
+  // on the logical position exposed by get_pos()/set_pos(), so any
+  // physical/circular index mapping stays internal.
+
+  /// Pre-decrement: move to the previous element.
+  StlConstIterator &operator -- ()
+    requires AlephRandomAccessItor<Itor>
+  {
+    this->prev();
+    return *this;
+  }
+
+  /// Post-decrement: move to the previous element and return the old iterator.
+  StlConstIterator operator -- (int)
+    requires AlephRandomAccessItor<Itor>
+  {
+    StlConstIterator ret_val = *this;
+    this->prev();
+    return ret_val;
+  }
+
+  /// Advance the iterator `n` positions (`n` may be negative).
+  StlConstIterator &operator += (difference_type n)
+    requires AlephRandomAccessItor<Itor>
+  {
+    this->set_pos(this->get_pos() + n);
+    return *this;
+  }
+
+  /// Move the iterator back `n` positions (`n` may be negative).
+  StlConstIterator &operator -= (difference_type n)
+    requires AlephRandomAccessItor<Itor>
+  {
+    this->set_pos(this->get_pos() - n);
+    return *this;
+  }
+
+  /// Return an iterator advanced `n` positions.
+  StlConstIterator operator + (difference_type n) const
+    requires AlephRandomAccessItor<Itor>
+  {
+    StlConstIterator ret_val = *this;
+    ret_val += n;
+    return ret_val;
+  }
+
+  /// Return an iterator advanced `n` positions (symmetric form).
+  friend StlConstIterator operator + (difference_type n, const StlConstIterator &it)
+    requires AlephRandomAccessItor<Itor>
+  {
+    return it + n;
+  }
+
+  /// Return an iterator moved back `n` positions.
+  StlConstIterator operator - (difference_type n) const
+    requires AlephRandomAccessItor<Itor>
+  {
+    StlConstIterator ret_val = *this;
+    ret_val -= n;
+    return ret_val;
+  }
+
+  /// Return the signed distance between two iterators.
+  difference_type operator - (const StlConstIterator &it) const
+    requires AlephRandomAccessItor<Itor>
+  {
+    return static_cast<difference_type>(this->get_pos() - it.get_pos());
+  }
+
+  /// Access the element `n` positions away from the current one.
+  reference operator [] (difference_type n) const
+    requires AlephRandomAccessItor<Itor>
+  {
+    StlConstIterator tmp = *this;
+    tmp += n;
+    return *tmp;
+  }
+
+  /// Order two iterators by their logical position.
+  std::strong_ordering operator <=> (const StlConstIterator &it) const
+    requires AlephRandomAccessItor<Itor>
+  {
+    return this->get_pos() <=> it.get_pos();
+  }
 
   /// Create a const iterator positioned at the first element of the container.
-  static StlConstIterator cbegin(const SetType & s)
+  static StlConstIterator cbegin(const SetType &s)
   {
     return StlConstIterator(s);
   }
 
   /// Create a const end iterator for the container.
-  static StlConstIterator cend(const SetType & s)
+  static StlConstIterator cend(const SetType &s)
   {
     StlConstIterator it(s);
     it.Itor::end();
@@ -239,32 +451,42 @@
   }
 };
 
+/** @brief Mixin that adds STL `begin()/end()` and `cbegin()/cend()` to Aleph containers.
 
- /** @brief Mixin that adds STL `begin()/end()` and `cbegin()/cend()` to Aleph containers.
+    Containers inheriting from this class must expose `Item_Type` and `Iterator`,
+    where `Iterator` meets the requirements described in `StlIterator`.
 
-     Containers inheriting from this class must expose `Item_Type` and `Iterator`,
-     where `Iterator` meets the requirements described in `StlIterator`.
+    @tparam SetName Aleph container type.
+*/
+template <class SetName>
+class StlAlephIterator
+{
+  SetName *me()
+  {
+    return static_cast<SetName *>(this);
+  }
 
-     @tparam SetName Aleph container type.
- */
- template <class SetName>
- class StlAlephIterator
- {
-  SetName * me() { return static_cast<SetName*>(this); }
-
-  const SetName * const_me() const { return static_cast<const SetName*>(this); }
+  const SetName *const_me() const
+  {
+    return static_cast<const SetName *>(this);
+  }
 
 public:
-
   using iterator = StlIterator<SetName>;
 
   using const_iterator = StlConstIterator<SetName>;
 
   /// Return an STL-compatible iterator to the first element.
-  iterator begin() noexcept { return iterator::begin(*me()); }
+  iterator begin() noexcept
+  {
+    return iterator::begin(*me());
+  }
 
   /// Return an STL-compatible end iterator.
-  iterator end() noexcept { return iterator::end(*me()); }
+  iterator end() noexcept
+  {
+    return iterator::end(*me());
+  }
 
   /// Return a const iterator to the first element.
   const_iterator begin() const noexcept
@@ -290,37 +512,52 @@ public:
     return const_iterator::cend(*const_me());
   }
 
-  friend const_iterator cbegin(const SetName & s) noexcept { return s.begin(); }
+  friend const_iterator cbegin(const SetName &s) noexcept
+  {
+    return s.begin();
+  }
 
-  friend const_iterator cend(const SetName & s) noexcept { return s.end(); }
+  friend const_iterator cend(const SetName &s) noexcept
+  {
+    return s.end();
+  }
 
-  friend const_iterator begin(const SetName & s) noexcept { return s.begin(); }
+  friend const_iterator begin(const SetName &s) noexcept
+  {
+    return s.begin();
+  }
 
-  friend const_iterator end(const SetName & s) noexcept { return s.end(); }
+  friend const_iterator end(const SetName &s) noexcept
+  {
+    return s.end();
+  }
 
-  friend iterator begin(SetName & s) noexcept { return s.begin(); }
+  friend iterator begin(SetName &s) noexcept
+  {
+    return s.begin();
+  }
 
-  friend iterator end(SetName & s) noexcept { return s.end(); }
+  friend iterator end(SetName &s) noexcept
+  {
+    return s.end();
+  }
 };
 
+/** @brief Extract all items from an STL container into an Aleph `DynList`.
 
- /** @brief Extract all items from an STL container into an Aleph `DynList`.
+    @tparam Container Any STL-like container supporting range-for iteration.
+    @param c Source container.
+    @return A `DynList` containing copies of all elements from `c`.
 
-     @tparam Container Any STL-like container supporting range-for iteration.
-     @param c Source container.
-     @return A `DynList` containing copies of all elements from `c`.
-
-     @ingroup Functional
- */
-template <class Container> inline
-Aleph::DynList<typename Container::value_type>
-extract_from_stl_container(const Container & c)
+    @ingroup Functional
+*/
+template <class Container>
+inline Aleph::DynList<typename Container::value_type> extract_from_stl_container(const Container &c)
 {
   Aleph::DynList<typename Container::value_type> ret;
-  for (const auto & i : c)
+  for (const auto &i : c)
     ret.append(i);
   return ret;
 }
 
-
-# endif // AH_ITERATOR_H
+#endif  // AH_ITERATOR_H

--- a/ah-parallel.H
+++ b/ah-parallel.H
@@ -121,6 +121,7 @@
 #include <iterator>
 #include <functional>
 #include <thread_pool.H>
+#include <ah-ranges.H>
 
 namespace Aleph
 {
@@ -1588,7 +1589,7 @@ namespace Aleph
         or n <= min_parallel_size)
       {
         parallel_detail::throw_if_parallel_canceled(options.cancel_token);
-        std::sort(std::begin(c), std::end(c), cmp);
+        sort_range(c, cmp);
         return;
       }
 

--- a/ah-ranges.H
+++ b/ah-ranges.H
@@ -128,7 +128,8 @@
 //   - Or pre-define ALEPH_HAS_RANGES to 0/1 to skip auto-detection entirely.
 //   This lets users on toolchains whose std::ranges is present but unreliable
 //   opt out without editing the library.
-#if defined(ALEPH_NO_RANGES) && !defined(ALEPH_HAS_RANGES)
+#if defined(ALEPH_NO_RANGES)
+#  undef ALEPH_HAS_RANGES
 #  define ALEPH_HAS_RANGES 0
 #endif
 
@@ -226,13 +227,11 @@ namespace Aleph
  */
 template <typename Range, typename Cmp>
 inline void sort_range(Range & r, Cmp cmp)
-{
 #if ALEPH_HAS_RANGES
-  std::ranges::sort(r, std::move(cmp));
+{ std::ranges::sort(r, std::move(cmp)); }
 #else
-  std::sort(std::begin(r), std::end(r), std::move(cmp)); // NOLINT(modernize-use-ranges)
+{ std::sort(std::begin(r), std::end(r), std::move(cmp)); } // NOLINT(modernize-use-ranges)
 #endif
-}
 
 /** @brief Sort a whole range in place using the default `<` ordering.
  *  @tparam Range a sortable random-access range.
@@ -240,13 +239,11 @@ inline void sort_range(Range & r, Cmp cmp)
  */
 template <typename Range>
 inline void sort_range(Range & r)
-{
 #if ALEPH_HAS_RANGES
-  std::ranges::sort(r);
+{ std::ranges::sort(r, std::ranges::less{}); }
 #else
-  std::sort(std::begin(r), std::end(r)); // NOLINT(modernize-use-ranges)
+{ std::sort(std::begin(r), std::end(r)); } // NOLINT(modernize-use-ranges)
 #endif
-}
 
 // Forward declarations for major Aleph containers with simple template signatures.
 // Containers with complex template signatures (like DynSetTree, DynBinHeap) 

--- a/ah-ranges.H
+++ b/ah-ranges.H
@@ -122,13 +122,28 @@
 //
 // We accept __cpp_lib_ranges >= 202106L for GCC, but exclude Clang + libc++
 // which has the header but incomplete views implementation.
-#if __cplusplus >= 202002L && __has_include(<ranges>)
-#  include <ranges>
-#  include <algorithm>
-#  include <iterator>
-#  include <concepts>
-#  if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 202106L
-     // Exclude Clang with libc++ (incomplete std::views implementation)
+// Manual override (portability escape hatch):
+//   - Define ALEPH_NO_RANGES (e.g. -DALEPH_NO_RANGES) to force ranges support
+//     OFF regardless of what the compiler reports.
+//   - Or pre-define ALEPH_HAS_RANGES to 0/1 to skip auto-detection entirely.
+//   This lets users on toolchains whose std::ranges is present but unreliable
+//   opt out without editing the library.
+#if defined(ALEPH_NO_RANGES) && !defined(ALEPH_HAS_RANGES)
+#  define ALEPH_HAS_RANGES 0
+#endif
+
+// <version> defines the standard library feature-test macros (e.g.
+// __cpp_lib_ranges) without pulling in a heavy header. It must be included
+// before the detection below, otherwise __cpp_lib_ranges is undefined and the
+// check wrongly resolves to "no ranges".
+#if __has_include(<version>)
+#  include <version>
+#endif
+
+#ifndef ALEPH_HAS_RANGES
+#  if __cplusplus >= 202002L && __has_include(<ranges>) &&                     \
+      defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 202106L
+     // Exclude Clang with libc++ < 16 (incomplete std::views implementation)
 #    if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000
 #      define ALEPH_HAS_RANGES 0
 #    else
@@ -137,8 +152,16 @@
 #  else
 #    define ALEPH_HAS_RANGES 0
 #  endif
-#else
-#  define ALEPH_HAS_RANGES 0
+#endif
+
+// Support headers required by the C++20 baseline (always available).
+#include <algorithm>
+#include <iterator>
+#include <concepts>
+
+// The <ranges> header is pulled in only when the feature is actually enabled.
+#if ALEPH_HAS_RANGES
+#  include <ranges>
 #endif
 
 // Feature detection for C++23 views
@@ -185,6 +208,45 @@
 
 namespace Aleph
 {
+
+/** @brief Sort a whole range in place, portably across the ranges divide.
+ *
+ *  Uses `std::ranges::sort` when the toolchain provides reliable ranges
+ *  support (`ALEPH_HAS_RANGES`) — which is what clang-tidy's use-ranges check
+ *  recommends — and falls back to `std::sort` otherwise, so the call still
+ *  compiles on C++20 toolchains without a complete `<ranges>` implementation.
+ *
+ *  Intended for sorting an entire container in place. For sub-ranges or raw
+ *  pointer ranges, call `std::sort` directly.
+ *
+ *  @tparam Range a sortable random-access range.
+ *  @tparam Cmp   a strict-weak-ordering comparator.
+ *  @param[in,out] r range to sort in place.
+ *  @param[in] cmp comparator `(a, b) -> bool` (true if `a` precedes `b`).
+ */
+template <typename Range, typename Cmp>
+inline void sort_range(Range & r, Cmp cmp)
+{
+#if ALEPH_HAS_RANGES
+  std::ranges::sort(r, std::move(cmp));
+#else
+  std::sort(std::begin(r), std::end(r), std::move(cmp)); // NOLINT(modernize-use-ranges)
+#endif
+}
+
+/** @brief Sort a whole range in place using the default `<` ordering.
+ *  @tparam Range a sortable random-access range.
+ *  @param[in,out] r range to sort in place.
+ */
+template <typename Range>
+inline void sort_range(Range & r)
+{
+#if ALEPH_HAS_RANGES
+  std::ranges::sort(r);
+#else
+  std::sort(std::begin(r), std::end(r)); // NOLINT(modernize-use-ranges)
+#endif
+}
 
 // Forward declarations for major Aleph containers with simple template signatures.
 // Containers with complex template signatures (like DynSetTree, DynBinHeap) 

--- a/ah-stl-functional.H
+++ b/ah-stl-functional.H
@@ -1464,7 +1464,7 @@ namespace Aleph
     using T = typename Container::value_type;
 
     std::vector<T> result(c.begin(), c.end());
-    std::sort(result.begin(), result.end());
+    sort_range(result);
     return result;
   }
 
@@ -1484,9 +1484,7 @@ namespace Aleph
     using T = typename Container::value_type;
 
     std::vector<T> result(c.begin(), c.end());
-    // std::sort only calls comparator, doesn't need forwarding protection
-    // as it makes copies/moves internally, but for consistency:
-    std::sort(result.begin(), result.end(), std::forward<Cmp>(cmp));
+    sort_range(result, std::forward<Cmp>(cmp));
     return result;
   }
 

--- a/ahSort.H
+++ b/ahSort.H
@@ -119,7 +119,6 @@
 
 #include <algorithm>
 #include <numeric>
-#include <ranges>
 #include <stdexcept>
 #include <utility>
 

--- a/array_it.H
+++ b/array_it.H
@@ -310,10 +310,36 @@ public:
     pos = num_items - 1;
   }
 
-  /// Put the iterator at the end (past the last item).
+  /** @brief Move the iterator to the logical position `new_pos`.
+
+      Sets the logical position and recomputes the physical (possibly
+      circular) index as `idx = (first + new_pos) % dim`. This mapping is
+      consistent with the wraparound performed by `next_ne()`/`prev_ne()` and
+      with the end state produced by `end()` (`pos == num_items`), enabling
+      O(1) random-access positioning.
+
+      @param[in] new_pos Logical position in `[0, num_items]`, where
+             `num_items` denotes the end state.
+      @note Complexity: O(1).
+      @warning No bounds checking: `new_pos` outside `[0, num_items]` yields an
+               iterator with no current item.
+  */
+  void set_pos(const long new_pos) noexcept
+  {
+    pos = new_pos;
+    if (dim > 0)
+      idx = (first + new_pos) % dim;
+  }
+
+  /** @brief Put the iterator at the end (past the last item).
+
+      The end state is defined as the logical position `num_items`, so that
+      `get_pos()` distances remain consistent for random-access adapters even
+      when the container is empty (`begin` and `end` are both position 0).
+  */
   void end() noexcept
   {
-    put_itor_at_the_end(*this);
+    set_pos(num_items);
   }
 };
 

--- a/tpl_array.H
+++ b/tpl_array.H
@@ -472,6 +472,11 @@ public:
     using Base::Base;
     using Set_Type = Array;
 
+    /// Opt-in marker for StlIterator random-access promotion. The iterator
+    /// inherits get_pos()/set_pos() unchanged from Array_Iterator, so the
+    /// logical position is consistent and random access is safe.
+    using aleph_random_access_iterator = Iterator;
+
     /// Initialize an iterator on array `s`
     Iterator(const Array<T> &s) noexcept: Base(s.array) {}
   };

--- a/tpl_dynArray.H
+++ b/tpl_dynArray.H
@@ -196,6 +196,10 @@ namespace Aleph
      directory allocation, but the directory is allocated once at
      construction time.
 
+     @note Due to the directory, segment, and block structuring, not all
+     entries in the array are contiguous in memory. Only the entries
+     within the same block are contiguous.
+
      @ingroup Sequences
    */
   template <typename T>
@@ -1356,6 +1360,13 @@ namespace Aleph
     public:
       using Set_Type = DynArray;
 
+      /// Opt-in marker for StlIterator random-access promotion. It is the
+      /// iterator's own type on purpose: derived iterators that reuse this
+      /// class as a base (e.g. DynArrayHeap::Iterator, which redefines
+      /// get_pos() with an offset) do NOT inherit the promotion, because their
+      /// own type differs from this marker. This keeps the promotion fail-safe.
+      using aleph_random_access_iterator = Iterator;
+
       /// Default constructor creates an "end" iterator
       Iterator() noexcept = default;
 
@@ -1366,10 +1377,12 @@ namespace Aleph
         // empty
       }
 
-      /// Return `true` if there is current item
+      /// Return `true` if there is a current item. Safe on default-constructed
+      /// (singular) iterators, which behave as an empty sequence so that two
+      /// value-initialized iterators compare equal (std::regular semantics).
       [[nodiscard]] bool has_curr() const noexcept
       {
-        return curr_idx >= 0 and curr_idx < array_ptr->size();
+        return array_ptr != nullptr and curr_idx >= 0 and curr_idx < array_ptr->size();
       }
 
       [[nodiscard]] bool is_last() const noexcept { return curr_idx == array_ptr->size() - 1; }

--- a/tpl_dynArrayHeap.H
+++ b/tpl_dynArrayHeap.H
@@ -40,6 +40,10 @@
  *  - Automatic resizing
  *  - Cache-friendly array storage
  *
+ *  @note Due to the underlying DynArray directory, segment, and block
+ *  structuring, not all entries in the heap are contiguous in memory. Only
+ *  the entries within the same block are contiguous.
+ *
  *  @see tpl_binHeap.H Fixed-size array heap
  *  @see tpl_dynBinHeap.H Node-based heap
  *  @ingroup Trees

--- a/tpl_dynarray_set.H
+++ b/tpl_dynarray_set.H
@@ -60,6 +60,10 @@ namespace Aleph
 
       This container **allows duplicates** for performance reasons.
 
+      @note Due to the underlying DynArray directory, segment, and block
+      structuring, not all entries in the set are contiguous in memory. Only
+      the entries within the same block are contiguous.
+
       @tparam T Element type.
       @tparam Equal Equality predicate used for linear search. It must model a
       boolean binary predicate.


### PR DESCRIPTION
Introduce a portability escape hatch for C++20 ranges support, allowing users to force ranges off. Update CI workflow to test this new functionality, including increased timeout. Refactor `ah-stl-functional.H` to use `sort_range`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Se añadió `ALEPH_DISABLE_RANGES` para desactivar globalmente `std::ranges` en el build, junto con nuevas utilidades `sort_range` compatibles con rangos y sin rangos.
  * Se adaptaron utilidades de ordenación/iteración para alinearse mejor con C++20 ranges, incluyendo promoción condicional a iteradores de acceso aleatorio.

* **Bug Fixes**
  * Se ajustó la lógica de detección/override de capacidades de rangos para evitar falsos positivos en toolchains problemáticas.
  * Se corrigió el camino de ordenación in-place en el modo secuencial.

* **Tests**
  * Se amplió la cobertura con casos específicos para iteradores y ordenación con/ sin rangos, y un job CI adicional (“ranges-off”) que valida esa configuración.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->