### PR TITLE
feat(mdspan): Implement mdspan views and examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ set(HLIST
     ah-cpp-compat.H
     ah-diagnostics.H
     ah-generator.H
+    ah-mdspan.H
     Compiler_Token.H
     Compiler_Lexer.H
     Compiler_Parser_Utils.H

--- a/Examples/deway.C
+++ b/Examples/deway.C
@@ -105,8 +105,6 @@
 #include <cstdlib>
 #include <cassert>
 using namespace std;
-#include <cstdlib>
-#include <cassert>
 using namespace Aleph;
 
 /**

--- a/Examples/deway.C
+++ b/Examples/deway.C
@@ -29,7 +29,6 @@
   SOFTWARE.
 */
 
-
 /**
  * @file deway.C
  * @brief Dewey ("deway") numbering for tree nodes (path-based hierarchical addresses).
@@ -96,30 +95,29 @@
  * @ingroup Examples
  */
 
-# include <iostream>
-# include <tclap/CmdLine.h>
-# include <tpl_binNodeUtils.H>
-# include <tpl_tree_node.H>
-# include <generate_tree.H>
-# include <ah-errors.H>
+#include <iostream>
+#include <tclap/CmdLine.h>
+#include <tpl_binNodeUtils.H>
+#include <tpl_tree_node.H>
+#include <generate_tree.H>
+#include <ah-errors.H>
 
-# include <cstdlib>
-# include <cassert>
+#include <cstdlib>
+#include <cassert>
 using namespace std;
-# include <cstdlib>
-# include <cassert>
+#include <cstdlib>
+#include <cassert>
 using namespace Aleph;
 
 /**
  * @brief Recursively compute and print Deway numbering for a tree node
- * 
+ *
  * @param p Current node
  * @param prefix Array storing the current Deway address
  * @param len Current depth in the tree
  * @param dim Maximum dimension of prefix array
  */
-void deway(Tree_Node<int> * p, int prefix[], const int & len, 
-           const size_t & dim)
+void deway(Tree_Node<int> *p, int prefix[], const int &len, const size_t &dim)
 {
   int i = 1;
 
@@ -127,17 +125,17 @@ void deway(Tree_Node<int> * p, int prefix[], const int & len,
     cout << "Root ";
   else
     cout << "Node " << prefix[i++];
-  
+
   while (i <= len)
     cout << "." << prefix[i++];
 
   cout << " \"" << p->get_key() << "\"" << endl;
-  
+
   if (static_cast<size_t>(len) >= dim)
     ah_overflow_error_if(true) << "Array dimension is smaller than Deway chain";
-  
-  Tree_Node<int> * child = p->get_left_child(); 
-  
+
+  Tree_Node<int> *child = p->get_left_child();
+
   for (int j = 0; child != nullptr; ++j, child = child->get_right_sibling())
     {
       prefix[len + 1] = j;
@@ -147,15 +145,15 @@ void deway(Tree_Node<int> * p, int prefix[], const int & len,
 
 /**
  * @brief Print Deway numbering for a forest
- * 
+ *
  * @param p Root of the first tree in the forest
  * @param h Height of the original binary tree (used to size prefix array)
  */
-void deway(Tree_Node<int> * p, const int & h)
+void deway(Tree_Node<int> *p, const int &h)
 {
   const size_t dim = 10 * h;
 
-  int * prefix = new int [dim];
+  int *prefix = new int[dim];
 
   for (int i = 0; p != nullptr; ++i, p = p->get_right_sibling())
     {
@@ -163,12 +161,12 @@ void deway(Tree_Node<int> * p, const int & h)
       deway(p, prefix, 0, dim);
     }
 
-  delete [] prefix;
+  delete[] prefix;
 }
 
 template <class Node>
-static void printNode(Node * node, int, int)
-{ 
+static void printNode(Node *node, int, int)
+{
   cout << " " << node->get_key();
 }
 
@@ -186,12 +184,12 @@ int random_int(int l, int r)
 /**
  * @brief Recursively build a random binary search tree
  */
-BinNode<int> * random_tree(int l, int r)
+BinNode<int> *random_tree(int l, int r)
 {
   if (l > r)
     return nullptr;
 
-  auto * root = new BinNode<int>(random_int(l, r));
+  auto *root = new BinNode<int>(random_int(l, r));
 
   LLINK(root) = random_tree(l, KEY(root) - 1);
   RLINK(root) = random_tree(KEY(root) + 1, r);
@@ -199,20 +197,17 @@ BinNode<int> * random_tree(int l, int r)
   return root;
 }
 
-int main(int argc, char * argv[])
+int main(int argc, char *argv[])
 {
   try
     {
       TCLAP::CmdLine cmd("Deway numbering example for trees", ' ', "1.0");
 
-      TCLAP::ValueArg<int> nArg("n", "nodes", 
-                                 "Number of nodes in the tree",
-                                 false, 10, "int");
+      TCLAP::ValueArg<int> nArg("n", "nodes", "Number of nodes in the tree", false, 10, "int");
       cmd.add(nArg);
 
-      TCLAP::ValueArg<unsigned int> seedArg("s", "seed",
-                                             "Random seed (0 = use time)",
-                                             false, 0, "unsigned int");
+      TCLAP::ValueArg<unsigned int> seedArg("s", "seed", "Random seed (0 = use time)", false, 0,
+                                            "unsigned int");
       cmd.add(seedArg);
 
       cmd.parse(argc, argv);
@@ -230,24 +225,18 @@ int main(int argc, char * argv[])
       cout << "Parameters: n=" << n << ", seed=" << t << endl << endl;
 
       // Generate random binary tree
-      BinNode<int> * bp = random_tree(1, n);
+      BinNode<int> *bp = random_tree(1, n);
 
       cout << "Binary tree (preorder):";
       preOrderRec(bp, printNode);
       cout << endl << endl;
-      
+
       cout << "Binary tree (inorder):";
       inOrderRec(bp, printNode);
       cout << endl << endl;
-      
-      // Convert to forest
-      Tree_Node<int> * tree = bin_to_forest<Tree_Node<int>, BinNode<int>>(bp);
 
-      // bin_to_forest creates a forest where sibling trees are linked,
-      // but the is_root flag is not set correctly for siblings.
-      // We fix this by setting is_root=true for all sibling trees.
-      for (auto* t = tree; t != nullptr; t = t->get_right_sibling())
-        t->set_is_root(true);
+      // Convert to forest
+      Tree_Node<int> *tree = bin_to_forest<Tree_Node<int>, BinNode<int>>(bp);
 
       cout << "Forest (preorder):";
       forest_preorder_traversal(tree, printNode);
@@ -258,7 +247,7 @@ int main(int argc, char * argv[])
       cout << endl << endl;
 
       // Verify conversion is reversible
-      BinNode<int> * prb = forest_to_bin<Tree_Node<int>, BinNode<int>>(tree);
+      BinNode<int> *prb = forest_to_bin<Tree_Node<int>, BinNode<int>>(tree);
       assert(areEquivalents(prb, bp));
       cout << "Conversion verification: PASSED" << endl << endl;
 

--- a/Examples/grid_example.cc
+++ b/Examples/grid_example.cc
@@ -1,0 +1,85 @@
+#include <iostream>
+#include <grid.H>
+#include <tpl_graph.H>
+
+using namespace std;
+using namespace Aleph;
+
+// A simple structure to hold node coordinates
+struct Coordinate {
+  size_t row, col;
+  Coordinate() : row(0), col(0) {}
+  Coordinate(size_t r, size_t c) : row(r), col(c) {}
+};
+
+// Functor to initialize node coordinates
+struct InitNode {
+  template <class Graph>
+  void operator()(Graph& /*g*/, typename Graph::Node* n, size_t r, size_t c) {
+    n->get_info() = Coordinate(r, c);
+  }
+};
+
+// Functor to initialize arc weights
+// For a grid, we might set orthogonal moves to cost 1.0 and diagonal to 1.414 (sqrt(2))
+struct InitArc {
+  template <class Graph>
+  void operator()(Graph& g, typename Graph::Arc* a, size_t /*r*/, size_t /*c*/) {
+    // Determine if the connection is diagonal or orthogonal based on coordinates
+    auto src_info = g.get_src_node(a)->get_info();
+    auto tgt_info = g.get_tgt_node(a)->get_info();
+    
+    bool is_diagonal = (src_info.row != tgt_info.row) && (src_info.col != tgt_info.col);
+    a->get_info() = is_diagonal ? 1.414 : 1.0;
+  }
+};
+
+int main() {
+  cout << "========================================" << endl;
+  cout << "        Grid Graph Generation Example" << endl;
+  cout << "========================================" << endl;
+
+  // We define a graph with Coordinate as node info and double as arc info
+  List_Graph<Graph_Node<Coordinate>, Graph_Arc<double>> g;
+  
+  // We use our custom functors to initialize the nodes and arcs during generation
+  Build_Grid<decltype(g), InitNode, InitArc> builder;
+  
+  const size_t rows = 4;
+  const size_t cols = 4;
+  
+  cout << "\nBuilding a " << rows << " x " << cols << " grid..." << endl;
+  // Note: parameters are (graph, width, height)
+  builder(g, cols, rows);
+  
+  cout << "Grid successfully built!" << endl;
+  cout << "Number of nodes: " << g.get_num_nodes() << endl;
+  cout << "Number of arcs: " << g.get_num_arcs() << endl;
+  
+  cout << "\nSample of connections from the bottom-right node (" << rows-1 << ", " << cols-1 << "):" << endl;
+  
+  // Find the node at (rows-1, cols-1)
+  List_Graph<Graph_Node<Coordinate>, Graph_Arc<double>>::Node* last_node = nullptr;
+  for (auto it = g.get_node_it(); it.has_curr(); it.next()) {
+    auto n = it.get_curr();
+    if (n->get_info().row == rows - 1 && n->get_info().col == cols - 1) {
+      last_node = n;
+      break;
+    }
+  }
+  
+  if (last_node) {
+    // In Aleph-w, arcs are directed from the node that created them. 
+    // Build_Grid connects node (i,j) to its previously created neighbors (left, up, diags).
+    // So the last node has outgoing arcs to its top, left, and upper-left neighbors.
+    for (auto it = g.get_out_it(last_node); it.has_curr(); it.next()) {
+      auto a = it.get_curr();
+      auto tgt = g.get_tgt_node(a);
+      cout << "  -> Connected to node (" << tgt->get_info().row << ", " << tgt->get_info().col 
+           << ") with weight " << a->get_info() << endl;
+    }
+  }
+
+  cout << "\n========================================" << endl;
+  return 0;
+}

--- a/Examples/grid_example.cc
+++ b/Examples/grid_example.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <numbers>
 #include <grid.H>
 #include <tpl_graph.H>
 
@@ -29,8 +30,8 @@ struct InitArc {
     auto src_info = g.get_src_node(a)->get_info();
     auto tgt_info = g.get_tgt_node(a)->get_info();
     
-    bool is_diagonal = (src_info.row != tgt_info.row) && (src_info.col != tgt_info.col);
-    a->get_info() = is_diagonal ? 1.414 : 1.0;
+    bool is_diagonal = (src_info.row != tgt_info.row) and (src_info.col != tgt_info.col);
+    a->get_info() = is_diagonal ? std::numbers::sqrt2 : 1.0;
   }
 };
 
@@ -62,7 +63,7 @@ int main() {
   List_Graph<Graph_Node<Coordinate>, Graph_Arc<double>>::Node* last_node = nullptr;
   for (auto it = g.get_node_it(); it.has_curr(); it.next()) {
     auto n = it.get_curr();
-    if (n->get_info().row == rows - 1 && n->get_info().col == cols - 1) {
+    if (n->get_info().row == rows - 1 and n->get_info().col == cols - 1) {
       last_node = n;
       break;
     }

--- a/Examples/grid_example.cc
+++ b/Examples/grid_example.cc
@@ -1,3 +1,34 @@
+
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  version 2.0.0b
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
 #include <iostream>
 #include <numbers>
 #include <grid.H>

--- a/Examples/mdspan_ca_lattice_view_example.cc
+++ b/Examples/mdspan_ca_lattice_view_example.cc
@@ -76,10 +76,13 @@ void demo_shared_buffer()
   std::cout << "v(0, 0) after grid.set(0,0,9): " << v(0, 0) << " (expect 9)\n\n";
 }
 
+#include <cassert>
+
 // A minimal 4-neighbour (von Neumann) sum, reading interior cells only —
-// the kind of loop that benefits from plain m(i, j) indexing.
+// the kind of loop that benefits from plain m(i, j) indexing. Must not be used on edge cells.
 int neighbour_sum(const Dense_Cell_Storage<int, 2>::const_view_type &v, size_t i, size_t j)
 {
+  assert(i > 0 and j > 0);
   return v(i - 1, j) + v(i + 1, j) + v(i, j - 1) + v(i, j + 1);
 }
 
@@ -123,7 +126,7 @@ void demo_read_only_view()
     for (size_t j = 0; j < 3; ++j)
       grid.set(i, j, next++);
 
-  print_view(grid.view());   // const Dense_Cell_Storage& -> const_view_type
+  print_view(grid.view());   // grid is non-const, so view() returns view_type which converts to const_view_type in print_view
   std::cout << "\n";
 }
 }  // namespace

--- a/Examples/mdspan_ca_lattice_view_example.cc
+++ b/Examples/mdspan_ca_lattice_view_example.cc
@@ -51,6 +51,7 @@
  *   function that only needs to read it, and get a read-only `mdspan`.
  */
 
+#include <cassert>
 #include <iostream>
 
 #include <print_rule.H>
@@ -75,8 +76,6 @@ void demo_shared_buffer()
   grid.set(0, 0, 9);                               // write through the storage API
   std::cout << "v(0, 0) after grid.set(0,0,9): " << v(0, 0) << " (expect 9)\n\n";
 }
-
-#include <cassert>
 
 // A minimal 4-neighbour (von Neumann) sum, reading interior cells only —
 // the kind of loop that benefits from plain m(i, j) indexing. Must not be used on edge cells.

--- a/Examples/mdspan_ca_lattice_view_example.cc
+++ b/Examples/mdspan_ca_lattice_view_example.cc
@@ -1,0 +1,141 @@
+
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file mdspan_ca_lattice_view_example.cc
+ * @brief `Dense_Cell_Storage::view()`: an `Aleph::mdspan` over a CA lattice.
+ *
+ * ## Overview
+ *
+ * `CA::Dense_Cell_Storage<T, N>` (`tpl_ca_storage.H`) already exposes
+ * `at(coord)`/`set(coord, v)` and 2D/3D shorthands `at(i,j)`/`set(i,j,v)`.
+ * `.view()` (and the read-only `.view() const`) hands back an
+ * `Aleph::mdspan` over the *same* buffer — zero allocation, zero copy —
+ * so code that wants plain `grid(i, j)` indexing (e.g. porting a
+ * numerical kernel that was written against a raw 2D array) can have it
+ * without going through the checked `at`/`set` pair one call at a time.
+ *
+ * - **[1] Same buffer, two ways to touch it**: writes through `.view()`
+ *   are immediately visible through `.at()`, and vice versa.
+ * - **[2] A tiny stencil kernel over the view**: sums each cell's 4
+ *   orthogonal neighbours directly through `operator()`, the kind of
+ *   inner loop this view exists for.
+ * - **[3] Read-only view**: pass a `const Dense_Cell_Storage&` to a
+ *   function that only needs to read it, and get a read-only `mdspan`.
+ */
+
+#include <iostream>
+
+#include <print_rule.H>
+#include <tpl_ca_storage.H>
+
+using namespace Aleph;
+using namespace Aleph::CA;
+
+namespace
+{
+void demo_shared_buffer()
+{
+  std::cout << "[1] .view() aliases the storage's own buffer\n";
+  print_rule();
+
+  Dense_Cell_Storage<int, 2> grid({3, 3}, 0);
+  auto v = grid.view();
+
+  v(1, 1) = 5;                                    // write through the view
+  std::cout << "grid.at(1, 1) after v(1,1)=5:  " << grid.at(1, 1) << " (expect 5)\n";
+
+  grid.set(0, 0, 9);                               // write through the storage API
+  std::cout << "v(0, 0) after grid.set(0,0,9): " << v(0, 0) << " (expect 9)\n\n";
+}
+
+// A minimal 4-neighbour (von Neumann) sum, reading interior cells only —
+// the kind of loop that benefits from plain m(i, j) indexing.
+int neighbour_sum(const Dense_Cell_Storage<int, 2>::const_view_type &v, size_t i, size_t j)
+{
+  return v(i - 1, j) + v(i + 1, j) + v(i, j - 1) + v(i, j + 1);
+}
+
+void demo_stencil_kernel()
+{
+  std::cout << "[2] A tiny stencil kernel driven directly through the view\n";
+  print_rule();
+
+  Dense_Cell_Storage<int, 2> grid({4, 4}, 1);   // every cell starts at 1
+  auto v = grid.view();
+
+  std::cout << "Sum of the 4 orthogonal neighbours of every interior cell\n"
+               "(each has value 1, so every sum should be 4):\n";
+  for (size_t i = 1; i + 1 < v.extent(0); ++i)
+    {
+      for (size_t j = 1; j + 1 < v.extent(1); ++j)
+        std::cout << neighbour_sum(v, i, j) << " ";
+      std::cout << "\n";
+    }
+  std::cout << "\n";
+}
+
+void print_view(const Dense_Cell_Storage<int, 2>::const_view_type &v)
+{
+  for (size_t i = 0; i < v.extent(0); ++i)
+    {
+      for (size_t j = 0; j < v.extent(1); ++j)
+        std::cout << v(i, j) << " ";
+      std::cout << "\n";
+    }
+}
+
+void demo_read_only_view()
+{
+  std::cout << "[3] Read-only view for a function that only reads the lattice\n";
+  print_rule();
+
+  Dense_Cell_Storage<int, 2> grid({2, 3});
+  int next = 0;
+  for (size_t i = 0; i < 2; ++i)
+    for (size_t j = 0; j < 3; ++j)
+      grid.set(i, j, next++);
+
+  print_view(grid.view());   // const Dense_Cell_Storage& -> const_view_type
+  std::cout << "\n";
+}
+}  // namespace
+
+int main()
+{
+  std::cout << "\n=== Dense_Cell_Storage::view(): mdspan over a CA lattice ===\n\n";
+
+  demo_shared_buffer();
+  demo_stencil_kernel();
+  demo_read_only_view();
+
+  std::cout << "Done.\n";
+  return 0;
+}

--- a/Examples/mdspan_matrix_view_example.cc
+++ b/Examples/mdspan_matrix_view_example.cc
@@ -1,0 +1,135 @@
+
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file mdspan_matrix_view_example.cc
+ * @brief `Aleph::mdspan` as a zero-copy 2D "matrix" view over a flat buffer.
+ *
+ * ## Overview
+ *
+ * `Aleph::mdspan` never owns memory: it is a pointer plus a shape. This
+ * example walks through the case that motivates it most directly —
+ * numerical code that already works with a flat, contiguous buffer
+ * (`Array<T>`, `std::vector<T>`, a `T*` from a C library, ...) and wants
+ * readable `m(row, col)` indexing without transposing or copying anything.
+ *
+ * - **[1] Row-major (the default)**: wrap a flat buffer and index it like
+ *   a matrix, matching the C/row-major convention Aleph itself uses.
+ * - **[2] Column-major interop**: view the *same* buffer as column-major
+ *   (`Aleph::layout_left`) without moving a single byte — useful when
+ *   interfacing with Fortran/BLAS-style routines that expect that layout.
+ * - **[3] Read-only views**: `mdspan<const T, ...>` exposes a buffer for
+ *   reading without allowing the view to mutate it.
+ */
+
+#include <iostream>
+#include <vector>
+
+#include <ah-mdspan.H>
+#include <print_rule.H>
+
+using namespace Aleph;
+
+namespace
+{
+void demo_row_major()
+{
+  std::cout << "[1] Row-major view (Aleph::layout_right, the default)\n";
+  print_rule();
+
+  // A 3x4 matrix stored flat, as numerical code typically hands it over.
+  std::vector<double> buf(3 * 4, 0.0);
+  mdspan<double, dextents<size_t, 2>> m(buf.data(), 3, 4);
+
+  for (size_t i = 0; i < m.extent(0); ++i)
+    for (size_t j = 0; j < m.extent(1); ++j)
+      m(i, j) = static_cast<double>(i * 10 + j);
+
+  std::cout << "m(" << m.extent(0) << "x" << m.extent(1) << "):\n";
+  for (size_t i = 0; i < m.extent(0); ++i)
+    {
+      for (size_t j = 0; j < m.extent(1); ++j)
+        std::cout << m(i, j) << "\t";
+      std::cout << "\n";
+    }
+  std::cout << "Row-major: m(1, 2) sits at buf[1*4 + 2] = buf["
+            << (1 * m.extent(1) + 2) << "] = " << buf[1 * 4 + 2] << "\n\n";
+}
+
+void demo_column_major_interop()
+{
+  std::cout << "[2] Column-major view (Aleph::layout_left) over the same data\n";
+  print_rule();
+
+  // Same flat buffer, no copy: just a different layout policy on top.
+  std::vector<int> buf(2 * 3);
+  mdspan<int, dextents<size_t, 2>, layout_left> m(buf.data(), 2, 3);
+
+  int next = 0;
+  for (size_t j = 0; j < m.extent(1); ++j)   // fastest-varying axis is first
+    for (size_t i = 0; i < m.extent(0); ++i)
+      m(i, j) = next++;
+
+  std::cout << "Column-major fill order produced buf = [";
+  for (size_t k = 0; k < buf.size(); ++k)
+    std::cout << buf[k] << (k + 1 < buf.size() ? ", " : "");
+  std::cout << "]\n";
+  std::cout << "(first axis varies fastest: m(0,0),m(1,0),m(0,1),... -- the\n"
+               " layout a Fortran/BLAS routine would expect from this buffer)\n\n";
+}
+
+void demo_read_only_view()
+{
+  std::cout << "[3] Read-only view over const data\n";
+  print_rule();
+
+  const std::vector<double> readings{98.6, 99.1, 97.9, 100.2};
+  mdspan<const double, dextents<size_t, 1>> m(readings.data(), readings.size());
+
+  double total = 0.0;
+  for (size_t i = 0; i < m.extent(0); ++i)
+    total += m(i);
+  std::cout << "Average of " << m.extent(0) << " read-only samples: "
+            << (total / static_cast<double>(m.extent(0))) << "\n";
+  std::cout << "(m(0) = readings[0]; the view has no write access to \"const double\")\n\n";
+}
+}  // namespace
+
+int main()
+{
+  std::cout << "\n=== Aleph::mdspan: zero-copy matrix views ===\n\n";
+
+  demo_row_major();
+  demo_column_major_interop();
+  demo_read_only_view();
+
+  std::cout << "Done.\n";
+  return 0;
+}

--- a/Examples/trie_example.C
+++ b/Examples/trie_example.C
@@ -29,11 +29,10 @@
   SOFTWARE.
 */
 
-
 /**
  * @file trie_example.C
  * @brief Prefix Tree (Trie): Efficient String Storage and Search
- * 
+ *
  * This example demonstrates the Trie (also called prefix tree or digital tree),
  * a tree-like data structure optimized for string storage and retrieval. Tries
  * excel at prefix-based operations and are fundamental to many text processing
@@ -171,19 +170,24 @@
  * ## Usage Example
  *
  * ```cpp
- * Trie<string> dictionary;
+ * Prefix_Tree dictionary;
  *
- * dictionary.insert("hello");
- * dictionary.insert("world");
- * dictionary.insert("help");
+ * dictionary.insert_word("hello");
+ * dictionary.insert_word("world");
+ * dictionary.insert_word("help");
  *
  * // Search
- * if (dictionary.search("hello"))
+ * if (dictionary.contains("hello"))
  *   cout << "Found!\n";
  *
  * // Prefix search
- * auto words = dictionary.prefix_search("hel"); // Returns ["hello", "help"]
+ * auto words = dictionary.words_with_prefix("hel"); // "hello", "help"
  * ```
+ *
+ * This example uses Prefix_Tree, the owning wrapper around the low-level
+ * Cnode nodes. Cnode is still available for manual tree manipulation, but
+ * Prefix_Tree is the preferred API for application code because it cleans up
+ * all nodes automatically.
  *
  * ## Command-line Usage
  *
@@ -229,47 +233,45 @@ void demo_basic_operations()
   cout << "\n" << string(60, '=') << endl;
   cout << "Trie: Basic Operations" << endl;
   cout << string(60, '=') << endl;
-  
-  Cnode root('\0');  // Root with sentinel character
-  
+
+  Prefix_Tree trie;
+
   cout << "\n--- Insertion ---" << endl;
-  
+
   vector<string> words = {"cat", "car", "card", "care", "careful", "cart"};
-  
+
   cout << "Inserting words with common prefix 'ca':" << endl;
-  for (const auto& word : words)
-  {
-    bool inserted = root.insert_word(word);
-    cout << "  " << word << " -> " << (inserted ? "inserted" : "exists") << endl;
-  }
-  
+  for (const auto &word : words)
+    {
+      const bool inserted = trie.insert_word(word);
+      cout << "  " << word << " -> " << (inserted ? "inserted" : "exists") << endl;
+    }
+
   // Try inserting duplicates
   cout << "\nTrying to insert duplicate:" << endl;
-  cout << "  cat -> " << (root.insert_word("cat") ? "inserted" : "already exists") << endl;
-  
+  cout << "  cat -> " << (trie.insert_word("cat") ? "inserted" : "already exists") << endl;
+
   cout << "\n--- Search ---" << endl;
-  
+
   vector<string> to_find = {"cat", "car", "care", "cap", "dog"};
   cout << "Searching for words:" << endl;
-  for (const auto& word : to_find)
-  {
-    bool found = root.contains(word);
-    cout << "  " << word << " -> " << (found ? "FOUND" : "not found") << endl;
-  }
-  
+  for (const auto &word : to_find)
+    {
+      bool found = trie.contains(word);
+      cout << "  " << word << " -> " << (found ? "FOUND" : "not found") << endl;
+    }
+
   cout << "\n--- Statistics ---" << endl;
-  cout << "Total words stored: " << root.count() << endl;
-  
+  cout << "Total words stored: " << trie.count() << endl;
+
   cout << "\n--- All Words ---" << endl;
   cout << "Words in lexicographic order:" << endl;
-  auto all_words = root.words();
+  auto all_words = trie.words();
   for (size_t i = 0; i < all_words.size(); ++i)
-  {
-    string word = all_words[i];
-    cout << "  " << (i + 1) << ". " << word << endl;
-  }
-  
-  root.destroy();
+    {
+      string word = all_words[i];
+      cout << "  " << (i + 1) << ". " << word << endl;
+    }
 }
 
 /**
@@ -280,74 +282,74 @@ void demo_prefix_search()
   cout << "\n" << string(60, '=') << endl;
   cout << "Prefix Search: Autocomplete Feature" << endl;
   cout << string(60, '=') << endl;
-  
-  Cnode root('\0');
-  
+
+  Prefix_Tree trie;
+
   // Build a dictionary
-  vector<string> dictionary = {
-    "apple", "application", "apply", "approach",
-    "apt", "aptitude",
-    "banana", "band", "bandana", "bank", "banner",
-    "car", "card", "care", "careful", "careless", "career",
-    "cart", "cartoon", "carton"
-  };
-  
+  vector<string> dictionary = {"apple",    "application", "apply", "approach", "apt",
+                               "aptitude", "banana",      "band",  "bandana",  "bank",
+                               "banner",   "car",         "card",  "care",     "careful",
+                               "careless", "career",      "cart",  "cartoon",  "carton"};
+
   cout << "\nBuilding dictionary with " << dictionary.size() << " words..." << endl;
-  for (const auto& word : dictionary)
-    root.insert_word(word);
-  
+  for (const auto &word : dictionary)
+    trie.insert_word(word);
+
   cout << "\n--- Prefix Search Demo ---" << endl;
-  
+
   vector<string> prefixes = {"app", "ban", "car", "cart", "xyz"};
-  
-  for (const auto& prefix : prefixes)
-  {
-    cout << "\nPrefix '" << prefix << "' matches:" << endl;
-    
-    auto matches = root.words_with_prefix(prefix);
-    
-    if (matches.size() == 0)
-      cout << "  (no matches)" << endl;
-    else
+
+  for (const auto &prefix : prefixes)
     {
-      for (size_t i = 0; i < matches.size(); ++i)
-      {
-        string match = matches[i];
-        cout << "  - " << match << endl;
-      }
+      cout << "\nPrefix '" << prefix << "' matches:" << endl;
+
+      auto matches = trie.words_with_prefix(prefix);
+
+      if (matches.size() == 0)
+        cout << "  (no matches)" << endl;
+      else
+        {
+          for (size_t i = 0; i < matches.size(); ++i)
+            {
+              string match = matches[i];
+              cout << "  - " << match << endl;
+            }
+        }
     }
-  }
-  
+
   cout << "\n--- Simulating Autocomplete ---" << endl;
-  
+
   string input = "c";
   cout << "\nTyping simulation (showing suggestions):" << endl;
-  
+
   while (input.length() <= 4)
-  {
-    auto suggestions = root.words_with_prefix(input);
-    cout << "  User types: '" << input << "'" << endl;
-    cout << "    Suggestions (" << suggestions.size() << " matches): ";
-    
-    size_t shown = 0;
-    for (size_t i = 0; i < suggestions.size() and shown < 5; ++i, ++shown)
     {
-      if (i > 0) cout << ", ";
-      string s = suggestions[i];
-      cout << s;
+      auto suggestions = trie.words_with_prefix(input);
+      cout << "  User types: '" << input << "'" << endl;
+      cout << "    Suggestions (" << suggestions.size() << " matches): ";
+
+      size_t shown = 0;
+      for (size_t i = 0; i < suggestions.size() and shown < 5; ++i, ++shown)
+        {
+          if (i > 0)
+            cout << ", ";
+          string s = suggestions[i];
+          cout << s;
+        }
+      if (suggestions.size() > 5)
+        cout << " ...(" << (suggestions.size() - 5) << " more)";
+      cout << endl;
+
+      // Simulate user typing more
+      if (input == "c")
+        input = "ca";
+      else if (input == "ca")
+        input = "car";
+      else if (input == "car")
+        input = "care";
+      else
+        break;
     }
-    if (suggestions.size() > 5)
-      cout << " ...(" << (suggestions.size() - 5) << " more)";
-    cout << endl;
-    
-    // Simulate user typing more
-    if (input == "c") input = "ca";
-    else if (input == "ca") input = "car";
-    else if (input == "car") input = "care";
-    else break;
-  }
-  
-  root.destroy();
 }
 
 /**
@@ -358,64 +360,59 @@ void demo_spell_checker()
   cout << "\n" << string(60, '=') << endl;
   cout << "Practical Example: Simple Spell Checker" << endl;
   cout << string(60, '=') << endl;
-  
-  Cnode root('\0');
-  
+
+  Prefix_Tree trie;
+
   // Build dictionary
   vector<string> dictionary = {
-    "program", "programming", "programmer", "progress", "project",
-    "computer", "compute", "computing", "computation",
-    "algorithm", "algorithms", "algorithmic",
-    "data", "database", "datum",
-    "structure", "structures", "structural",
-    "the", "they", "them", "there", "their", "these",
-    "hello", "help", "helper", "helpful"
-  };
-  
+    "program",   "programming", "programmer", "progress",   "project",     "computer", "compute",
+    "computing", "computation", "algorithm",  "algorithms", "algorithmic", "data",     "database",
+    "datum",     "structure",   "structures", "structural", "the",         "they",     "them",
+    "there",     "their",       "these",      "hello",      "help",        "helper",   "helpful"};
+
   cout << "Loading dictionary with " << dictionary.size() << " words..." << endl;
-  for (const auto& word : dictionary)
-    root.insert_word(word);
-  
+  for (const auto &word : dictionary)
+    trie.insert_word(word);
+
   cout << "\n--- Spell Check Demo ---" << endl;
-  
+
   vector<string> to_check = {"program", "progam", "algoritm", "helllo", "data", "computer"};
-  
-  for (const auto& word : to_check)
-  {
-    cout << "\nChecking: '" << word << "'" << endl;
-    
-    if (root.contains(word))
+
+  for (const auto &word : to_check)
     {
-      cout << "  Status: Correct!" << endl;
-    }
-    else
-    {
-      cout << "  Status: Not found - might be misspelled" << endl;
-      
-      // Simple suggestion: words with same prefix
-      for (size_t prefixLen = word.length() - 1; prefixLen >= 2; --prefixLen)
-      {
-        string prefix = word.substr(0, prefixLen);
-        auto suggestions = root.words_with_prefix(prefix);
-        
-        if (suggestions.size() > 0)
+      cout << "\nChecking: '" << word << "'" << endl;
+
+      if (trie.contains(word))
         {
-          cout << "  Did you mean: ";
-          size_t shown = 0;
-          for (size_t i = 0; i < suggestions.size() and shown < 3; ++i, ++shown)
-          {
-            if (i > 0) cout << ", ";
-            string s = suggestions[i];
-            cout << s;
-          }
-          cout << "?" << endl;
-          break;
+          cout << "  Status: Correct!" << endl;
         }
-      }
+      else
+        {
+          cout << "  Status: Not found - might be misspelled" << endl;
+
+          // Simple suggestion: words with same prefix
+          for (size_t prefixLen = word.length() - 1; prefixLen >= 2; --prefixLen)
+            {
+              string prefix = word.substr(0, prefixLen);
+              auto suggestions = trie.words_with_prefix(prefix);
+
+              if (suggestions.size() > 0)
+                {
+                  cout << "  Did you mean: ";
+                  size_t shown = 0;
+                  for (size_t i = 0; i < suggestions.size() and shown < 3; ++i, ++shown)
+                    {
+                      if (i > 0)
+                        cout << ", ";
+                      string s = suggestions[i];
+                      cout << s;
+                    }
+                  cout << "?" << endl;
+                  break;
+                }
+            }
+        }
     }
-  }
-  
-  root.destroy();
 }
 
 /**
@@ -426,58 +423,51 @@ void demo_command_autocomplete()
   cout << "\n" << string(60, '=') << endl;
   cout << "Practical Example: Shell Command Autocomplete" << endl;
   cout << string(60, '=') << endl;
-  
-  Cnode root('\0');
-  
+
+  Prefix_Tree trie;
+
   // Common shell commands
   vector<string> commands = {
-    "cd", "ls", "pwd", "mkdir", "rmdir", "rm", "cp", "mv",
-    "cat", "less", "more", "head", "tail",
-    "grep", "find", "locate", "which", "whereis",
-    "chmod", "chown", "chgrp",
-    "ps", "top", "htop", "kill", "killall",
-    "ssh", "scp", "sftp",
-    "git", "gitk", "github",
-    "make", "cmake", "gcc", "g++", "gdb",
-    "python", "python3", "pip", "pip3",
-    "apt", "apt-get", "apt-cache"
-  };
-  
+    "cd",    "ls",     "pwd",     "mkdir", "rmdir",  "rm",   "cp",      "mv",       "cat",
+    "less",  "more",   "head",    "tail",  "grep",   "find", "locate",  "which",    "whereis",
+    "chmod", "chown",  "chgrp",   "ps",    "top",    "htop", "kill",    "killall",  "ssh",
+    "scp",   "sftp",   "git",     "gitk",  "github", "make", "cmake",   "gcc",      "g++",
+    "gdb",   "python", "python3", "pip",   "pip3",   "apt",  "apt-get", "apt-cache"};
+
   cout << "Loading " << commands.size() << " shell commands..." << endl;
-  for (const auto& cmd : commands)
-    root.insert_word(cmd);
-  
+  for (const auto &cmd : commands)
+    trie.insert_word(cmd);
+
   cout << "\n--- Tab Completion Simulation ---" << endl;
-  
+
   vector<string> partial_inputs = {"g", "gi", "apt", "ch", "py"};
-  
-  for (const auto& input : partial_inputs)
-  {
-    cout << "\n$ " << input << "<TAB>" << endl;
-    
-    auto completions = root.words_with_prefix(input);
-    
-    if (completions.size() == 0)
-      cout << "  (no completions)" << endl;
-    else if (completions.size() == 1)
+
+  for (const auto &input : partial_inputs)
     {
-      string c = completions[0];
-      cout << "  -> " << c << " (unique match)" << endl;
+      cout << "\n$ " << input << "<TAB>" << endl;
+
+      auto completions = trie.words_with_prefix(input);
+
+      if (completions.size() == 0)
+        cout << "  (no completions)" << endl;
+      else if (completions.size() == 1)
+        {
+          string c = completions[0];
+          cout << "  -> " << c << " (unique match)" << endl;
+        }
+      else
+        {
+          cout << "  Possible completions: ";
+          for (size_t i = 0; i < completions.size(); ++i)
+            {
+              if (i > 0)
+                cout << "  ";
+              string c = completions[i];
+              cout << c;
+            }
+          cout << endl;
+        }
     }
-    else
-    {
-      cout << "  Possible completions: ";
-      for (size_t i = 0; i < completions.size(); ++i)
-      {
-        if (i > 0) cout << "  ";
-        string c = completions[i];
-        cout << c;
-      }
-      cout << endl;
-    }
-  }
-  
-  root.destroy();
 }
 
 /**
@@ -488,39 +478,40 @@ void demo_trie_structure()
   cout << "\n" << string(60, '=') << endl;
   cout << "Trie Structure Visualization" << endl;
   cout << string(60, '=') << endl;
-  
-  Cnode root('\0');
-  
+
+  Prefix_Tree trie;
+
   vector<string> words = {"cat", "car", "card"};
-  
+
   cout << "\nInserting: ";
   for (size_t i = 0; i < words.size(); ++i)
-  {
-    if (i > 0) cout << ", ";
-    cout << words[i];
-    root.insert_word(words[i]);
-  }
+    {
+      if (i > 0)
+        cout << ", ";
+      cout << words[i];
+      trie.insert_word(words[i]);
+    }
   cout << endl;
-  
+
   cout << "\nTrie structure:" << endl;
   cout << "             root" << endl;
   cout << "               |" << endl;
   cout << "               c" << endl;
   cout << "               |" << endl;
   cout << "               a" << endl;
-  cout << "              /|" << endl;
-  cout << "             t r ($=end)" << endl;
-  cout << "             |  |" << endl;
-  cout << "             $ ($) d" << endl;
-  cout << "                  |" << endl;
-  cout << "                  $" << endl;
+  cout << "              / \\" << endl;
+  cout << "             r*  t*" << endl;
+  cout << "             |" << endl;
+  cout << "             d*" << endl;
   cout << endl;
   cout << "Words: cat, car, card" << endl;
   cout << "Notice how 'c', 'a' are shared!" << endl;
-  
-  cout << "\nTree string representation: " << root.to_str() << endl;
-  
-  root.destroy();
+  cout << "The '*' marks word endings stored as node state, not child nodes." << endl;
+
+  string structure = trie.root()->to_str();
+  if (not structure.empty() and structure.front() == '\0')
+    structure.replace(0, 1, "<root>");
+  cout << "\nTree string representation: " << structure << endl;
 }
 
 /**
@@ -531,156 +522,151 @@ void demo_performance(int n)
   cout << "\n" << string(60, '=') << endl;
   cout << "Performance Analysis (n = " << n << " words)" << endl;
   cout << string(60, '=') << endl;
-  
-  Cnode root('\0');
-  
+
+  Prefix_Tree trie;
+
   // Generate random-ish words
   vector<string> words;
   words.reserve(n);
-  
+
   vector<string> prefixes = {"pre", "post", "un", "re", "in", "ex", "sub", "super", "anti", "auto"};
-  vector<string> roots = {"act", "form", "port", "ject", "duct", "spect", "scrib", "struct", "mit", "vers"};
-  vector<string> suffixes = {"ion", "ment", "ness", "able", "ible", "ful", "less", "ive", "ous", "al"};
-  
+  vector<string> roots = {"act",   "form",  "port",   "ject", "duct",
+                          "spect", "scrib", "struct", "mit",  "vers"};
+  vector<string> suffixes = {"ion", "ment", "ness", "able", "ible",
+                             "ful", "less", "ive",  "ous",  "al"};
+
   for (int i = 0; i < n; ++i)
-  {
-    string word = prefixes[i % prefixes.size()] + 
-                  roots[(i / prefixes.size()) % roots.size()] +
-                  suffixes[(i / (prefixes.size() * roots.size())) % suffixes.size()];
-    // Add some variation
-    if (i % 3 == 0) word += "ed";
-    if (i % 5 == 0) word += "ly";
-    if (i % 7 == 0) word += "ing";
-    words.push_back(word);
-  }
-  
+    {
+      string word = prefixes[i % prefixes.size()] + roots[(i / prefixes.size()) % roots.size()] +
+        suffixes[(i / (prefixes.size() * roots.size())) % suffixes.size()];
+      // Add some variation
+      if (i % 3 == 0)
+        word += "ed";
+      if (i % 5 == 0)
+        word += "ly";
+      if (i % 7 == 0)
+        word += "ing";
+      words.push_back(word);
+    }
+
   cout << "\nGenerated " << words.size() << " words for testing" << endl;
-  
+
   // Insertion benchmark
   auto start = chrono::high_resolution_clock::now();
-  
-  for (const auto& word : words)
-    root.insert_word(word);
-  
+
+  for (const auto &word : words)
+    trie.insert_word(word);
+
   auto mid = chrono::high_resolution_clock::now();
-  
+
   // Search benchmark
   int found = 0;
-  for (const auto& word : words)
-    if (root.contains(word)) ++found;
-  
+  for (const auto &word : words)
+    if (trie.contains(word))
+      ++found;
+
   auto end = chrono::high_resolution_clock::now();
-  
+
   auto insert_us = chrono::duration_cast<chrono::microseconds>(mid - start).count();
   auto search_us = chrono::duration_cast<chrono::microseconds>(end - mid).count();
-  
+
   cout << "\nResults:" << endl;
-  cout << "  Words in trie: " << root.count() << endl;
+  cout << "  Words in trie: " << trie.count() << endl;
   cout << "  Insert time: " << insert_us << " us" << endl;
   cout << "  Search time: " << search_us << " us" << endl;
   cout << "  Found: " << found << "/" << words.size() << endl;
-  
+
   // Prefix search benchmark
   start = chrono::high_resolution_clock::now();
-  
+
   size_t total_matches = 0;
-  for (const auto& prefix : prefixes)
-  {
-    auto matches = root.words_with_prefix(prefix);
-    total_matches += matches.size();
-  }
-  
+  for (const auto &prefix : prefixes)
+    {
+      auto matches = trie.words_with_prefix(prefix);
+      total_matches += matches.size();
+    }
+
   end = chrono::high_resolution_clock::now();
-  
+
   auto prefix_us = chrono::duration_cast<chrono::microseconds>(end - start).count();
-  
+
   cout << "\nPrefix search (10 prefixes):" << endl;
   cout << "  Time: " << prefix_us << " us" << endl;
   cout << "  Total matches: " << total_matches << endl;
-  
-  root.destroy();
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
   try
-  {
-    TCLAP::CmdLine cmd("Trie (Prefix Tree) Example", ' ', "1.0");
-    
-    TCLAP::ValueArg<int> nArg("n", "count",
-      "Number of words for performance test", false, 1000, "int");
-    TCLAP::SwitchArg basicArg("b", "basic",
-      "Show basic operations", false);
-    TCLAP::SwitchArg prefixArg("p", "prefix",
-      "Show prefix search / autocomplete", false);
-    TCLAP::SwitchArg spellArg("s", "spell",
-      "Show spell checker example", false);
-    TCLAP::SwitchArg cmdArg("c", "commands",
-      "Show command autocomplete example", false);
-    TCLAP::SwitchArg structArg("t", "structure",
-      "Show trie structure visualization", false);
-    TCLAP::SwitchArg perfArg("f", "performance",
-      "Run performance analysis", false);
-    TCLAP::SwitchArg allArg("a", "all",
-      "Run all demos", false);
-    
-    cmd.add(nArg);
-    cmd.add(basicArg);
-    cmd.add(prefixArg);
-    cmd.add(spellArg);
-    cmd.add(cmdArg);
-    cmd.add(structArg);
-    cmd.add(perfArg);
-    cmd.add(allArg);
-    
-    cmd.parse(argc, argv);
-    
-    int n = nArg.getValue();
-    bool runBasic = basicArg.getValue();
-    bool runPrefix = prefixArg.getValue();
-    bool runSpell = spellArg.getValue();
-    bool runCmd = cmdArg.getValue();
-    bool runStruct = structArg.getValue();
-    bool runPerf = perfArg.getValue();
-    bool runAll = allArg.getValue();
-    
-    if (not runBasic and not runPrefix and not runSpell and 
-        not runCmd and not runStruct and not runPerf)
-      runAll = true;
-    
-    cout << "=== Trie (Prefix Tree): Efficient String Storage ===" << endl;
-    
-    if (runAll or runBasic)
-      demo_basic_operations();
-    
-    if (runAll or runStruct)
-      demo_trie_structure();
-    
-    if (runAll or runPrefix)
-      demo_prefix_search();
-    
-    if (runAll or runSpell)
-      demo_spell_checker();
-    
-    if (runAll or runCmd)
-      demo_command_autocomplete();
-    
-    if (runAll or runPerf)
-      demo_performance(n);
-    
-    cout << "\n=== Summary ===" << endl;
-    cout << "Tries excel at:" << endl;
-    cout << "  - Fast prefix searches (autocomplete)" << endl;
-    cout << "  - Memory-efficient storage of strings with shared prefixes" << endl;
-    cout << "  - O(k) operations where k = word length" << endl;
-    cout << "Use cases: autocomplete, spell checkers, IP routing, dictionaries" << endl;
-    
-    return 0;
-  }
-  catch (TCLAP::ArgException& e)
-  {
-    cerr << "Error: " << e.error() << " for arg " << e.argId() << endl;
-    return 1;
-  }
-}
+    {
+      TCLAP::CmdLine cmd("Trie (Prefix Tree) Example", ' ', "1.0");
 
+      TCLAP::ValueArg<int> nArg("n", "count", "Number of words for performance test", false, 1000,
+                                "int");
+      TCLAP::SwitchArg basicArg("b", "basic", "Show basic operations", false);
+      TCLAP::SwitchArg prefixArg("p", "prefix", "Show prefix search / autocomplete", false);
+      TCLAP::SwitchArg spellArg("s", "spell", "Show spell checker example", false);
+      TCLAP::SwitchArg cmdArg("c", "commands", "Show command autocomplete example", false);
+      TCLAP::SwitchArg structArg("t", "structure", "Show trie structure visualization", false);
+      TCLAP::SwitchArg perfArg("f", "performance", "Run performance analysis", false);
+      TCLAP::SwitchArg allArg("a", "all", "Run all demos", false);
+
+      cmd.add(nArg);
+      cmd.add(basicArg);
+      cmd.add(prefixArg);
+      cmd.add(spellArg);
+      cmd.add(cmdArg);
+      cmd.add(structArg);
+      cmd.add(perfArg);
+      cmd.add(allArg);
+
+      cmd.parse(argc, argv);
+
+      int n = nArg.getValue();
+      bool runBasic = basicArg.getValue();
+      bool runPrefix = prefixArg.getValue();
+      bool runSpell = spellArg.getValue();
+      bool runCmd = cmdArg.getValue();
+      bool runStruct = structArg.getValue();
+      bool runPerf = perfArg.getValue();
+      bool runAll = allArg.getValue();
+
+      if (not runBasic and not runPrefix and not runSpell and not runCmd and not runStruct and
+          not runPerf)
+        runAll = true;
+
+      cout << "=== Trie (Prefix Tree): Efficient String Storage ===" << endl;
+
+      if (runAll or runBasic)
+        demo_basic_operations();
+
+      if (runAll or runStruct)
+        demo_trie_structure();
+
+      if (runAll or runPrefix)
+        demo_prefix_search();
+
+      if (runAll or runSpell)
+        demo_spell_checker();
+
+      if (runAll or runCmd)
+        demo_command_autocomplete();
+
+      if (runAll or runPerf)
+        demo_performance(n);
+
+      cout << "\n=== Summary ===" << endl;
+      cout << "Tries excel at:" << endl;
+      cout << "  - Fast prefix searches (autocomplete)" << endl;
+      cout << "  - Memory-efficient storage of strings with shared prefixes" << endl;
+      cout << "  - O(k) operations where k = word length" << endl;
+      cout << "Use cases: autocomplete, spell checkers, IP routing, dictionaries" << endl;
+
+      return 0;
+    }
+  catch (TCLAP::ArgException &e)
+    {
+      cerr << "Error: " << e.error() << " for arg " << e.argId() << endl;
+      return 1;
+    }
+}

--- a/README.es.md
+++ b/README.es.md
@@ -3720,6 +3720,8 @@ Por favor, consulta la sección canónica de [Algoritmos de programación dinám
 | `ah-arena.H` | `AhArenaAllocator` | Arena allocator |
 | `ah-arena.H` | `allocate<T>()` | Construct object in arena |
 | `ah-arena.H` | `dealloc<T>()` | Destroy object from arena |
+| `ah-mdspan.H` | `Aleph::mdspan<T, Extents>` | Vista multidimensional no-owning y zero-copy sobre un buffer contiguo (nativa en C++20 — se alía a `std::mdspan` si el toolchain tiene `<mdspan>`); `layout_right` (row-major, por defecto) y `layout_left` (column-major) |
+| `tpl_ca_storage.H` | `Dense_Cell_Storage::view()` | Vista `Aleph::mdspan` sobre el buffer propio de un lattice CA, para indexar `grid(i, j)` sin ninguna asignación extra |
 
 #### Herramientas para compiladores
 

--- a/README.md
+++ b/README.md
@@ -4069,6 +4069,8 @@ Please refer to the canonical [Dynamic Programming Algorithms](#readme-dp-algori
 | `ah-arena.H` | `AhArenaAllocator` | Arena allocator |
 | `ah-arena.H` | `allocate<T>()` | Construct object in arena |
 | `ah-arena.H` | `dealloc<T>()` | Destroy object from arena |
+| `ah-mdspan.H` | `Aleph::mdspan<T, Extents>` | Non-owning, zero-copy multidimensional view over a contiguous buffer (native C++20 — aliased to `std::mdspan` when the toolchain has `<mdspan>`); `layout_right` (row-major, default) and `layout_left` (column-major) |
+| `tpl_ca_storage.H` | `Dense_Cell_Storage::view()` | `Aleph::mdspan` view of a CA lattice's own buffer, for `grid(i, j)`-style indexing with zero extra allocation |
 
 #### Compiler Tooling
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -231,6 +231,7 @@ set(TEST_PROGRAMS
     tpl_binNodeGenerators_test
     graph_traverse_generators_test
     ah_comb_generators_test
+    ah_mdspan_test
     index-node
     sort_arrays
     primes

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -232,6 +232,7 @@ set(TEST_PROGRAMS
     graph_traverse_generators_test
     ah_comb_generators_test
     ah_mdspan_test
+    grid_test
     index-node
     sort_arrays
     primes

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -382,6 +382,7 @@ set(TEST_PROGRAMS
     planarity_test
     graph_copy_test
     thread_pool_test
+    concurrency_test_utils_test
     timeoutQueue_test
     graph_traverse_test
     test_ah_errors

--- a/Tests/ah_mdspan_test.cc
+++ b/Tests/ah_mdspan_test.cc
@@ -1,0 +1,234 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file ah_mdspan_test.cc
+ * @brief Tests for the multidimensional view type (ah-mdspan.H).
+ *
+ * Exercises `Aleph::mdspan` through the same surface regardless of whether
+ * it resolves to `std::mdspan` (C++23) or the in-house C++20 polyfill.
+ */
+
+#include <array>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <ah-mdspan.H>
+
+using Aleph::dextents;
+using Aleph::dynamic_extent;
+using Aleph::extents;
+using Aleph::layout_left;
+using Aleph::layout_right;
+using Aleph::mdspan;
+
+TEST(AhMdspan, DetectionMacroIsDefined)
+{
+  // Must always be defined to 0 or 1, regardless of -std.
+  constexpr int v = ALEPH_HAS_STD_MDSPAN;
+  EXPECT_TRUE(v == 0 or v == 1);
+}
+
+TEST(AhMdspan, DextentsRankAndRankDynamic)
+{
+  using Ext = dextents<size_t, 3>;
+  static_assert(Ext::rank() == 3);
+  static_assert(Ext::rank_dynamic() == 3);
+  Ext e(2, 3, 4);
+  EXPECT_EQ(e.extent(0), 2u);
+  EXPECT_EQ(e.extent(1), 3u);
+  EXPECT_EQ(e.extent(2), 4u);
+}
+
+TEST(AhMdspan, MixedStaticAndDynamicExtents)
+{
+  // Axis 0 dynamic, axis 1 fixed to 4.
+  using Ext = extents<size_t, dynamic_extent, 4>;
+  static_assert(Ext::rank() == 2);
+  static_assert(Ext::rank_dynamic() == 1);
+  static_assert(Ext::static_extent(1) == 4);
+  static_assert(Ext::static_extent(0) == dynamic_extent);
+
+  Ext e(7);  // only the one dynamic axis needs a value
+  EXPECT_EQ(e.extent(0), 7u);
+  EXPECT_EQ(e.extent(1), 4u);
+}
+
+TEST(AhMdspan, ExtentsFromArray)
+{
+  std::array<size_t, 2> shape{3, 5};
+  dextents<size_t, 2> e(shape);
+  EXPECT_EQ(e.extent(0), 3u);
+  EXPECT_EQ(e.extent(1), 5u);
+}
+
+TEST(AhMdspan, ExtentsEquality)
+{
+  dextents<size_t, 2> a(2, 3);
+  dextents<size_t, 2> b(2, 3);
+  dextents<size_t, 2> c(3, 2);
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a == c);
+}
+
+TEST(AhMdspan, BasicConstructionAndShape)
+{
+  std::vector<int> buf(2 * 3, 0);
+  mdspan<int, dextents<size_t, 2>> m(buf.data(), 2, 3);
+
+  EXPECT_EQ(m.rank(), 2u);
+  EXPECT_EQ(m.extent(0), 2u);
+  EXPECT_EQ(m.extent(1), 3u);
+  EXPECT_EQ(m.size(), 6u);
+  EXPECT_FALSE(m.empty());
+  EXPECT_EQ(m.data_handle(), buf.data());
+}
+
+TEST(AhMdspan, ConstructFromArrayOfDynamicExtents)
+{
+  std::vector<int> buf(6, 0);
+  std::array<size_t, 2> shape{2, 3};
+  mdspan<int, dextents<size_t, 2>> m(buf.data(), shape);
+  EXPECT_EQ(m.extent(0), 2u);
+  EXPECT_EQ(m.extent(1), 3u);
+}
+
+TEST(AhMdspan, RowMajorIsDefaultAndMatchesFlatBufferOrder)
+{
+  // layout_right (row-major): the LAST axis varies fastest, i.e. m(i, j)
+  // maps to buf[i * ncols + j] -- exactly Aleph's own Array/C convention.
+  std::vector<int> buf(2 * 3, 0);
+  mdspan<int, dextents<size_t, 2>> m(buf.data(), 2, 3);
+
+  int next = 0;
+  for (size_t i = 0; i < m.extent(0); ++i)
+    for (size_t j = 0; j < m.extent(1); ++j)
+      m(i, j) = next++;
+
+  EXPECT_EQ(buf, (std::vector<int>{0, 1, 2, 3, 4, 5}));
+}
+
+TEST(AhMdspan, LayoutLeftIsColumnMajor)
+{
+  // layout_left (column-major): the FIRST axis varies fastest.
+  std::vector<int> buf(2 * 3, 0);
+  mdspan<int, dextents<size_t, 2>, layout_left> m(buf.data(), 2, 3);
+
+  int next = 0;
+  for (size_t j = 0; j < m.extent(1); ++j)
+    for (size_t i = 0; i < m.extent(0); ++i)
+      m(i, j) = next++;
+
+  EXPECT_EQ(buf, (std::vector<int>{0, 1, 2, 3, 4, 5}));
+}
+
+TEST(AhMdspan, WriteThroughViewIsVisibleThroughBuffer)
+{
+  std::vector<double> buf(4, 0.0);
+  mdspan<double, dextents<size_t, 2>> m(buf.data(), 2, 2);
+  m(0, 0) = 1.0;
+  m(0, 1) = 2.0;
+  m(1, 0) = 3.0;
+  m(1, 1) = 4.0;
+  EXPECT_EQ(buf, (std::vector<double>{1.0, 2.0, 3.0, 4.0}));
+}
+
+TEST(AhMdspan, ReadOnlyViewOverConstElement)
+{
+  const std::vector<int> buf{9, 8, 7, 6};
+  mdspan<const int, dextents<size_t, 1>> m(buf.data(), 4);
+  EXPECT_EQ(m(0), 9);
+  EXPECT_EQ(m(2), 7);
+  static_assert(std::is_const_v<std::remove_reference_t<decltype(m(0))>>);
+}
+
+TEST(AhMdspan, AtThrowsOnOutOfRangeIndex)
+{
+  std::vector<int> buf(6, 0);
+  mdspan<int, dextents<size_t, 2>> m(buf.data(), 2, 3);
+  EXPECT_NO_THROW((void) m.at(1, 2));
+  EXPECT_THROW((void) m.at(2, 0), std::out_of_range);
+  EXPECT_THROW((void) m.at(0, 3), std::out_of_range);
+}
+
+TEST(AhMdspan, OneDimensionalView)
+{
+  std::vector<int> buf{10, 20, 30};
+  mdspan<int, dextents<size_t, 1>> m(buf.data(), 3);
+  EXPECT_EQ(m.rank(), 1u);
+  EXPECT_EQ(m(0), 10);
+  EXPECT_EQ(m(2), 30);
+}
+
+TEST(AhMdspan, ThreeDimensionalRowMajorRoundTrip)
+{
+  std::vector<int> buf(2 * 2 * 2, -1);
+  mdspan<int, dextents<size_t, 3>> m(buf.data(), 2, 2, 2);
+
+  int next = 0;
+  for (size_t i = 0; i < 2; ++i)
+    for (size_t j = 0; j < 2; ++j)
+      for (size_t k = 0; k < 2; ++k)
+        m(i, j, k) = next++;
+
+  for (int v : buf)
+    EXPECT_NE(v, -1);
+  EXPECT_EQ(m(1, 1, 1), 7);
+  EXPECT_EQ(buf.back(), 7);
+}
+
+TEST(AhMdspan, DefaultConstructedIsEmptyWithNullData)
+{
+  mdspan<int, dextents<size_t, 1>> m;
+  EXPECT_EQ(m.data_handle(), nullptr);
+  EXPECT_TRUE(m.empty());
+  EXPECT_EQ(m.size(), 0u);
+}
+
+TEST(AhMdspan, MultipleIndependentViewsOverSameBufferDoNotInterfere)
+{
+  std::vector<int> buf(4, 0);
+  mdspan<int, dextents<size_t, 2>> m1(buf.data(), 2, 2);
+  mdspan<int, dextents<size_t, 2>> m2(buf.data(), 2, 2);
+  m1(0, 0) = 42;
+  EXPECT_EQ(m2(0, 0), 42);  // same underlying buffer: aliasing is intentional
+}
+
+TEST(AhMdspan, MutableViewConvertsImplicitlyToConstView)
+{
+  // Mirrors T* -> const T* implicit conversion.
+  int buf[4] = {1, 2, 3, 4};
+  mdspan<int, dextents<size_t, 2>> m(buf, 2, 2);
+
+  auto reader = [](mdspan<const int, dextents<size_t, 2>> v) { return v(1, 1); };
+  EXPECT_EQ(reader(m), 4);
+}

--- a/Tests/ah_mdspan_test.cc
+++ b/Tests/ah_mdspan_test.cc
@@ -51,6 +51,31 @@ using Aleph::layout_left;
 using Aleph::layout_right;
 using Aleph::mdspan;
 
+// Compile-time regression: operator()/at() must reject a wrong number of
+// indices for the view's rank instead of silently reading past a local
+// array (a real out-of-bounds stack read was reproduced before this
+// constraint existed — see the PR review discussion). A rank-2 view must
+// accept exactly 2 indices, not 1 and not 3.
+using Rank2 = mdspan<int, dextents<size_t, 2>>;
+
+// A bare top-level `requires(Rank2 m) { m(1); }` would NOT reliably detect
+// this: once `Rank2` is a fully concrete (non-dependent) type, an unsatisfied
+// call is a plain "no matching function" error, not a substitution failure
+// in the immediate context of a template parameter -- so it is not silently
+// absorbed. Wrapping the check in a genuine template (a concept) restores
+// the SFINAE-friendly behavior actually needed here.
+template <class M, class... Args>
+concept CanCall = requires(M m, Args... args) { m(args...); };
+template <class M, class... Args>
+concept CanCallAt = requires(M m, Args... args) { m.at(args...); };
+
+static_assert(CanCall<Rank2, int, int>);
+static_assert(not CanCall<Rank2, int>);
+static_assert(not CanCall<Rank2, int, int, int>);
+static_assert(CanCallAt<Rank2, int, int>);
+static_assert(not CanCallAt<Rank2, int>);
+static_assert(not CanCallAt<Rank2, int, int, int>);
+
 TEST(AhMdspan, DetectionMacroIsDefined)
 {
   // Must always be defined to 0 or 1, regardless of -std.
@@ -111,6 +136,19 @@ TEST(AhMdspan, BasicConstructionAndShape)
   EXPECT_EQ(m.size(), 6u);
   EXPECT_FALSE(m.empty());
   EXPECT_EQ(m.data_handle(), buf.data());
+}
+
+TEST(AhMdspan, OperatorRequiresExactRankArguments)
+{
+  std::vector<int> buf(6, 0);
+  mdspan<int, dextents<size_t, 2>> m(buf.data(), 2, 3);
+  
+  // Valid call: 2 indices for rank-2 span
+  static_assert(std::is_invocable_v<decltype(m), int, int>);
+  
+  // Invalid calls: wrong arity
+  static_assert(not std::is_invocable_v<decltype(m), int>);
+  static_assert(not std::is_invocable_v<decltype(m), int, int, int>);
 }
 
 TEST(AhMdspan, ConstructFromArrayOfDynamicExtents)

--- a/Tests/concurrency_test_utils.H
+++ b/Tests/concurrency_test_utils.H
@@ -1,0 +1,305 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  version 2.0.0b
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file concurrency_test_utils.H
+ * @brief Reusable helpers for concurrent data-structure tests.
+ */
+
+#ifndef ALEPH_CONCURRENCY_TEST_UTILS_H
+#define ALEPH_CONCURRENCY_TEST_UTILS_H
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <random>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace Aleph
+{
+namespace Testing
+{
+
+/** One-shot deterministic start gate for test worker threads. */
+class StartGate
+{
+  const size_t participants;
+  size_t waiting = 0;
+  bool open = false;
+  std::mutex mutex;
+  std::condition_variable cv;
+
+public:
+  /** Builds a gate that opens when `num_participants` threads arrive.
+
+      @param[in] num_participants number of worker threads expected.
+      @throw std::invalid_argument if `num_participants` is zero.
+  */
+  explicit StartGate(const size_t num_participants)
+    : participants(num_participants)
+  {
+    if (participants == 0)
+      throw std::invalid_argument("StartGate requires at least one participant");
+  }
+
+  /** Blocks until all participants have arrived. */
+  void arrive_and_wait()
+  {
+    std::unique_lock lock(mutex);
+    ++waiting;
+    if (waiting == participants)
+      {
+        open = true;
+        cv.notify_all();
+        return;
+      }
+
+    cv.wait(lock, [this] { return open; });
+  }
+};
+
+/** Runs `worker(index)` in `thread_count` threads with a shared start gate.
+
+    Any exception thrown by a worker is rethrown after all threads join.
+
+    @param[in] thread_count number of worker threads to launch.
+    @param[in] worker callable receiving the worker index.
+    @throw std::invalid_argument if `thread_count` is zero.
+*/
+template <class Worker>
+void run_concurrently(const size_t thread_count, Worker worker)
+{
+  if (thread_count == 0)
+    throw std::invalid_argument("run_concurrently requires at least one thread");
+
+  StartGate gate(thread_count);
+  std::mutex exception_mutex;
+  std::exception_ptr first_exception;
+  std::vector<std::thread> threads;
+  threads.reserve(thread_count);
+
+  for (size_t i = 0; i < thread_count; ++i)
+    threads.emplace_back([&, i]
+    {
+      gate.arrive_and_wait();
+      try
+        {
+          std::invoke(worker, i);
+        }
+      catch (...)
+        {
+          std::lock_guard lock(exception_mutex);
+          if (first_exception == nullptr)
+            first_exception = std::current_exception();
+        }
+    });
+
+  for (auto &thread : threads)
+    thread.join();
+
+  if (first_exception != nullptr)
+    std::rethrow_exception(first_exception);
+}
+
+/** Runs producer and consumer workers from the same deterministic start gate.
+
+    The producer callable receives a producer index in `[0, producer_count)`.
+    The consumer callable receives a consumer index in `[0, consumer_count)`.
+    Exceptions are rethrown after all threads join.
+
+    @param[in] producer_count number of producer workers.
+    @param[in] consumer_count number of consumer workers.
+    @param[in] producer producer callable.
+    @param[in] consumer consumer callable.
+    @throw std::invalid_argument if both counts are zero.
+*/
+template <class Producer, class Consumer>
+void run_producers_consumers(const size_t producer_count,
+                             const size_t consumer_count,
+                             Producer producer, Consumer consumer)
+{
+  const size_t total = producer_count + consumer_count;
+  if (total == 0)
+    throw std::invalid_argument("run_producers_consumers requires workers");
+
+  StartGate gate(total);
+  std::mutex exception_mutex;
+  std::exception_ptr first_exception;
+  std::vector<std::thread> threads;
+  threads.reserve(total);
+
+  auto capture_exception = [&]
+  {
+    std::lock_guard lock(exception_mutex);
+    if (first_exception == nullptr)
+      first_exception = std::current_exception();
+  };
+
+  for (size_t i = 0; i < producer_count; ++i)
+    threads.emplace_back([&, i]
+    {
+      gate.arrive_and_wait();
+      try
+        {
+          std::invoke(producer, i);
+        }
+      catch (...)
+        {
+          capture_exception();
+        }
+    });
+
+  for (size_t i = 0; i < consumer_count; ++i)
+    threads.emplace_back([&, i]
+    {
+      gate.arrive_and_wait();
+      try
+        {
+          std::invoke(consumer, i);
+        }
+      catch (...)
+        {
+          capture_exception();
+        }
+    });
+
+  for (auto &thread : threads)
+    thread.join();
+
+  if (first_exception != nullptr)
+    std::rethrow_exception(first_exception);
+}
+
+/** Operation kinds used by randomized data-structure parity traces. */
+enum class OperationKind
+{
+  insert,
+  erase,
+  find,
+  update,
+  push,
+  pop
+};
+
+/** One randomized operation entry for parity and stress tests. */
+struct OperationTraceEntry
+{
+  OperationKind kind = OperationKind::find;
+  size_t key = 0;
+  size_t value = 0;
+
+  bool operator == (const OperationTraceEntry &) const = default;
+};
+
+/** Configuration for `make_random_operation_trace()`. */
+struct OperationTraceConfig
+{
+  size_t length = 0;
+  size_t key_range = 1;
+  size_t value_range = 1;
+  uint64_t seed = 0xA13F2026u;
+  std::vector<OperationKind> operations =
+    { OperationKind::insert, OperationKind::erase, OperationKind::find };
+};
+
+/** Builds a deterministic randomized operation trace.
+
+    @param[in] config trace generation parameters.
+    @return generated trace entries.
+    @throw std::invalid_argument if a range is zero or no operations are given.
+*/
+inline std::vector<OperationTraceEntry>
+make_random_operation_trace(const OperationTraceConfig &config)
+{
+  if (config.key_range == 0)
+    throw std::invalid_argument("operation trace key_range must be positive");
+  if (config.value_range == 0)
+    throw std::invalid_argument("operation trace value_range must be positive");
+  if (config.operations.empty())
+    throw std::invalid_argument("operation trace requires operations");
+
+  std::mt19937_64 rng(config.seed);
+  std::uniform_int_distribution<size_t> op_dist(0, config.operations.size() - 1);
+  std::uniform_int_distribution<size_t> key_dist(0, config.key_range - 1);
+  std::uniform_int_distribution<size_t> value_dist(0, config.value_range - 1);
+
+  std::vector<OperationTraceEntry> trace;
+  trace.reserve(config.length);
+  for (size_t i = 0; i < config.length; ++i)
+    trace.push_back({ config.operations[op_dist(rng)],
+                      key_dist(rng),
+                      value_dist(rng) });
+
+  return trace;
+}
+
+/** Replays a trace against a model and a subject and reports first mismatch.
+
+    `apply_model(model, op)` and `apply_subject(subject, op)` perform one
+    operation. `equivalent(model, subject)` checks full-state parity after each
+    operation.
+
+    @return index of the first mismatching operation, or `std::nullopt`.
+*/
+template <class Trace, class Model, class Subject,
+          class ApplyModel, class ApplySubject, class Equivalent>
+std::optional<size_t>
+first_state_mismatch_after_replay(const Trace &trace,
+                                  Model &model,
+                                  Subject &subject,
+                                  ApplyModel apply_model,
+                                  ApplySubject apply_subject,
+                                  Equivalent equivalent)
+{
+  size_t index = 0;
+  for (const auto &op : trace)
+    {
+      std::invoke(apply_model, model, op);
+      std::invoke(apply_subject, subject, op);
+      if (not std::invoke(equivalent, model, subject))
+        return index;
+      ++index;
+    }
+
+  return std::nullopt;
+}
+
+} // namespace Testing
+} // namespace Aleph
+
+#endif // ALEPH_CONCURRENCY_TEST_UTILS_H

--- a/Tests/concurrency_test_utils.H
+++ b/Tests/concurrency_test_utils.H
@@ -50,62 +50,206 @@
 #include <utility>
 #include <vector>
 
+#include <ah-errors.H>
+
 namespace Aleph
 {
 namespace Testing
 {
 
-/** One-shot deterministic start gate for test worker threads. */
+/** @brief One-shot deterministic start gate for test worker threads.
+ *
+ *  All participants call `arrive_and_wait()` and block until the last one
+ *  arrives, so a test can launch several worker threads and have them begin
+ *  their timed/racy section as simultaneously as the scheduler allows,
+ *  instead of racing from staggered `std::thread` start times.
+ *
+ *  @par Thread-safety
+ *  `arrive_and_wait()` and `cancel()` may be called concurrently from any
+ *  number of threads; both synchronize internally on the gate's own mutex.
+ *  The constructor is not thread-safe with respect to concurrent use of the
+ *  same (not-yet-published) instance, matching ordinary construction rules.
+ *
+ *  @par Complexity
+ *  `arrive_and_wait()` and `cancel()` are O(1) plus the cost of waking up
+ *  to `num_participants` blocked threads (a single `notify_all()`).
+ */
 class StartGate
 {
   const size_t participants;
   size_t waiting = 0;
   bool open = false;
+  bool cancelled = false;
   std::mutex mutex;
   std::condition_variable cv;
 
 public:
-  /** Builds a gate that opens when `num_participants` threads arrive.
-
-      @param[in] num_participants number of worker threads expected.
-      @throw std::invalid_argument if `num_participants` is zero.
-  */
+  /** @brief Builds a gate that opens when `num_participants` threads arrive.
+   *
+   *  @param[in] num_participants number of worker threads expected.
+   *  @throw std::invalid_argument if `num_participants` is zero.
+   */
   explicit StartGate(const size_t num_participants)
     : participants(num_participants)
   {
-    if (participants == 0)
-      throw std::invalid_argument("StartGate requires at least one participant");
+    ah_invalid_argument_if(participants == 0)
+      << "StartGate requires at least one participant";
   }
 
-  /** Blocks until all participants have arrived. */
-  void arrive_and_wait()
+  /** @brief Blocks until all participants have arrived, or the gate is
+   *         cancelled.
+   *
+   *  @pre Called at most once per logical participant (calling it more
+   *       times than `num_participants` from distinct threads means more
+   *       than `num_participants` threads will block here, and the gate
+   *       never opens on its own).
+   *  @post On a `true` return, every participant's `arrive_and_wait()` has
+   *        also returned or is about to return -- the gate does not open
+   *        for only some of them.
+   *  @return `true` if the gate opened normally (all participants
+   *          arrived); `false` if `cancel()` unblocked this call instead.
+   *  @note Does not throw; blocking is done through
+   *        `std::condition_variable::wait`, which only propagates spurious
+   *        wakeups internally (handled by the wait predicate) and does not
+   *        surface exceptions in normal use.
+   */
+  bool arrive_and_wait()
   {
     std::unique_lock lock(mutex);
+    if (cancelled)
+      return false;
+
     ++waiting;
     if (waiting == participants)
       {
         open = true;
         cv.notify_all();
-        return;
+        return true;
       }
 
-    cv.wait(lock, [this] { return open; });
+    cv.wait(lock, [this] { return open or cancelled; });
+    return open;
+  }
+
+  /** @brief Aborts the gate, releasing every participant currently blocked
+   *         in `arrive_and_wait()` (and any that calls it afterward).
+   *
+   *  Released participants observe `arrive_and_wait()` returning `false`
+   *  instead of waiting forever. Intended for exception-safety cleanup:
+   *  if launching one worker thread of a cohort fails partway through
+   *  (see `run_concurrently()`), the threads already started would
+   *  otherwise block on this gate indefinitely, since the full
+   *  `num_participants` will never arrive.
+   *
+   *  @post `open` remains as it was (cancelling an already-open gate is a
+   *        harmless no-op); further `arrive_and_wait()` calls return
+   *        `false` immediately.
+   */
+  void cancel() noexcept
+  {
+    std::lock_guard lock(mutex);
+    cancelled = true;
+    cv.notify_all();
   }
 };
 
-/** Runs `worker(index)` in `thread_count` threads with a shared start gate.
+namespace concurrency_test_utils_detail
+{
 
-    Any exception thrown by a worker is rethrown after all threads join.
+/** @brief RAII guard that leaves no thread joinable when it goes out of
+ *         scope, cancelling `gate` first so any thread still blocked in
+ *         `StartGate::arrive_and_wait()` wakes up instead of waiting
+ *         forever.
+ *
+ *  Constructing a cohort of worker threads with `std::vector::emplace_back`
+ *  can throw partway through (typically `std::system_error` from the OS
+ *  refusing to create another thread). Without this guard, the threads
+ *  already started stay blocked on the shared `StartGate` -- it will never
+ *  reach `num_participants` arrivals -- and when the exception unwinds the
+ *  enclosing `std::vector<std::thread>`, destroying still-joinable
+ *  `std::thread` objects calls `std::terminate()`.
+ *
+ *  Usage is a commit/rollback pattern: construct the guard right before the
+ *  launch loop, call `dismiss()` right after every thread has been launched
+ *  successfully, then let normal execution join the threads as before (or
+ *  let the guard's destructor do it). If an exception unwinds the scope
+ *  *before* `dismiss()` runs, the destructor knows the full cohort never
+ *  launched, so it cancels the gate first -- unblocking every thread
+ *  already waiting in `StartGate::arrive_and_wait()` -- and only then joins
+ *  them. After `dismiss()`, the destructor still joins any still-joinable
+ *  thread (harmless once the caller's own join loop already ran), but does
+ *  not cancel the gate, since all participants are known to have been
+ *  launched and will reach it on their own.
+ *
+ *  @note Not copyable or movable; it is meant to be a single scope-local
+ *        guard around one `std::vector<std::thread>` and `StartGate` pair.
+ */
+class Joining_Thread_Guard
+{
+  std::vector<std::thread> &threads;
+  StartGate &gate;
+  bool launch_completed = false;
 
-    @param[in] thread_count number of worker threads to launch.
-    @param[in] worker callable receiving the worker index.
-    @throw std::invalid_argument if `thread_count` is zero.
-*/
+public:
+  Joining_Thread_Guard(std::vector<std::thread> &threads_, StartGate &gate_) noexcept
+    : threads(threads_), gate(gate_)
+  {}
+
+  Joining_Thread_Guard(const Joining_Thread_Guard &) = delete;
+  Joining_Thread_Guard &operator=(const Joining_Thread_Guard &) = delete;
+
+  /** @brief Marks the launch loop as having completed without throwing.
+   *
+   *  Call this once, right after the last `threads.emplace_back(...)`. It
+   *  must not be called if any launch attempt failed.
+   */
+  void dismiss() noexcept { launch_completed = true; }
+
+  ~Joining_Thread_Guard()
+  {
+    if (not launch_completed)
+      gate.cancel();
+    for (auto &thread : threads)
+      if (thread.joinable())
+        thread.join();
+  }
+};
+
+} // namespace concurrency_test_utils_detail
+
+/** @brief Runs `worker(index)` in `thread_count` threads with a shared
+ *         start gate.
+ *
+ *  Every worker blocks on a shared `StartGate` before calling
+ *  `worker(index)`, so all `thread_count` invocations begin as close to
+ *  simultaneously as the scheduler allows. Any exception thrown by a
+ *  worker is captured (the first one, by arrival order under the internal
+ *  mutex) and rethrown from this function after every thread has joined.
+ *
+ *  @tparam Worker callable, invocable as `worker(size_t)`; must be safe to
+ *          copy into `thread_count` closures and to call concurrently from
+ *          different threads (each thread calls its own copy, so `Worker`
+ *          itself need not be thread-safe unless it captures shared state).
+ *  @param[in] thread_count number of worker threads to launch.
+ *  @param[in] worker callable receiving the worker index in
+ *             `[0, thread_count)`.
+ *  @throw std::invalid_argument if `thread_count` is zero.
+ *  @throw std::system_error propagated as-is if the underlying
+ *         `std::thread` constructor fails to create a thread; threads
+ *         already launched are joined (never left blocked on the gate or
+ *         abandoned joinable) before this propagates.
+ *  @note Exception safety: if a worker throws anything other than what it
+ *        raises through normal execution, that exception (the first one
+ *        observed) is rethrown by this function; all other workers still
+ *        run to completion and are joined regardless.
+ *  @note Complexity: O(thread_count) thread creations/joins plus whatever
+ *        `worker` itself costs.
+ */
 template <class Worker>
 void run_concurrently(const size_t thread_count, Worker worker)
 {
-  if (thread_count == 0)
-    throw std::invalid_argument("run_concurrently requires at least one thread");
+  ah_invalid_argument_if(thread_count == 0)
+    << "run_concurrently requires at least one thread";
 
   StartGate gate(thread_count);
   std::mutex exception_mutex;
@@ -113,49 +257,69 @@ void run_concurrently(const size_t thread_count, Worker worker)
   std::vector<std::thread> threads;
   threads.reserve(thread_count);
 
-  for (size_t i = 0; i < thread_count; ++i)
-    threads.emplace_back([&, i]
-    {
-      gate.arrive_and_wait();
-      try
-        {
-          std::invoke(worker, i);
-        }
-      catch (...)
-        {
-          std::lock_guard lock(exception_mutex);
-          if (first_exception == nullptr)
-            first_exception = std::current_exception();
-        }
-    });
-
-  for (auto &thread : threads)
-    thread.join();
+  {
+    concurrency_test_utils_detail::Joining_Thread_Guard guard(threads, gate);
+    for (size_t i = 0; i < thread_count; ++i)
+      threads.emplace_back([&, i]
+      {
+        if (not gate.arrive_and_wait())
+          return;
+        try
+          {
+            std::invoke(worker, i);
+          }
+        catch (...)
+          {
+            std::lock_guard lock(exception_mutex);
+            if (first_exception == nullptr)
+              first_exception = std::current_exception();
+          }
+      });
+    guard.dismiss();  // every thread launched; let them reach the gate on
+                       // their own instead of racing to cancel() it here.
+  } // guard destructor: on the normal path above, just joins (already-
+    // dismissed); if emplace_back threw before dismiss(), cancels the gate
+    // first so threads already blocked on it wake up, then joins them.
 
   if (first_exception != nullptr)
     std::rethrow_exception(first_exception);
 }
 
-/** Runs producer and consumer workers from the same deterministic start gate.
-
-    The producer callable receives a producer index in `[0, producer_count)`.
-    The consumer callable receives a consumer index in `[0, consumer_count)`.
-    Exceptions are rethrown after all threads join.
-
-    @param[in] producer_count number of producer workers.
-    @param[in] consumer_count number of consumer workers.
-    @param[in] producer producer callable.
-    @param[in] consumer consumer callable.
-    @throw std::invalid_argument if both counts are zero.
-*/
+/** @brief Runs producer and consumer workers from the same deterministic
+ *         start gate.
+ *
+ *  The producer callable receives a producer index in `[0, producer_count)`.
+ *  The consumer callable receives a consumer index in `[0, consumer_count)`.
+ *  All `producer_count + consumer_count` workers share one `StartGate`, so
+ *  producers and consumers start together rather than producers racing
+ *  ahead. Exceptions are captured (the first one observed) and rethrown
+ *  after all threads join.
+ *
+ *  @tparam Producer callable, invocable as `producer(size_t)`.
+ *  @tparam Consumer callable, invocable as `consumer(size_t)`.
+ *  @param[in] producer_count number of producer workers.
+ *  @param[in] consumer_count number of consumer workers.
+ *  @param[in] producer producer callable.
+ *  @param[in] consumer consumer callable.
+ *  @throw std::invalid_argument if both counts are zero.
+ *  @throw std::system_error propagated as-is if the underlying
+ *         `std::thread` constructor fails to create a thread; threads
+ *         already launched are joined (never left blocked on the gate or
+ *         abandoned joinable) before this propagates.
+ *  @note Exception safety: same as `run_concurrently()` -- the first
+ *        exception observed from any producer or consumer is rethrown
+ *        once every thread has joined.
+ *  @note Complexity: O(producer_count + consumer_count) thread
+ *        creations/joins plus whatever `producer`/`consumer` cost.
+ */
 template <class Producer, class Consumer>
 void run_producers_consumers(const size_t producer_count,
                              const size_t consumer_count,
                              Producer producer, Consumer consumer)
 {
   const size_t total = producer_count + consumer_count;
-  if (total == 0)
-    throw std::invalid_argument("run_producers_consumers requires workers");
+  ah_invalid_argument_if(total == 0)
+    << "run_producers_consumers requires workers";
 
   StartGate gate(total);
   std::mutex exception_mutex;
@@ -170,36 +334,43 @@ void run_producers_consumers(const size_t producer_count,
       first_exception = std::current_exception();
   };
 
-  for (size_t i = 0; i < producer_count; ++i)
-    threads.emplace_back([&, i]
-    {
-      gate.arrive_and_wait();
-      try
-        {
-          std::invoke(producer, i);
-        }
-      catch (...)
-        {
-          capture_exception();
-        }
-    });
+  {
+    concurrency_test_utils_detail::Joining_Thread_Guard guard(threads, gate);
 
-  for (size_t i = 0; i < consumer_count; ++i)
-    threads.emplace_back([&, i]
-    {
-      gate.arrive_and_wait();
-      try
-        {
-          std::invoke(consumer, i);
-        }
-      catch (...)
-        {
-          capture_exception();
-        }
-    });
+    for (size_t i = 0; i < producer_count; ++i)
+      threads.emplace_back([&, i]
+      {
+        if (not gate.arrive_and_wait())
+          return;
+        try
+          {
+            std::invoke(producer, i);
+          }
+        catch (...)
+          {
+            capture_exception();
+          }
+      });
 
-  for (auto &thread : threads)
-    thread.join();
+    for (size_t i = 0; i < consumer_count; ++i)
+      threads.emplace_back([&, i]
+      {
+        if (not gate.arrive_and_wait())
+          return;
+        try
+          {
+            std::invoke(consumer, i);
+          }
+        catch (...)
+          {
+            capture_exception();
+          }
+      });
+    guard.dismiss();  // every thread launched; let them reach the gate on
+                       // their own instead of racing to cancel() it here.
+  } // guard destructor: on the normal path above, just joins (already-
+    // dismissed); if emplace_back threw before dismiss(), cancels the gate
+    // first so threads already blocked on it wake up, then joins them.
 
   if (first_exception != nullptr)
     std::rethrow_exception(first_exception);
@@ -216,17 +387,41 @@ enum class OperationKind
   pop
 };
 
-/** One randomized operation entry for parity and stress tests. */
+/** @brief One randomized operation entry for parity and stress tests.
+ *
+ *  `kind` selects which operation to replay; `key`/`value` are always
+ *  populated (in `[0, key_range)`/`[0, value_range)` of whatever
+ *  `OperationTraceConfig` produced this entry), even for operations that
+ *  do not use one of them (e.g. `find` ignores `value`) -- callers decide
+ *  which fields their `apply_model`/`apply_subject` callables read.
+ */
 struct OperationTraceEntry
 {
   OperationKind kind = OperationKind::find;
   size_t key = 0;
   size_t value = 0;
 
+  /// Structural equality of all three fields (C++20 defaulted comparison).
   bool operator == (const OperationTraceEntry &) const = default;
 };
 
-/** Configuration for `make_random_operation_trace()`. */
+/** @brief Configuration for `make_random_operation_trace()`.
+ *
+ *  @var OperationTraceConfig::length
+ *  Number of entries to generate. Zero is valid (produces an empty trace).
+ *  @var OperationTraceConfig::key_range
+ *  Exclusive upper bound for generated keys (`key` is drawn from
+ *  `[0, key_range)`). Must be positive.
+ *  @var OperationTraceConfig::value_range
+ *  Exclusive upper bound for generated values (`value` is drawn from
+ *  `[0, value_range)`). Must be positive.
+ *  @var OperationTraceConfig::seed
+ *  Seed for the internal `std::mt19937_64` engine; the same seed and the
+ *  rest of the configuration always reproduce the same trace (see
+ *  `make_random_operation_trace()`'s determinism note).
+ *  @var OperationTraceConfig::operations
+ *  Pool `kind` is drawn from, uniformly at random. Must be non-empty.
+ */
 struct OperationTraceConfig
 {
   size_t length = 0;
@@ -237,21 +432,36 @@ struct OperationTraceConfig
     { OperationKind::insert, OperationKind::erase, OperationKind::find };
 };
 
-/** Builds a deterministic randomized operation trace.
-
-    @param[in] config trace generation parameters.
-    @return generated trace entries.
-    @throw std::invalid_argument if a range is zero or no operations are given.
-*/
+/** @brief Builds a deterministic randomized operation trace.
+ *
+ *  Draws `config.length` entries from a `std::mt19937_64` engine seeded
+ *  with `config.seed`: `kind` is chosen uniformly from `config.operations`,
+ *  `key` uniformly from `[0, config.key_range)`, and `value` uniformly from
+ *  `[0, config.value_range)`.
+ *
+ *  @param[in] config trace generation parameters.
+ *  @return generated trace entries, `config.length` of them, in generation
+ *          order.
+ *  @throw std::invalid_argument if `config.key_range` or
+ *         `config.value_range` is zero, or if `config.operations` is empty.
+ *  @note Determinism: calling this twice with equal `OperationTraceConfig`
+ *        values (same `seed`, ranges, and `operations`, compared
+ *        element-wise) always yields an identical trace, since the only
+ *        source of randomness is the seeded engine constructed from
+ *        `config` -- there is no reliance on global or time-based state.
+ *  @note Complexity: O(config.length) time, and the returned vector is
+ *        preallocated to `config.length` (one allocation, no reallocation
+ *        growth).
+ */
 inline std::vector<OperationTraceEntry>
 make_random_operation_trace(const OperationTraceConfig &config)
 {
-  if (config.key_range == 0)
-    throw std::invalid_argument("operation trace key_range must be positive");
-  if (config.value_range == 0)
-    throw std::invalid_argument("operation trace value_range must be positive");
-  if (config.operations.empty())
-    throw std::invalid_argument("operation trace requires operations");
+  ah_invalid_argument_if(config.key_range == 0)
+    << "operation trace key_range must be positive";
+  ah_invalid_argument_if(config.value_range == 0)
+    << "operation trace value_range must be positive";
+  ah_invalid_argument_if(config.operations.empty())
+    << "operation trace requires operations";
 
   std::mt19937_64 rng(config.seed);
   std::uniform_int_distribution<size_t> op_dist(0, config.operations.size() - 1);
@@ -268,14 +478,41 @@ make_random_operation_trace(const OperationTraceConfig &config)
   return trace;
 }
 
-/** Replays a trace against a model and a subject and reports first mismatch.
-
-    `apply_model(model, op)` and `apply_subject(subject, op)` perform one
-    operation. `equivalent(model, subject)` checks full-state parity after each
-    operation.
-
-    @return index of the first mismatching operation, or `std::nullopt`.
-*/
+/** @brief Replays a trace against a model and a subject and reports the
+ *         first mismatch.
+ *
+ *  For each entry `op` in `trace`, in order: applies `op` to `model`, then
+ *  to `subject`, then checks `equivalent(model, subject)`. Stops and
+ *  reports the index of the first operation after which the two disagree;
+ *  a typical use is a simple reference container (`model`) checked against
+ *  an `Aleph` container under test (`subject`) after every step of a
+ *  randomized trace from `make_random_operation_trace()`.
+ *
+ *  @tparam Trace any range of entries `op` accepted by both `apply_model`
+ *          and `apply_subject` (typically `std::vector<OperationTraceEntry>`).
+ *  @tparam Model reference/model container type.
+ *  @tparam Subject container type under test.
+ *  @tparam ApplyModel callable, invocable as `apply_model(model, op)`.
+ *  @tparam ApplySubject callable, invocable as `apply_subject(subject, op)`.
+ *  @tparam Equivalent callable, invocable as `equivalent(model, subject)`,
+ *          returning a value contextually convertible to `bool`.
+ *  @param[in] trace operations to replay, in order.
+ *  @param[in,out] model reference model mutated by `apply_model`.
+ *  @param[in,out] subject container under test mutated by `apply_subject`.
+ *  @param[in] apply_model applies one trace entry to `model`.
+ *  @param[in] apply_subject applies one trace entry to `subject`.
+ *  @param[in] equivalent full-state parity check between `model` and
+ *             `subject`, called after every replayed operation.
+ *  @return index of the first mismatching operation, or `std::nullopt` if
+ *          `model` and `subject` stayed equivalent through the whole trace
+ *          (including the empty-trace case, which never runs the check).
+ *  @throw Whatever `apply_model`, `apply_subject`, or `equivalent` throw;
+ *         this function itself does not throw. No cleanup beyond the
+ *         basic guarantee is provided if one of them does -- `model` and
+ *         `subject` may be left mid-replay.
+ *  @note Complexity: O(trace.size()) calls to `apply_model`/
+ *        `apply_subject`/`equivalent`, plus whatever those cost.
+ */
 template <class Trace, class Model, class Subject,
           class ApplyModel, class ApplySubject, class Equivalent>
 std::optional<size_t>

--- a/Tests/concurrency_test_utils.H
+++ b/Tests/concurrency_test_utils.H
@@ -46,6 +46,7 @@
 #include <optional>
 #include <random>
 #include <stdexcept>
+#include <system_error>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -209,9 +210,48 @@ public:
   {
     if (not launch_completed)
       gate.cancel();
+    join_all_no_throw();
+  }
+
+private:
+  /** @brief Joins every joinable thread, never letting an exception escape.
+   *
+   *  `std::thread::join()` can throw `std::system_error` (the `joinable()`
+   *  guard already rules out the most common case, `errc::invalid_argument`
+   *  for a non-joinable thread, but the standard does not otherwise bound
+   *  what an implementation may report). Destructors are implicitly
+   *  `noexcept`, so letting that propagate out of `~Joining_Thread_Guard()`
+   *  would call `std::terminate()`.
+   *
+   *  Per the standard, a `std::thread` that throws out of `join()` remains
+   *  joinable -- swallowing the exception alone would leave that thread
+   *  joinable in the caller's `std::vector<std::thread>`, which would then
+   *  call `std::terminate()` itself once that vector is later destroyed.
+   *  `detach()` is attempted as a fallback specifically to avoid trading
+   *  one `std::terminate()` for a delayed one; if that also throws, nothing
+   *  further can be done from a destructor with nothing left to report to.
+   */
+  void join_all_no_throw() noexcept
+  {
     for (auto &thread : threads)
       if (thread.joinable())
-        thread.join();
+        {
+          try
+            {
+              thread.join();
+            }
+          catch (const std::system_error &)
+            {
+              try
+                {
+                  thread.detach();
+                }
+              catch (const std::system_error &)
+                {
+                  // Nothing actionable from here; see rationale above.
+                }
+            }
+        }
   }
 };
 

--- a/Tests/concurrency_test_utils.H
+++ b/Tests/concurrency_test_utils.H
@@ -260,7 +260,7 @@ void run_concurrently(const size_t thread_count, Worker worker)
   {
     concurrency_test_utils_detail::Joining_Thread_Guard guard(threads, gate);
     for (size_t i = 0; i < thread_count; ++i)
-      threads.emplace_back([&, i]
+      threads.emplace_back([&, i, worker]() mutable
       {
         if (not gate.arrive_and_wait())
           return;
@@ -295,8 +295,13 @@ void run_concurrently(const size_t thread_count, Worker worker)
  *  ahead. Exceptions are captured (the first one observed) and rethrown
  *  after all threads join.
  *
- *  @tparam Producer callable, invocable as `producer(size_t)`.
- *  @tparam Consumer callable, invocable as `consumer(size_t)`.
+ *  @tparam Producer callable, invocable as `producer(size_t)`; must be safe
+ *          to copy into `producer_count` closures and to call concurrently
+ *          from different threads (each thread calls its own copy, so
+ *          `Producer` itself need not be thread-safe unless it captures
+ *          shared state).
+ *  @tparam Consumer callable, invocable as `consumer(size_t)`; same
+ *          per-thread-copy contract as `Producer`.
  *  @param[in] producer_count number of producer workers.
  *  @param[in] consumer_count number of consumer workers.
  *  @param[in] producer producer callable.
@@ -338,7 +343,7 @@ void run_producers_consumers(const size_t producer_count,
     concurrency_test_utils_detail::Joining_Thread_Guard guard(threads, gate);
 
     for (size_t i = 0; i < producer_count; ++i)
-      threads.emplace_back([&, i]
+      threads.emplace_back([&, i, producer]() mutable
       {
         if (not gate.arrive_and_wait())
           return;
@@ -353,7 +358,7 @@ void run_producers_consumers(const size_t producer_count,
       });
 
     for (size_t i = 0; i < consumer_count; ++i)
-      threads.emplace_back([&, i]
+      threads.emplace_back([&, i, consumer]() mutable
       {
         if (not gate.arrive_and_wait())
           return;

--- a/Tests/concurrency_test_utils_test.cc
+++ b/Tests/concurrency_test_utils_test.cc
@@ -1,0 +1,188 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  version 2.0.0b
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#include <gtest/gtest.h>
+
+#include "concurrency_test_utils.H"
+
+#include <atomic>
+#include <map>
+#include <stdexcept>
+#include <vector>
+
+using namespace Aleph::Testing;
+
+TEST(ConcurrencyTestUtils, StartGateRejectsZeroParticipants)
+{
+  EXPECT_THROW(StartGate(0), std::invalid_argument);
+}
+
+TEST(ConcurrencyTestUtils, RunConcurrentlyStartsEveryWorker)
+{
+  std::atomic<size_t> count{0};
+
+  run_concurrently(8, [&](const size_t)
+  {
+    count.fetch_add(1, std::memory_order_relaxed);
+  });
+
+  EXPECT_EQ(count.load(std::memory_order_relaxed), 8u);
+}
+
+TEST(ConcurrencyTestUtils, RunConcurrentlyRethrowsWorkerException)
+{
+  EXPECT_THROW(
+    run_concurrently(4, [](const size_t index)
+    {
+      if (index == 2)
+        throw std::runtime_error("worker failed");
+    }),
+    std::runtime_error);
+}
+
+TEST(ConcurrencyTestUtils, RunProducersConsumersRunsBothSides)
+{
+  std::atomic<size_t> producers{0};
+  std::atomic<size_t> consumers{0};
+
+  run_producers_consumers(
+    3, 2,
+    [&](const size_t) { producers.fetch_add(1, std::memory_order_relaxed); },
+    [&](const size_t) { consumers.fetch_add(1, std::memory_order_relaxed); });
+
+  EXPECT_EQ(producers.load(std::memory_order_relaxed), 3u);
+  EXPECT_EQ(consumers.load(std::memory_order_relaxed), 2u);
+}
+
+TEST(ConcurrencyTestUtils, RandomOperationTraceIsDeterministic)
+{
+  OperationTraceConfig config;
+  config.length = 16;
+  config.key_range = 7;
+  config.value_range = 11;
+  config.seed = 12345;
+  config.operations = { OperationKind::insert, OperationKind::erase,
+                        OperationKind::find, OperationKind::update };
+
+  const auto first = make_random_operation_trace(config);
+  const auto second = make_random_operation_trace(config);
+
+  ASSERT_EQ(first, second);
+  ASSERT_EQ(first.size(), 16u);
+  for (const auto &op : first)
+    {
+      EXPECT_LT(op.key, 7u);
+      EXPECT_LT(op.value, 11u);
+    }
+}
+
+TEST(ConcurrencyTestUtils, RandomOperationTraceValidatesConfiguration)
+{
+  OperationTraceConfig config;
+  config.length = 1;
+
+  config.key_range = 0;
+  EXPECT_THROW((void) make_random_operation_trace(config), std::invalid_argument);
+
+  config.key_range = 1;
+  config.value_range = 0;
+  EXPECT_THROW((void) make_random_operation_trace(config), std::invalid_argument);
+
+  config.value_range = 1;
+  config.operations.clear();
+  EXPECT_THROW((void) make_random_operation_trace(config), std::invalid_argument);
+}
+
+TEST(ConcurrencyTestUtils, ReplayParityPassesMatchingStates)
+{
+  std::vector<OperationTraceEntry> trace =
+    {
+      { OperationKind::insert, 3, 30 },
+      { OperationKind::insert, 4, 40 },
+      { OperationKind::erase, 3, 0 }
+    };
+
+  std::map<size_t, size_t> model;
+  std::map<size_t, size_t> subject;
+
+  const auto mismatch = first_state_mismatch_after_replay(
+    trace, model, subject,
+    [](auto &map, const OperationTraceEntry &op)
+    {
+      if (op.kind == OperationKind::insert)
+        map[op.key] = op.value;
+      else if (op.kind == OperationKind::erase)
+        map.erase(op.key);
+    },
+    [](auto &map, const OperationTraceEntry &op)
+    {
+      if (op.kind == OperationKind::insert)
+        map[op.key] = op.value;
+      else if (op.kind == OperationKind::erase)
+        map.erase(op.key);
+    },
+    [](const auto &lhs, const auto &rhs) { return lhs == rhs; });
+
+  EXPECT_FALSE(mismatch.has_value());
+}
+
+TEST(ConcurrencyTestUtils, ReplayParityReportsFirstMismatch)
+{
+  std::vector<OperationTraceEntry> trace =
+    {
+      { OperationKind::insert, 1, 10 },
+      { OperationKind::insert, 2, 20 },
+      { OperationKind::erase, 1, 0 }
+    };
+
+  std::map<size_t, size_t> model;
+  std::map<size_t, size_t> subject;
+
+  const auto mismatch = first_state_mismatch_after_replay(
+    trace, model, subject,
+    [](auto &map, const OperationTraceEntry &op)
+    {
+      if (op.kind == OperationKind::insert)
+        map[op.key] = op.value;
+      else if (op.kind == OperationKind::erase)
+        map.erase(op.key);
+    },
+    [](auto &map, const OperationTraceEntry &op)
+    {
+      if (op.kind == OperationKind::insert)
+        map[op.key] = op.key == 2 ? 99 : op.value;
+      else if (op.kind == OperationKind::erase)
+        map.erase(op.key);
+    },
+    [](const auto &lhs, const auto &rhs) { return lhs == rhs; });
+
+  ASSERT_TRUE(mismatch.has_value());
+  EXPECT_EQ(*mismatch, 1u);
+}

--- a/Tests/concurrency_test_utils_test.cc
+++ b/Tests/concurrency_test_utils_test.cc
@@ -32,6 +32,7 @@
 
 #include "concurrency_test_utils.H"
 
+#include <algorithm>
 #include <atomic>
 #include <map>
 #include <stdexcept>
@@ -42,6 +43,19 @@ using namespace Aleph::Testing;
 TEST(ConcurrencyTestUtils, StartGateRejectsZeroParticipants)
 {
   EXPECT_THROW(StartGate(0), std::invalid_argument);
+}
+
+TEST(ConcurrencyTestUtils, RunConcurrentlyRejectsZeroThreads)
+{
+  EXPECT_THROW(run_concurrently(0, [](const size_t) {}),
+               std::invalid_argument);
+}
+
+TEST(ConcurrencyTestUtils, RunProducersConsumersRejectsZeroWorkers)
+{
+  EXPECT_THROW(
+    run_producers_consumers(0, 0, [](const size_t) {}, [](const size_t) {}),
+    std::invalid_argument);
 }
 
 TEST(ConcurrencyTestUtils, RunConcurrentlyStartsEveryWorker)
@@ -100,6 +114,9 @@ TEST(ConcurrencyTestUtils, RandomOperationTraceIsDeterministic)
     {
       EXPECT_LT(op.key, 7u);
       EXPECT_LT(op.value, 11u);
+      EXPECT_NE(std::find(config.operations.begin(), config.operations.end(),
+                          op.kind),
+               config.operations.end());
     }
 }
 

--- a/Tests/grid_test.cc
+++ b/Tests/grid_test.cc
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+#include <grid.H>
+#include <tpl_graph.H>
+
+using namespace Aleph;
+
+TEST(GridTest, BasicCreation) {
+  List_Graph<Graph_Node<int>, Graph_Arc<int>> g;
+  Build_Grid<decltype(g)> build;
+  build(g, 10, 10);
+  
+  EXPECT_EQ(g.get_num_nodes(), 100);
+  
+  // horizontal: 10 * 9 = 90
+  // vertical: 10 * 9 = 90
+  // upper-left diag: 9 * 9 = 81
+  // upper-right diag: 9 * 9 = 81
+  // Total arcs = 342
+  EXPECT_EQ(g.get_num_arcs(), 342);
+}
+
+TEST(GridTest, InvalidDimensions) {
+  List_Graph<Graph_Node<int>, Graph_Arc<int>> g;
+  Build_Grid<decltype(g)> build;
+  
+  EXPECT_THROW(build(g, 1, 10), std::length_error);
+  EXPECT_THROW(build(g, 10, 1), std::length_error);
+}
+
+TEST(GridTest, CustomOperations) {
+  List_Graph<Graph_Node<int>, Graph_Arc<int>> g;
+  
+  struct NodeOp {
+    void operator()(decltype(g)& /*g*/, decltype(g)::Node* n, size_t row, size_t col) {
+      n->get_info() = row * 100 + col;
+    }
+  };
+  
+  struct ArcOp {
+    void operator()(decltype(g)& /*g*/, decltype(g)::Arc* a, size_t /*row*/, size_t /*col*/) {
+      a->get_info() = 1;
+    }
+  };
+
+  Build_Grid<decltype(g), NodeOp, ArcOp> build;
+  build(g, 3, 3);
+  
+  EXPECT_EQ(g.get_num_nodes(), 9);
+  
+  size_t sum_info = 0;
+  for (auto it = g.get_node_it(); it.has_curr(); it.next()) {
+    sum_info += it.get_curr()->get_info();
+  }
+  
+  // row 0: 0, 1, 2 = 3
+  // row 1: 100, 101, 102 = 303
+  // row 2: 200, 201, 202 = 603
+  // sum = 909
+  EXPECT_EQ(sum_info, 909);
+  
+  size_t arc_sum = 0;
+  for (auto it = g.get_arc_it(); it.has_curr(); it.next()) {
+    arc_sum += it.get_curr()->get_info();
+  }
+  
+  // 3x3 grid:
+  // horiz: 3 * 2 = 6
+  // vert: 3 * 2 = 6
+  // ul: 2 * 2 = 4
+  // ur: 2 * 2 = 4
+  // total = 20
+  EXPECT_EQ(arc_sum, 20);
+}

--- a/Tests/grid_test.cc
+++ b/Tests/grid_test.cc
@@ -1,3 +1,34 @@
+
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  version 2.0.0b
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
 #include <gtest/gtest.h>
 #include <grid.H>
 #include <tpl_graph.H>

--- a/Tests/grid_test.cc
+++ b/Tests/grid_test.cc
@@ -25,6 +25,9 @@ TEST(GridTest, InvalidDimensions) {
   
   EXPECT_THROW(build(g, 1, 10), std::length_error);
   EXPECT_THROW(build(g, 10, 1), std::length_error);
+  
+  EXPECT_NO_THROW(build(g, 2, 2));
+  EXPECT_EQ(g.get_num_nodes(), 4);
 }
 
 TEST(GridTest, CustomOperations) {

--- a/Tests/prefix_tree_test.cc
+++ b/Tests/prefix_tree_test.cc
@@ -51,9 +51,178 @@
 #include <gtest/gtest.h>
 #include <prefix-tree.H>
 #include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdlib>
+#include <new>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
+namespace
+{
+  std::atomic<int> allocation_countdown{-1};
+  std::atomic<bool> track_allocations{false};
+  std::atomic<int> tracked_balance{0};
+
+  bool should_fail_allocation() noexcept
+  {
+    int remaining = allocation_countdown.load(std::memory_order_relaxed);
+    while (remaining >= 0)
+      {
+        if (remaining == 0)
+          return true;
+        if (allocation_countdown.compare_exchange_weak(
+                remaining, remaining - 1, std::memory_order_relaxed))
+          return false;
+      }
+    return false;
+  }
+
+  void * allocate_or_throw(std::size_t size)
+  {
+    if (should_fail_allocation())
+      throw std::bad_alloc();
+
+    if (size == 0)
+      size = 1;
+
+    void *ptr = std::malloc(size);
+    if (ptr == nullptr)
+      throw std::bad_alloc();
+
+    if (track_allocations.load(std::memory_order_relaxed))
+      tracked_balance.fetch_add(1, std::memory_order_relaxed);
+
+    return ptr;
+  }
+
+  void release_allocation(void *ptr) noexcept
+  {
+    if (ptr == nullptr)
+      return;
+
+    if (track_allocations.load(std::memory_order_relaxed))
+      tracked_balance.fetch_sub(1, std::memory_order_relaxed);
+
+    std::free(ptr);
+  }
+
+  class AllocationFailureScope
+  {
+  public:
+    explicit AllocationFailureScope(const int successful_allocations_before_failure)
+    {
+      tracked_balance.store(0, std::memory_order_relaxed);
+      track_allocations.store(true, std::memory_order_relaxed);
+      allocation_countdown.store(successful_allocations_before_failure,
+                                 std::memory_order_relaxed);
+    }
+
+    ~AllocationFailureScope()
+    {
+      allocation_countdown.store(-1, std::memory_order_relaxed);
+      track_allocations.store(false, std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] int balance() const noexcept
+    {
+      return tracked_balance.load(std::memory_order_relaxed);
+    }
+  };
+}
+
+void *operator new(std::size_t size)
+{
+  return allocate_or_throw(size);
+}
+
+void *operator new[](std::size_t size)
+{
+  return allocate_or_throw(size);
+}
+
+void *operator new(std::size_t size, const std::nothrow_t &) noexcept
+{
+  try
+    {
+      return allocate_or_throw(size);
+    }
+  catch (...)
+    {
+      return nullptr;
+    }
+}
+
+void *operator new[](std::size_t size, const std::nothrow_t &) noexcept
+{
+  try
+    {
+      return allocate_or_throw(size);
+    }
+  catch (...)
+    {
+      return nullptr;
+    }
+}
+
+void operator delete(void *ptr) noexcept
+{
+  release_allocation(ptr);
+}
+
+void operator delete[](void *ptr) noexcept
+{
+  release_allocation(ptr);
+}
+
+void operator delete(void *ptr, std::size_t) noexcept
+{
+  release_allocation(ptr);
+}
+
+void operator delete[](void *ptr, std::size_t) noexcept
+{
+  release_allocation(ptr);
+}
+
+void operator delete(void *ptr, const std::nothrow_t &) noexcept
+{
+  release_allocation(ptr);
+}
+
+void operator delete[](void *ptr, const std::nothrow_t &) noexcept
+{
+  release_allocation(ptr);
+}
+
 using namespace Aleph;
+
+static_assert(std::is_same_v<decltype(std::declval<Cnode &>().search_child('a')),
+                             Cnode *>);
+static_assert(std::is_same_v<decltype(std::declval<const Cnode &>().search_child('a')),
+                             const Cnode *>);
+static_assert(std::is_same_v<decltype(std::declval<Cnode &>().greater_child('a')),
+                             Cnode *>);
+static_assert(std::is_same_v<decltype(std::declval<const Cnode &>().greater_child('a')),
+                             const Cnode *>);
+static_assert(std::is_same_v<decltype(std::declval<Cnode &>().search_prefix("a")),
+                             std::tuple<Cnode *, const char *>>);
+static_assert(std::is_same_v<decltype(std::declval<const Cnode &>().search_prefix("a")),
+                             std::tuple<const Cnode *, const char *>>);
+static_assert(std::is_same_v<decltype(std::declval<Prefix_Tree &>().root()),
+                             Cnode *>);
+static_assert(std::is_same_v<decltype(std::declval<const Prefix_Tree &>().root()),
+                             const Cnode *>);
+
+static std::vector<std::string> to_sorted_vector(const DynArray<std::string> & words)
+{
+  std::vector<std::string> ret;
+  words.for_each([&ret](const std::string & w) { ret.push_back(w); });
+  std::sort(ret.begin(), ret.end());
+  return ret;
+}
 
 //==============================================================================
 // Test Fixture
@@ -117,9 +286,7 @@ TEST_F(PrefixTreeTest, MarkEndWord)
   
   node.mark_end_word();
   EXPECT_TRUE(node.is_end_word());
-  
-  // Clean up the '$' child created by mark_end_word
-  node.destroy();
+  EXPECT_TRUE(node.children().is_empty());
 }
 
 //==============================================================================
@@ -218,6 +385,50 @@ TEST_F(PrefixTreeTest, InsertSingleCharacter)
 {
   EXPECT_TRUE(root->insert_word("a"));
   EXPECT_TRUE(root->contains("a"));
+}
+
+TEST_F(PrefixTreeTest, WordEndSurvivesLowerSortedChild)
+{
+  EXPECT_TRUE(root->insert_word("a"));
+  EXPECT_TRUE(root->insert_word("a!"));
+
+  EXPECT_TRUE(root->contains("a"));
+  EXPECT_TRUE(root->contains("a!"));
+  EXPECT_EQ(root->count(), 2);
+
+  EXPECT_EQ(to_sorted_vector(root->words()), (std::vector<std::string>{"a", "a!"}));
+  EXPECT_EQ(to_sorted_vector(root->words_with_prefix("a")),
+            (std::vector<std::string>{"a", "a!"}));
+}
+
+TEST_F(PrefixTreeTest, InsertWordCleansDetachedPathOnAllocationFailure)
+{
+  EXPECT_TRUE(root->insert_word("mango"));
+  const auto before = to_sorted_vector(root->words());
+
+  bool threw = false;
+  int balance = 0;
+  {
+    AllocationFailureScope fail_after_one_node(2);
+    try
+      {
+        root->insert_word("abc");
+      }
+    catch (const std::bad_alloc &)
+      {
+        threw = true;
+      }
+    balance = fail_after_one_node.balance();
+  }
+
+  EXPECT_TRUE(threw);
+  EXPECT_EQ(balance, 0);
+  EXPECT_EQ(to_sorted_vector(root->words()), before);
+  EXPECT_TRUE(root->contains("mango"));
+  EXPECT_FALSE(root->contains("a"));
+  EXPECT_FALSE(root->contains("ab"));
+  EXPECT_FALSE(root->contains("abc"));
+  EXPECT_EQ(root->count(), 1);
 }
 
 TEST_F(PrefixTreeTest, PrefixNotAWord)
@@ -370,6 +581,31 @@ TEST_F(PrefixTreeTest, WordsWithCommonPrefixes)
   ASSERT_EQ(words.size(), 4);
 }
 
+TEST_F(PrefixTreeTest, WordsCanContainDollarCharacter)
+{
+  EXPECT_TRUE(root->insert_word("$"));
+  EXPECT_TRUE(root->insert_word("a$"));
+  EXPECT_TRUE(root->insert_word("a$b"));
+
+  EXPECT_TRUE(root->contains("$"));
+  EXPECT_TRUE(root->contains("a$"));
+  EXPECT_TRUE(root->contains("a$b"));
+
+  EXPECT_EQ(to_sorted_vector(root->words()),
+            (std::vector<std::string>{"$", "a$", "a$b"}));
+}
+
+TEST_F(PrefixTreeTest, WordsCanContainEmptyString)
+{
+  EXPECT_TRUE(root->insert_word(""));
+  EXPECT_TRUE(root->insert_word("!"));
+
+  EXPECT_TRUE(root->contains(""));
+  EXPECT_TRUE(root->contains("!"));
+  EXPECT_EQ(to_sorted_vector(root->words()),
+            (std::vector<std::string>{"", "!"}));
+}
+
 //==============================================================================
 // Clone Tests
 //==============================================================================
@@ -405,6 +641,58 @@ TEST_F(PrefixTreeTest, CloneWithWords)
   
   cloned->destroy();
   delete cloned;
+}
+
+TEST_F(PrefixTreeTest, ClonePreservesWordEndFlags)
+{
+  root->insert_word("");
+  root->insert_word("$");
+  root->insert_word("a!");
+  root->insert_word("a");
+
+  Cnode * cloned = root->clone();
+
+  EXPECT_TRUE(cloned->contains(""));
+  EXPECT_TRUE(cloned->contains("$"));
+  EXPECT_TRUE(cloned->contains("a!"));
+  EXPECT_TRUE(cloned->contains("a"));
+  EXPECT_EQ(to_sorted_vector(cloned->words()),
+            (std::vector<std::string>{"", "$", "a", "a!"}));
+
+  cloned->destroy();
+  delete cloned;
+}
+
+TEST_F(PrefixTreeTest, CloneCleansPartialCopyOnAllocationFailure)
+{
+  root->insert_word("alpha");
+  root->insert_word("beta");
+  root->insert_word("$");
+  const auto before = to_sorted_vector(root->words());
+
+  bool threw = false;
+  int balance = 0;
+  {
+    AllocationFailureScope fail_after_two_nodes(2);
+    try
+      {
+        Cnode *cloned = root->clone();
+        cloned->destroy();
+        delete cloned;
+      }
+    catch (const std::bad_alloc &)
+      {
+        threw = true;
+      }
+    balance = fail_after_two_nodes.balance();
+  }
+
+  EXPECT_TRUE(threw);
+  EXPECT_EQ(balance, 0);
+  EXPECT_EQ(to_sorted_vector(root->words()), before);
+  EXPECT_TRUE(root->contains("alpha"));
+  EXPECT_TRUE(root->contains("beta"));
+  EXPECT_TRUE(root->contains("$"));
 }
 
 //==============================================================================
@@ -545,6 +833,17 @@ TEST_F(PrefixTreeTest, WordsWithPrefixNoMatch)
   EXPECT_TRUE(words.is_empty());
 }
 
+TEST_F(PrefixTreeTest, WordsWithEmptyPrefixMatchesWords)
+{
+  root->insert_word("");
+  root->insert_word("hello");
+  root->insert_word("help");
+  root->insert_word("world");
+
+  EXPECT_EQ(to_sorted_vector(root->words_with_prefix("")),
+            to_sorted_vector(root->words()));
+}
+
 TEST(PrefixTreeDestroyTest, DestroyWorks)
 {
   // Use a separate test without the fixture to avoid double-free
@@ -559,6 +858,140 @@ TEST(PrefixTreeDestroyTest, DestroyWorks)
   tree->destroy();
   delete tree;
   // If we get here without crashing, destroy worked
+}
+
+//==============================================================================
+// Owning Wrapper Tests
+//==============================================================================
+
+TEST(PrefixTreeWrapperTest, DelegatesWordOperations)
+{
+  Prefix_Tree tree;
+
+  EXPECT_TRUE(tree.insert_word(""));
+  EXPECT_TRUE(tree.insert_word("alpha"));
+  EXPECT_TRUE(tree.insert_word("alphabet"));
+  EXPECT_FALSE(tree.insert_word("alpha"));
+
+  EXPECT_TRUE(tree.contains(""));
+  EXPECT_TRUE(tree.contains("alpha"));
+  EXPECT_TRUE(tree.contains("alphabet"));
+  EXPECT_FALSE(tree.contains("alpine"));
+  EXPECT_EQ(tree.count(), 3);
+  EXPECT_EQ(to_sorted_vector(tree.words()),
+            (std::vector<std::string>{"", "alpha", "alphabet"}));
+  EXPECT_EQ(to_sorted_vector(tree.words_with_prefix("alpha")),
+            (std::vector<std::string>{"alpha", "alphabet"}));
+}
+
+TEST(PrefixTreeWrapperTest, OwnsRootAndDestroysNodes)
+{
+  size_t count = 0;
+  int balance = 0;
+  {
+    AllocationFailureScope track_only(-1);
+    {
+      Prefix_Tree tree;
+      tree.insert_word("alpha");
+      tree.insert_word("beta");
+      count = tree.count();
+    }
+    balance = track_only.balance();
+  }
+
+  EXPECT_EQ(count, 2);
+  EXPECT_EQ(balance, 0);
+}
+
+TEST(PrefixTreeWrapperTest, RootExposesLowLevelAccessWithoutOwnershipTransfer)
+{
+  Prefix_Tree tree;
+  const Prefix_Tree &const_tree = tree;
+
+  ASSERT_NE(tree.root(), nullptr);
+  EXPECT_EQ(tree.root()->symbol(), '\0');
+  EXPECT_EQ(const_tree.root(), tree.root());
+
+  EXPECT_TRUE(tree.root()->insert_word("raw"));
+  EXPECT_TRUE(tree.contains("raw"));
+}
+
+TEST(PrefixTreeWrapperTest, CopyConstructorCreatesIndependentTree)
+{
+  Prefix_Tree tree;
+  tree.insert_word("alpha");
+  tree.insert_word("$");
+
+  Prefix_Tree copy(tree);
+  tree.insert_word("beta");
+  copy.insert_word("gamma");
+
+  EXPECT_TRUE(copy.contains("alpha"));
+  EXPECT_TRUE(copy.contains("$"));
+  EXPECT_TRUE(copy.contains("gamma"));
+  EXPECT_FALSE(copy.contains("beta"));
+  EXPECT_TRUE(tree.contains("beta"));
+  EXPECT_FALSE(tree.contains("gamma"));
+}
+
+TEST(PrefixTreeWrapperTest, CopyAssignmentCreatesIndependentTree)
+{
+  Prefix_Tree source;
+  source.insert_word("alpha");
+  source.insert_word("beta");
+
+  Prefix_Tree target;
+  target.insert_word("old");
+
+  target = source;
+  source.insert_word("gamma");
+  target.insert_word("delta");
+
+  EXPECT_TRUE(target.contains("alpha"));
+  EXPECT_TRUE(target.contains("beta"));
+  EXPECT_TRUE(target.contains("delta"));
+  EXPECT_FALSE(target.contains("old"));
+  EXPECT_FALSE(target.contains("gamma"));
+  EXPECT_TRUE(source.contains("gamma"));
+
+  target = target;
+  EXPECT_TRUE(target.contains("alpha"));
+  EXPECT_TRUE(target.contains("delta"));
+}
+
+TEST(PrefixTreeWrapperTest, CopyAssignmentKeepsOldTreeOnAllocationFailure)
+{
+  Prefix_Tree source;
+  source.insert_word("alpha");
+  source.insert_word("beta");
+  source.insert_word("$");
+
+  Prefix_Tree target;
+  target.insert_word("old");
+  const auto before = to_sorted_vector(target.words());
+
+  bool threw = false;
+  int balance = 0;
+  {
+    AllocationFailureScope fail_after_two_nodes(2);
+    try
+      {
+        target = source;
+      }
+    catch (const std::bad_alloc &)
+      {
+        threw = true;
+      }
+    balance = fail_after_two_nodes.balance();
+  }
+
+  EXPECT_TRUE(threw);
+  EXPECT_EQ(balance, 0);
+  EXPECT_EQ(to_sorted_vector(target.words()), before);
+  EXPECT_TRUE(target.contains("old"));
+  EXPECT_FALSE(target.contains("alpha"));
+  EXPECT_FALSE(target.contains("beta"));
+  EXPECT_FALSE(target.contains("$"));
 }
 
 //==============================================================================

--- a/Tests/prefix_tree_test.cc
+++ b/Tests/prefix_tree_test.cc
@@ -60,12 +60,30 @@
 #include <utility>
 #include <vector>
 
+// ThreadSanitizer ships its own strong global operator new/delete
+// replacements (tsan_new_delete.cpp.o). Defining our own below -- needed to
+// inject allocation failures for the tests exercising prefix-tree.H's
+// exception-safety paths -- collides with those at link time ("multiple
+// definition") under -fsanitize=thread. ASan/UBSan/plain Debug builds are
+// unaffected; only skip the override (and the tests relying on it) for TSan.
+#if defined(__SANITIZE_THREAD__)
+#  define ALEPH_PREFIX_TREE_TEST_UNDER_TSAN 1
+#elif defined(__has_feature)
+#  if __has_feature(thread_sanitizer)
+#    define ALEPH_PREFIX_TREE_TEST_UNDER_TSAN 1
+#  endif
+#endif
+#ifndef ALEPH_PREFIX_TREE_TEST_UNDER_TSAN
+#  define ALEPH_PREFIX_TREE_TEST_UNDER_TSAN 0
+#endif
+
 namespace
 {
   std::atomic<int> allocation_countdown{-1};
   std::atomic<bool> track_allocations{false};
   std::atomic<int> tracked_balance{0};
 
+#if !ALEPH_PREFIX_TREE_TEST_UNDER_TSAN
   bool should_fail_allocation() noexcept
   {
     int remaining = allocation_countdown.load(std::memory_order_relaxed);
@@ -79,6 +97,7 @@ namespace
       }
     return false;
   }
+
 
   void * allocate_or_throw(std::size_t size)
   {
@@ -108,6 +127,7 @@ namespace
 
     std::free(ptr);
   }
+#endif  // !ALEPH_PREFIX_TREE_TEST_UNDER_TSAN
 
   class AllocationFailureScope
   {
@@ -132,6 +152,8 @@ namespace
     }
   };
 }
+
+#if !ALEPH_PREFIX_TREE_TEST_UNDER_TSAN
 
 void *operator new(std::size_t size)
 {
@@ -196,6 +218,8 @@ void operator delete[](void *ptr, const std::nothrow_t &) noexcept
 {
   release_allocation(ptr);
 }
+
+#endif  // !ALEPH_PREFIX_TREE_TEST_UNDER_TSAN
 
 using namespace Aleph;
 
@@ -403,6 +427,10 @@ TEST_F(PrefixTreeTest, WordEndSurvivesLowerSortedChild)
 
 TEST_F(PrefixTreeTest, InsertWordCleansDetachedPathOnAllocationFailure)
 {
+#if ALEPH_PREFIX_TREE_TEST_UNDER_TSAN
+  GTEST_SKIP() << "AllocationFailureScope needs a custom global operator "
+                  "new/delete, which conflicts with TSan's own at link time.";
+#endif
   EXPECT_TRUE(root->insert_word("mango"));
   const auto before = to_sorted_vector(root->words());
 
@@ -665,6 +693,10 @@ TEST_F(PrefixTreeTest, ClonePreservesWordEndFlags)
 
 TEST_F(PrefixTreeTest, CloneCleansPartialCopyOnAllocationFailure)
 {
+#if ALEPH_PREFIX_TREE_TEST_UNDER_TSAN
+  GTEST_SKIP() << "AllocationFailureScope needs a custom global operator "
+                  "new/delete, which conflicts with TSan's own at link time.";
+#endif
   root->insert_word("alpha");
   root->insert_word("beta");
   root->insert_word("$");
@@ -886,6 +918,10 @@ TEST(PrefixTreeWrapperTest, DelegatesWordOperations)
 
 TEST(PrefixTreeWrapperTest, OwnsRootAndDestroysNodes)
 {
+#if ALEPH_PREFIX_TREE_TEST_UNDER_TSAN
+  GTEST_SKIP() << "AllocationFailureScope needs a custom global operator "
+                  "new/delete, which conflicts with TSan's own at link time.";
+#endif
   size_t count = 0;
   int balance = 0;
   {
@@ -959,8 +995,40 @@ TEST(PrefixTreeWrapperTest, CopyAssignmentCreatesIndependentTree)
   EXPECT_TRUE(target.contains("delta"));
 }
 
+TEST(PrefixTreeWrapperTest, MoveConstructorTransfersOwnership)
+{
+  Prefix_Tree source;
+  source.insert_word("alpha");
+  source.insert_word("$");
+
+  Prefix_Tree moved(std::move(source));
+
+  EXPECT_TRUE(moved.contains("alpha"));
+  EXPECT_TRUE(moved.contains("$"));
+}
+
+TEST(PrefixTreeWrapperTest, MoveAssignmentTransfersOwnershipAndFreesOldRoot)
+{
+  Prefix_Tree source;
+  source.insert_word("alpha");
+  source.insert_word("beta");
+
+  Prefix_Tree target;
+  target.insert_word("old");
+
+  target = std::move(source);
+
+  EXPECT_TRUE(target.contains("alpha"));
+  EXPECT_TRUE(target.contains("beta"));
+  EXPECT_FALSE(target.contains("old"));
+}
+
 TEST(PrefixTreeWrapperTest, CopyAssignmentKeepsOldTreeOnAllocationFailure)
 {
+#if ALEPH_PREFIX_TREE_TEST_UNDER_TSAN
+  GTEST_SKIP() << "AllocationFailureScope needs a custom global operator "
+                  "new/delete, which conflicts with TSan's own at link time.";
+#endif
   Prefix_Tree source;
   source.insert_word("alpha");
   source.insert_word("beta");

--- a/Tests/tpl_ca_storage_test.cc
+++ b/Tests/tpl_ca_storage_test.cc
@@ -189,6 +189,14 @@ TEST(CADenseCellStorage, ViewMatchesShapeAndAliasesTheSameBuffer)
   EXPECT_EQ(v.data_handle(), s.data());
 }
 
+TEST(CADenseCellStorage, EmptyStorageViewReturnsEmptyView)
+{
+  Dense_Cell_Storage<int, 2> s;
+  auto v = s.view();
+  EXPECT_EQ(v.size(), 0u);
+  EXPECT_EQ(v.data_handle(), nullptr);
+}
+
 TEST(CADenseCellStorage, WriteThroughViewIsVisibleThroughStorageApi)
 {
   Dense_Cell_Storage<int, 2> s({ 3, 4 }, 0);

--- a/Tests/tpl_ca_storage_test.cc
+++ b/Tests/tpl_ca_storage_test.cc
@@ -41,6 +41,7 @@
 # include <cstdint>
 # include <limits>
 # include <stdexcept>
+# include <type_traits>
 # include <utility>
 
 # include <gtest/gtest.h>
@@ -176,6 +177,65 @@ TEST(CADenseCellStorage, FreeFunctionSwap)
   swap(a, b);
   EXPECT_EQ(a.at(0, 0), 9);
   EXPECT_EQ(b.at(0, 0), 1);
+}
+
+TEST(CADenseCellStorage, ViewMatchesShapeAndAliasesTheSameBuffer)
+{
+  Dense_Cell_Storage<int, 2> s({ 3, 4 }, 0);
+  auto v = s.view();
+  EXPECT_EQ(v.rank(), 2u);
+  EXPECT_EQ(v.extent(0), 3u);
+  EXPECT_EQ(v.extent(1), 4u);
+  EXPECT_EQ(v.data_handle(), s.data());
+}
+
+TEST(CADenseCellStorage, WriteThroughViewIsVisibleThroughStorageApi)
+{
+  Dense_Cell_Storage<int, 2> s({ 3, 4 }, 0);
+  auto v = s.view();
+  v(1, 2) = 42;
+  EXPECT_EQ(s.at(1, 2), 42);
+}
+
+TEST(CADenseCellStorage, WriteThroughStorageIsVisibleThroughView)
+{
+  Dense_Cell_Storage<int, 2> s({ 3, 4 }, 0);
+  auto v = s.view();
+  s.set(0, 0, 7);
+  EXPECT_EQ(v(0, 0), 7);
+}
+
+TEST(CADenseCellStorage, ConstStorageYieldsReadOnlyView)
+{
+  Dense_Cell_Storage<int, 2> s({ 2, 2 }, 5);
+  const auto &cs = s;
+  auto cv = cs.view();
+  EXPECT_EQ(cv(0, 0), 5);
+  static_assert(std::is_const_v<std::remove_reference_t<decltype(cv(0, 0))>>);
+}
+
+TEST(CADenseCellStorage, ViewRowMajorOrderMatchesLinearIndex)
+{
+  Dense_Cell_Storage<int, 2> s({ 2, 3 });
+  auto v = s.view();
+  int next = 0;
+  for (ca_size_t i = 0; i < v.extent(0); ++i)
+    for (ca_size_t j = 0; j < v.extent(1); ++j)
+      v(i, j) = next++;
+
+  next = 0;
+  for (ca_index_t i = 0; i < 2; ++i)
+    for (ca_index_t j = 0; j < 3; ++j)
+      EXPECT_EQ(s.at(i, j), next++);
+}
+
+TEST(CADenseCellStorage, ViewOverThreeDimensionalStorage)
+{
+  Dense_Cell_Storage<int, 3> s({ 2, 2, 2 }, -1);
+  auto v = s.view();
+  v(1, 0, 1) = 99;
+  EXPECT_EQ(s.at(1, 0, 1), 99);
+  EXPECT_EQ(v.size(), s.size());
 }
 
 TEST(CADenseCellStorage, MoveTransfersOwnership)

--- a/Tests/tree-node.cc
+++ b/Tests/tree-node.cc
@@ -37,6 +37,7 @@
  */
 # include <gtest/gtest.h>
 
+# include <tpl_binNode.H>
 # include <tpl_tree_node.H>
 # include <ah-zip.H>
 # include <ah-string-utils.H>
@@ -90,6 +91,159 @@ TEST(Tree_Node, on_isolated_node)
   ASSERT_FALSE(cit.has_curr());
   ASSERT_THROW(cit.get_curr(), overflow_error);
   ASSERT_THROW(cit.next(), overflow_error);
+}
+
+TEST(Tree_Node, get_parent_tracks_multi_level_tree)
+{
+  Tree_Node<int> root(0);
+  Tree_Node<int> left(1);
+  Tree_Node<int> right(2);
+  Tree_Node<int> left_left(3);
+  Tree_Node<int> left_right(4);
+  Tree_Node<int> deep(5);
+
+  root.insert_rightmost_child(&left);
+  root.insert_rightmost_child(&right);
+  left.insert_rightmost_child(&left_left);
+  left.insert_rightmost_child(&left_right);
+  left_left.insert_rightmost_child(&deep);
+
+  ASSERT_EQ(root.get_parent(), nullptr);
+  ASSERT_EQ(left.get_parent(), &root);
+  ASSERT_EQ(right.get_parent(), &root);
+  ASSERT_EQ(left_left.get_parent(), &left);
+  ASSERT_EQ(left_right.get_parent(), &left);
+  ASSERT_EQ(deep.get_parent(), &left_left);
+}
+
+TEST(Tree_Node, insert_leftmost_child_preserves_existing_subtree_parent_links)
+{
+  Tree_Node<int> root(0);
+  Tree_Node<int> old_left(1);
+  Tree_Node<int> old_right(2);
+  Tree_Node<int> old_left_child(3);
+  Tree_Node<int> new_left(4);
+
+  root.insert_rightmost_child(&old_left);
+  root.insert_rightmost_child(&old_right);
+  old_left.insert_rightmost_child(&old_left_child);
+
+  root.insert_leftmost_child(&new_left);
+
+  ASSERT_EQ(root.get_left_child(), &new_left);
+  ASSERT_EQ(root.get_child(0), &new_left);
+  ASSERT_EQ(root.get_child(1), &old_left);
+  ASSERT_EQ(root.get_child(2), &old_right);
+
+  ASSERT_EQ(new_left.get_parent(), &root);
+  ASSERT_EQ(old_left.get_parent(), &root);
+  ASSERT_EQ(old_right.get_parent(), &root);
+  ASSERT_EQ(old_left_child.get_parent(), &old_left);
+
+  ASSERT_TRUE(new_left.is_leftmost());
+  ASSERT_FALSE(new_left.is_rightmost());
+  ASSERT_FALSE(old_left.is_leftmost());
+  ASSERT_FALSE(old_right.is_leftmost());
+  ASSERT_TRUE(old_right.is_rightmost());
+}
+
+TEST(Tree_Node, insert_left_sibling_before_leftmost_child_updates_spine)
+{
+  Tree_Node<int> root(0);
+  Tree_Node<int> old_left(1);
+  Tree_Node<int> right(2);
+  Tree_Node<int> old_left_child(3);
+  Tree_Node<int> new_left(4);
+
+  root.insert_rightmost_child(&old_left);
+  root.insert_rightmost_child(&right);
+  old_left.insert_rightmost_child(&old_left_child);
+
+  old_left.insert_left_sibling(&new_left);
+
+  ASSERT_EQ(root.get_left_child(), &new_left);
+  ASSERT_EQ(root.get_child(0), &new_left);
+  ASSERT_EQ(root.get_child(1), &old_left);
+  ASSERT_EQ(root.get_child(2), &right);
+
+  ASSERT_EQ(new_left.get_parent(), &root);
+  ASSERT_EQ(old_left.get_parent(), &root);
+  ASSERT_EQ(right.get_parent(), &root);
+  ASSERT_EQ(old_left_child.get_parent(), &old_left);
+
+  ASSERT_TRUE(new_left.is_leftmost());
+  ASSERT_FALSE(new_left.is_rightmost());
+  ASSERT_FALSE(old_left.is_leftmost());
+  ASSERT_FALSE(right.is_leftmost());
+  ASSERT_TRUE(right.is_rightmost());
+}
+
+TEST(Tree_Node, bin_to_forest_preserves_each_forest_root_flag)
+{
+  BinNode<int> n1(1);
+  BinNode<int> n2(2);
+  BinNode<int> n3(3);
+
+  RLINK(&n1) = &n2;
+  RLINK(&n2) = &n3;
+
+  auto * forest = bin_to_forest<Tree_Node<int>, BinNode<int>>(&n1);
+  ASSERT_NE(forest, nullptr);
+
+  size_t count = 0;
+  for (auto * t = forest; t != nullptr; t = t->get_right_sibling(), ++count)
+    {
+      EXPECT_TRUE(t->is_root()) << "tree key " << t->get_key()
+                                << " must remain a forest root";
+      EXPECT_EQ(t->get_parent(), nullptr);
+    }
+
+  EXPECT_EQ(count, 3);
+  destroy_forest(forest);
+}
+
+TEST(Tree_Node, insert_right_sibling_on_root_links_forest_roots)
+{
+  Tree_Node<int> tree1(1);
+  Tree_Node<int> tree2(2);
+  Tree_Node<int> tree3(3);
+
+  tree1.insert_right_sibling(&tree2);
+  tree2.insert_right_sibling(&tree3);
+
+  ASSERT_EQ(tree1.get_right_tree(), &tree2);
+  ASSERT_EQ(tree2.get_right_tree(), &tree3);
+  ASSERT_EQ(tree3.get_right_tree(), nullptr);
+
+  ASSERT_TRUE(tree1.is_root());
+  ASSERT_TRUE(tree2.is_root());
+  ASSERT_TRUE(tree3.is_root());
+
+  ASSERT_EQ(tree1.get_parent(), nullptr);
+  ASSERT_EQ(tree2.get_parent(), nullptr);
+  ASSERT_EQ(tree3.get_parent(), nullptr);
+}
+
+TEST(Tree_Node, unique_sibling_macro_tracks_sibling_links)
+{
+  Tree_Node<int> isolated(0);
+  ASSERT_TRUE(IS_UNIQUE_SIBLING(&isolated));
+
+  Tree_Node<int> root(1);
+  Tree_Node<int> only_child(2);
+  root.insert_rightmost_child(&only_child);
+  ASSERT_TRUE(IS_UNIQUE_SIBLING(&only_child));
+
+  Tree_Node<int> other_child(3);
+  root.insert_rightmost_child(&other_child);
+  ASSERT_FALSE(IS_UNIQUE_SIBLING(&only_child));
+  ASSERT_FALSE(IS_UNIQUE_SIBLING(&other_child));
+
+  Tree_Node<int> tree1(4);
+  Tree_Node<int> tree2(5);
+  tree1.insert_tree_to_right(&tree2);
+  ASSERT_FALSE(IS_UNIQUE_SIBLING(&tree1));
+  ASSERT_FALSE(IS_UNIQUE_SIBLING(&tree2));
 }
 
 TEST(Tree_Node, simple_tree_construction_and_destruction)
@@ -422,5 +576,3 @@ TEST_F(Three_Trees, join)
 
   destroy_forest(t);
 }
-
-

--- a/Tests/tree-node.cc
+++ b/Tests/tree-node.cc
@@ -246,6 +246,26 @@ TEST(Tree_Node, unique_sibling_macro_tracks_sibling_links)
   ASSERT_FALSE(IS_UNIQUE_SIBLING(&tree2));
 }
 
+TEST(Tree_Node, destroy_tree_on_non_leftmost_child_regression)
+{
+  Tree_Node<int>* root = new Tree_Node<int>(1);
+  Tree_Node<int>* child1 = new Tree_Node<int>(2);
+  Tree_Node<int>* child2 = new Tree_Node<int>(3);
+  
+  root->insert_rightmost_child(child1);
+  root->insert_rightmost_child(child2);
+
+  // Layout: child1 -> child2 (rightmost)
+  // Destroying a non-leftmost sibling with a left sibling
+  destroy_tree(child2);
+
+  ASSERT_EQ(root->get_left_child(), child1);
+  ASSERT_EQ(root->get_right_child(), child1);
+  ASSERT_TRUE(IS_UNIQUE_SIBLING(child1));
+
+  destroy_tree(root);
+}
+
 TEST(Tree_Node, simple_tree_construction_and_destruction)
 {
   Tree_Node<int> p1 = 1;

--- a/Tests/tree-node.cc
+++ b/Tests/tree-node.cc
@@ -262,6 +262,61 @@ TEST(Tree_Node, destroy_tree_on_non_leftmost_child_regression)
   ASSERT_EQ(root->get_left_child(), child1);
   ASSERT_EQ(root->get_right_child(), child1);
   ASSERT_TRUE(IS_UNIQUE_SIBLING(child1));
+  ASSERT_TRUE(child1->is_rightmost());
+  ASSERT_EQ(child1->get_right_sibling(), nullptr);
+
+  destroy_tree(root);
+}
+
+TEST(Tree_Node, destroy_tree_restores_is_rightmost_on_surviving_sibling)
+{
+  // Regression: destroy_tree() unlinked a node from its sibling list
+  // without restoring is_rightmost()/is_leftmost() on the neighbor taking
+  // its place. get_right_child()/get_left_child() use the raw (flag-blind)
+  // Dlink links and so cannot detect this; get_right_sibling() and anything
+  // built on it (for_each_child(), Children_Iterator) are flag-gated and
+  // did loop forever on the surviving sibling before this fix.
+  auto *root = new Tree_Node<int>(0);
+  auto *a = new Tree_Node<int>(1);
+  auto *b = new Tree_Node<int>(2);
+  auto *c = new Tree_Node<int>(3);
+  root->insert_rightmost_child(a);
+  root->insert_rightmost_child(b);
+  root->insert_rightmost_child(c);  // root -> a, b, c (c is rightmost)
+
+  destroy_tree(c);
+
+  EXPECT_TRUE(b->is_rightmost());
+  EXPECT_EQ(b->get_right_sibling(), nullptr);
+
+  int count = 0;
+  root->for_each_child([&count](auto) { ++count; });
+  EXPECT_EQ(count, 2);  // a, b -- would loop forever before the fix
+
+  destroy_tree(root);
+}
+
+TEST(Tree_Node, destroy_tree_restores_is_leftmost_on_surviving_sibling)
+{
+  // Symmetric case: destroying the current leftmost child must promote
+  // its former right neighbor to is_leftmost().
+  auto *root = new Tree_Node<int>(0);
+  auto *a = new Tree_Node<int>(1);
+  auto *b = new Tree_Node<int>(2);
+  auto *c = new Tree_Node<int>(3);
+  root->insert_rightmost_child(a);
+  root->insert_rightmost_child(b);
+  root->insert_rightmost_child(c);  // root -> a (leftmost), b, c
+
+  destroy_tree(a);
+
+  EXPECT_TRUE(b->is_leftmost());
+  EXPECT_EQ(b->get_left_sibling(), nullptr);
+  EXPECT_EQ(root->get_left_child(), b);
+
+  int count = 0;
+  root->for_each_child([&count](auto) { ++count; });
+  EXPECT_EQ(count, 2);  // b, c
 
   destroy_tree(root);
 }

--- a/ah-mdspan.H
+++ b/ah-mdspan.H
@@ -38,35 +38,41 @@
  *  multidimensional grid indexable via `operator()(i, j, ...)`. It never
  *  allocates, copies, or owns anything — it is a pointer plus a shape.
  *
- *  When the toolchain provides C++23's `<mdspan>` (`ALEPH_HAS_STD_MDSPAN`,
- *  see `ah-cpp-compat.H`), `Aleph::mdspan` and friends are plain aliases
- *  of `std::mdspan`/`std::extents`/`std::dextents`/`std::layout_right`/
- *  `std::layout_left`/`std::default_accessor`. Otherwise this header
- *  provides a native **C++20** implementation covering the common surface
- *  (construction, `extents()`/`extent(r)`/`rank()`/`size()`, `operator()`,
- *  `data_handle()`, `layout_right`/`layout_left`). It is not a bit-for-bit
- *  reimplementation of the standard: in particular, the polyfill's
- *  `extents<IndexType, Exts...>` stores every extent at runtime rather
- *  than folding compile-time (`static_extent`) values out of the object's
- *  storage — a deliberate simplification that costs nothing for the
- *  fully-dynamic `dextents` case this library actually uses (e.g.
- *  `CA::Dense_Cell_Storage`), and only forgoes a size optimization for
- *  mixed static/dynamic extents, which Aleph does not currently need.
+ *  `Aleph::mdspan`'s element access is exclusively `operator()(i, j, ...)`
+ *  plus a bounds-checked `.at(i, j, ...)` — **not** `std::mdspan`'s own
+ *  `operator[](i, j, ...)` (a C++23 *language* feature, multi-argument
+ *  subscript, which cannot be backported to C++20; Aleph's baseline is
+ *  C++20, GCC 11+/Clang 14+). This surface is identical regardless of the
+ *  toolchain:
+ *  - When the toolchain provides C++23's `<mdspan>` (`ALEPH_HAS_STD_MDSPAN`,
+ *    see `ah-cpp-compat.H`), `Aleph::mdspan<T, Extents, Layout, Accessor>`
+ *    is a thin wrapper *around* a `std::mdspan` (still zero-copy — the
+ *    wrapper only holds the `std::mdspan` by value, itself just a
+ *    pointer/mapping/accessor triple) that forwards everything except
+ *    element access, and implements `operator()`/`.at()` on top of the
+ *    real `std::mdspan::operator[]`. `Aleph::extents`, `Aleph::dextents`,
+ *    `Aleph::layout_right`, `Aleph::layout_left` and
+ *    `Aleph::default_accessor` remain plain aliases of their `std::`
+ *    counterparts — only the class with the element-access surface needs
+ *    wrapping.
+ *  - Otherwise this header provides a native **C++20** implementation
+ *    covering the same surface (construction, `extents()`/`extent(r)`/
+ *    `rank()`/`size()`, `operator()`, `.at()`, `data_handle()`,
+ *    `layout_right`/`layout_left`). It is not a bit-for-bit
+ *    reimplementation of the standard: in particular, the polyfill's
+ *    `extents<IndexType, Exts...>` stores every extent at runtime rather
+ *    than folding compile-time (`static_extent`) values out of the
+ *    object's storage — a deliberate simplification that costs nothing
+ *    for the fully-dynamic `dextents` case this library actually uses
+ *    (e.g. `CA::Dense_Cell_Storage`), and only forgoes a size
+ *    optimization for mixed static/dynamic extents, which Aleph does not
+ *    currently need.
  *
  *  @par Why a view, not a container
  *  `mdspan` never allocates. It is the multidimensional-shape counterpart
  *  of `std::span`: wrap an existing buffer to get readable `m(i, j)`
  *  indexing and shape introspection, with zero copies and zero overhead
  *  beyond the index-to-offset arithmetic itself.
- *
- *  @par `operator()`, not multidimensional `operator[]`
- *  C++23 also allows `m[i, j]` (multi-argument `operator[]`), a
- *  **language** feature, not a library one — it cannot be backported to
- *  C++20. Aleph's baseline is C++20 (GCC 11+/Clang 14+), so this header
- *  exposes indexing exclusively through `operator()(i, j, ...)`, which
- *  works identically on `std::mdspan` too. `m[i, j]` remains available as
- *  an *additional* option on `std::mdspan` under C++23, tracked
- *  separately as future, opt-in, non-polyfillable work.
  *
  *  @par Bounds checking
  *  `operator()` matches `std::mdspan`'s contract: out-of-range indices are
@@ -127,9 +133,143 @@ using layout_left = std::layout_left;
 template <class ElementType>
 using default_accessor = std::default_accessor<ElementType>;
 
+/** @brief Aleph's stable view surface, wrapping `std::mdspan`.
+ *
+ *  `std::mdspan`'s own element access is `operator[](i, j, ...)` — a
+ *  C++23 *language* feature (multi-argument subscript) — and it has no
+ *  bounds-checked accessor at all. A bare `using mdspan = std::mdspan<...>`
+ *  alias would therefore silently break every Aleph caller written
+ *  against `operator()(i, j, ...)`/`.at(i, j, ...)` (this header's own
+ *  documented surface, used throughout Aleph — see
+ *  `CA::Dense_Cell_Storage::view()`) the moment a toolchain sets
+ *  `ALEPH_HAS_STD_MDSPAN=1`. Wrapping `std::mdspan` instead keeps that
+ *  surface identical on both paths, at the cost of one extra forwarding
+ *  layer around the real `std::mdspan` (still zero-copy: this class
+ *  holds a `std::mdspan` by value, which is itself just a pointer plus
+ *  a mapping plus an accessor).
+ */
 template <class T, class Extents, class LayoutPolicy = std::layout_right,
           class AccessorPolicy = std::default_accessor<T>>
-using mdspan = std::mdspan<T, Extents, LayoutPolicy, AccessorPolicy>;
+/**
+ *  @par Thread-safety
+ *  Concurrent reads on different cells are safe. Concurrent writes
+ *  to overlapping cells are not synchronised.
+ */
+class mdspan
+{
+  using impl_type = std::mdspan<T, Extents, LayoutPolicy, AccessorPolicy>;
+
+  impl_type impl_{};
+
+  template <class, class, class, class>
+  friend class mdspan;
+
+public:
+  using extents_type = typename impl_type::extents_type;
+  using layout_type = typename impl_type::layout_type;
+  using accessor_type = typename impl_type::accessor_type;
+  using mapping_type = typename impl_type::mapping_type;
+  using element_type = typename impl_type::element_type;
+  using value_type = typename impl_type::value_type;
+  using index_type = typename impl_type::index_type;
+  using rank_type = typename impl_type::rank_type;
+  using data_handle_type = typename impl_type::data_handle_type;
+  using reference = typename impl_type::reference;
+
+  constexpr mdspan() noexcept = default;
+  constexpr mdspan(const mdspan &) noexcept = default;
+  constexpr mdspan(mdspan &&) noexcept = default;
+  constexpr mdspan &operator=(const mdspan &) noexcept = default;
+  constexpr mdspan &operator=(mdspan &&) noexcept = default;
+
+  /** @brief View `p` through the shape `e`.
+   *  @param p pointer to the first element of the buffer to view.
+   *  @param e extents object defining the shape.
+   */
+  constexpr mdspan(data_handle_type p, const extents_type &e) noexcept
+    : impl_(p, e)
+  {}
+
+  /// View `p` through an already-built mapping.
+  constexpr mdspan(data_handle_type p, const mapping_type &m) noexcept
+    : impl_(p, m)
+  {}
+
+  /** @brief View `p` through mapping `m`, reading via accessor `a`.
+   *  @param p pointer to the first element of the buffer to view.
+   *  @param m mapping object defining the layout.
+   *  @param a accessor object defining element access.
+   */
+  constexpr mdspan(data_handle_type p, const mapping_type &m, const accessor_type &a) noexcept
+    : impl_(p, m, a)
+  {}
+
+  /** @brief View `p` as a grid with the given per-axis sizes.
+   *  @param p pointer to the first element of the buffer to view.
+   *  @param exts one size per **dynamic** axis of `Extents`, in rank order.
+   */
+  template <class... IndexTypes>
+    requires(sizeof...(IndexTypes) >= 1 and
+             (std::is_convertible_v<IndexTypes, index_type> and ...))
+  constexpr explicit mdspan(data_handle_type p, IndexTypes... exts) noexcept
+    : impl_(p, static_cast<index_type>(exts)...)
+  {}
+
+  /// View `p` as a grid whose dynamic axes are packed in an array.
+  template <class OtherIndexType>
+    requires std::is_convertible_v<const OtherIndexType &, index_type>
+  constexpr mdspan(data_handle_type p,
+                    const std::array<OtherIndexType, extents_type::rank_dynamic()> &dyn) noexcept
+    : impl_(p, dyn)
+  {}
+
+  /// Converting constructor: `mdspan<T,...>` -> `mdspan<const T,...>`.
+  template <class OtherT, class OtherAccessor>
+    requires(not std::is_same_v<OtherT, T> and std::is_convertible_v<OtherT (*)[], T (*)[]>)
+  constexpr mdspan(const mdspan<OtherT, Extents, LayoutPolicy, OtherAccessor> &other) noexcept
+    : impl_(other.impl_)
+  {}
+
+  [[nodiscard]] static constexpr rank_type rank() noexcept { return impl_type::rank(); }
+  [[nodiscard]] constexpr index_type extent(rank_type r) const noexcept { return impl_.extent(r); }
+  [[nodiscard]] constexpr const extents_type &extents() const noexcept { return impl_.extents(); }
+  [[nodiscard]] constexpr const mapping_type &mapping() const noexcept { return impl_.mapping(); }
+  [[nodiscard]] constexpr const accessor_type &accessor() const noexcept { return impl_.accessor(); }
+  [[nodiscard]] constexpr data_handle_type data_handle() const noexcept { return impl_.data_handle(); }
+  [[nodiscard]] constexpr data_handle_type data() const noexcept { return impl_.data_handle(); }
+  [[nodiscard]] constexpr index_type size() const noexcept { return impl_.size(); }
+  [[nodiscard]] constexpr bool empty() const noexcept { return impl_.empty(); }
+
+  /** @brief Unchecked element access.
+   *  @param idxs one index per axis, in rank order.
+   *  @return A reference to the accessed element.
+   *  @warning Undefined behavior if any `idxs[r]` is outside
+   *           `[0, extent(r))`. Use `at()` for a bounds-checked variant.
+   */
+  template <class... Indices>
+    requires(sizeof...(Indices) == extents_type::rank())
+  [[nodiscard]] constexpr reference operator()(Indices... idxs) const
+  {
+    return impl_[static_cast<index_type>(idxs)...];
+  }
+
+  /** @brief Bounds-checked element access.
+   *  @param idxs one index per axis, in rank order.
+   *  @return A reference to the accessed element.
+   *  @throws std::out_of_range if any `idxs[r]` is outside `[0, extent(r))`.
+   */
+  template <class... Indices>
+    requires(sizeof...(Indices) == extents_type::rank())
+  [[nodiscard]] constexpr reference at(Indices... idxs) const
+  {
+    const index_type idx[]{static_cast<index_type>(idxs)...};
+    for (rank_type r = 0; r < rank(); ++r)
+      ah_out_of_range_error_if(idx[r] < 0 or idx[r] >= extent(r))
+        << "Aleph::mdspan::at(): index[" << r << "]=" << idx[r] << " out of [0, "
+        << extent(r) << ")";
+    return impl_[idxs...];
+  }
+};
 
 #else  // !ALEPH_HAS_STD_MDSPAN: native C++20 polyfill
 
@@ -225,7 +365,10 @@ public:
                                                 : static_cast<IndexType>(Static[r]);
   }
 
-  /// Run-time size of axis `r`.
+  /** @brief Run-time size of axis `r`.
+   *  @param r The axis to query.
+   *  @return The extent of the specified axis.
+   */
   [[nodiscard]] constexpr index_type extent(rank_type r) const noexcept { return values_[r]; }
 
   [[nodiscard]] friend constexpr bool operator==(const extents &a, const extents &b) noexcept
@@ -237,15 +380,18 @@ public:
 /// @cond INTERNAL
 namespace mdspan_detail
 {
+/// Expands an index sequence into an all-dynamic extents type.
 template <class IndexType, size_t... Is>
 struct dextents_helper
 {
   using type = extents<IndexType, ((void) Is, dynamic_extent)...>;
 };
 
-// Declared, never defined: used only inside decltype() below to expand an
-// index_sequence<Is...> into dextents_helper<IndexType, Is...> without
-// resorting to a lambda in an unevaluated operand.
+/// Expands an index_sequence into dextents_helper without evaluating code.
+///
+/// Declared, never defined: used only inside decltype() below to expand an
+/// index_sequence<Is...> into dextents_helper<IndexType, Is...> without
+/// resorting to a lambda in an unevaluated operand.
 template <class IndexType, size_t... Is>
 dextents_helper<IndexType, Is...> dextents_of(std::index_sequence<Is...>);
 }  // namespace mdspan_detail
@@ -266,6 +412,7 @@ using dextents =
 struct layout_right
 {
   template <class Extents>
+  /// Mapping from row-major multi-indices to linear offsets.
   class mapping
   {
     Extents exts_{};
@@ -281,7 +428,13 @@ struct layout_right
 
     [[nodiscard]] constexpr const extents_type &extents() const noexcept { return exts_; }
 
+    /** @brief Calculate the flat offset for a multi-dimensional index.
+     *  @param idxs one index per axis, in rank order.
+     *  @return The linear memory offset computed in row-major order.
+     *  @note Does not perform bounds checking.
+     */
     template <class... Indices>
+      requires(sizeof...(Indices) == Extents::rank())
     [[nodiscard]] constexpr index_type operator()(Indices... idxs) const noexcept
     {
       const index_type idx[]{static_cast<index_type>(idxs)...};
@@ -313,6 +466,7 @@ struct layout_right
 struct layout_left
 {
   template <class Extents>
+  /// Mapping from column-major multi-indices to linear offsets.
   class mapping
   {
     Extents exts_{};
@@ -328,7 +482,13 @@ struct layout_left
 
     [[nodiscard]] constexpr const extents_type &extents() const noexcept { return exts_; }
 
+    /** @brief Calculate the flat offset for a multi-dimensional index.
+     *  @param idxs one index per axis, in rank order.
+     *  @return The linear memory offset computed in column-major order.
+     *  @note Does not perform bounds checking.
+     */
     template <class... Indices>
+      requires(sizeof...(Indices) == Extents::rank())
     [[nodiscard]] constexpr index_type operator()(Indices... idxs) const noexcept
     {
       const index_type idx[]{static_cast<index_type>(idxs)...};
@@ -376,6 +536,11 @@ struct default_accessor
   constexpr default_accessor(default_accessor<OtherElementType>) noexcept
   {}
 
+  /** @brief Access an element from a pointer and an offset.
+   *  @param p Pointer to the start of the data.
+   *  @param i Linear offset.
+   *  @return A reference to the element at the specified offset.
+   */
   [[nodiscard]] constexpr reference access(data_handle_type p, size_t i) const noexcept
   {
     return p[i];
@@ -402,6 +567,11 @@ struct default_accessor
  */
 template <class T, class Extents, class LayoutPolicy = layout_right,
           class AccessorPolicy = default_accessor<T>>
+/**
+ *  @par Thread-safety
+ *  Concurrent reads on different cells are safe. Concurrent writes
+ *  to overlapping cells are not synchronised.
+ */
 class mdspan
 {
 public:
@@ -444,17 +614,27 @@ public:
     : ptr_(other.data_handle()), map_(other.mapping()), acc_(other.accessor())
   {}
 
-  /// View `p` through the shape `e`.
+  /** @brief View `p` through the shape `e`.
+   *  @param p pointer to the first element of the buffer to view.
+   *  @param e extents object defining the shape.
+   */
   constexpr mdspan(data_handle_type p, const extents_type &e) noexcept
     : ptr_(p), map_(e)
   {}
 
-  /// View `p` through an already-built mapping (shares the mapping's extents).
+  /** @brief View `p` through an already-built mapping.
+   *  @param p pointer to the first element of the buffer to view.
+   *  @param m mapping object defining the layout.
+   */
   constexpr mdspan(data_handle_type p, const mapping_type &m) noexcept
     : ptr_(p), map_(m)
   {}
 
-  /// View `p` through mapping `m`, reading via accessor `a`.
+  /** @brief View `p` through mapping `m`, reading via accessor `a`.
+   *  @param p pointer to the first element of the buffer to view.
+   *  @param m mapping object defining the layout.
+   *  @param a accessor object defining element access.
+   */
   constexpr mdspan(data_handle_type p, const mapping_type &m, const accessor_type &a) noexcept
     : ptr_(p), map_(m), acc_(a)
   {}
@@ -486,10 +666,15 @@ public:
     : ptr_(p), map_(extents_type(dyn))
   {}
 
-  /// Number of axes (compile-time constant).
+  /** @brief Number of axes (compile-time constant).
+   *  @return The rank of the mdspan.
+   */
   [[nodiscard]] static constexpr rank_type rank() noexcept { return extents_type::rank(); }
 
-  /// Run-time size of axis `r`.
+  /** @brief Run-time size of axis `r`.
+   *  @param r The axis to query.
+   *  @return The extent of the specified axis.
+   */
   [[nodiscard]] constexpr index_type extent(rank_type r) const noexcept
   {
     return map_.extents().extent(r);
@@ -519,7 +704,9 @@ public:
     return total;
   }
 
-  /// `true` if any axis has extent 0 (so the view has no elements).
+  /** @brief Checks if the view has no elements.
+   *  @return `true` if any axis has extent 0, `false` otherwise.
+   */
   [[nodiscard]] constexpr bool empty() const noexcept
   {
     for (rank_type r = 0; r < rank(); ++r)
@@ -531,12 +718,13 @@ public:
   /** @brief Unchecked element access.
    *
    *  @param idxs one index per axis, in rank order.
+   *  @return A reference to the accessed element.
    *  @warning Undefined behavior if any `idxs[r]` is outside
    *           `[0, extent(r))` — matches `std::mdspan::operator[]`'s
    *           contract exactly. Use `at()` for a bounds-checked variant.
    */
   template <class... Indices>
-    requires(sizeof...(Indices) == 0 ? extents_type::rank() == 0 : sizeof...(Indices) >= 1)
+    requires(sizeof...(Indices) == extents_type::rank())
   [[nodiscard]] constexpr reference operator()(Indices... idxs) const
   {
     return acc_.access(ptr_, map_(static_cast<index_type>(idxs)...));
@@ -545,6 +733,7 @@ public:
   /** @brief Bounds-checked element access.
    *
    *  @param idxs one index per axis, in rank order.
+   *  @return A reference to the accessed element.
    *  @throws std::out_of_range if any `idxs[r]` is outside `[0, extent(r))`.
    */
   template <class... Indices>

--- a/ah-mdspan.H
+++ b/ah-mdspan.H
@@ -1,0 +1,567 @@
+
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/** @file ah-mdspan.H
+ *  @brief Non-owning multidimensional array view (`Aleph::mdspan`).
+ *
+ *  `Aleph::mdspan<T, Extents, Layout, Accessor>` is a lightweight,
+ *  non-owning "view" over a contiguous buffer the caller already owns
+ *  (a `T*`, `Aleph::Array<T>::data()`, `std::vector<T>::data()`, a
+ *  `CA::Dense_Cell_Storage<T,N>::view()`, ...), exposing it as a
+ *  multidimensional grid indexable via `operator()(i, j, ...)`. It never
+ *  allocates, copies, or owns anything — it is a pointer plus a shape.
+ *
+ *  When the toolchain provides C++23's `<mdspan>` (`ALEPH_HAS_STD_MDSPAN`,
+ *  see `ah-cpp-compat.H`), `Aleph::mdspan` and friends are plain aliases
+ *  of `std::mdspan`/`std::extents`/`std::dextents`/`std::layout_right`/
+ *  `std::layout_left`/`std::default_accessor`. Otherwise this header
+ *  provides a native **C++20** implementation covering the common surface
+ *  (construction, `extents()`/`extent(r)`/`rank()`/`size()`, `operator()`,
+ *  `data_handle()`, `layout_right`/`layout_left`). It is not a bit-for-bit
+ *  reimplementation of the standard: in particular, the polyfill's
+ *  `extents<IndexType, Exts...>` stores every extent at runtime rather
+ *  than folding compile-time (`static_extent`) values out of the object's
+ *  storage — a deliberate simplification that costs nothing for the
+ *  fully-dynamic `dextents` case this library actually uses (e.g.
+ *  `CA::Dense_Cell_Storage`), and only forgoes a size optimization for
+ *  mixed static/dynamic extents, which Aleph does not currently need.
+ *
+ *  @par Why a view, not a container
+ *  `mdspan` never allocates. It is the multidimensional-shape counterpart
+ *  of `std::span`: wrap an existing buffer to get readable `m(i, j)`
+ *  indexing and shape introspection, with zero copies and zero overhead
+ *  beyond the index-to-offset arithmetic itself.
+ *
+ *  @par `operator()`, not multidimensional `operator[]`
+ *  C++23 also allows `m[i, j]` (multi-argument `operator[]`), a
+ *  **language** feature, not a library one — it cannot be backported to
+ *  C++20. Aleph's baseline is C++20 (GCC 11+/Clang 14+), so this header
+ *  exposes indexing exclusively through `operator()(i, j, ...)`, which
+ *  works identically on `std::mdspan` too. `m[i, j]` remains available as
+ *  an *additional* option on `std::mdspan` under C++23, tracked
+ *  separately as future, opt-in, non-polyfillable work.
+ *
+ *  @par Bounds checking
+ *  `operator()` matches `std::mdspan`'s contract: out-of-range indices are
+ *  undefined behavior (this is a zero-overhead view, not a checked
+ *  container). Use `.at(i, j, ...)` for a bounds-checked access that
+ *  throws `std::out_of_range` via `ah_out_of_range_error_if`, matching
+ *  the `get_curr()`/`get_curr_ne()`-style checked/unchecked pairing used
+ *  elsewhere in Aleph.
+ *
+ *  @par Example
+ *  @code
+ *  std::vector<double> buf(6, 0.0);
+ *  Aleph::mdspan<double, Aleph::dextents<size_t, 2>> m(buf.data(), 2, 3);
+ *  m(0, 0) = 1.0; m(1, 2) = 5.0;
+ *  for (size_t i = 0; i < m.extent(0); ++i)
+ *    for (size_t j = 0; j < m.extent(1); ++j)
+ *      std::cout << m(i, j) << (j + 1 == m.extent(1) ? '\n' : ' ');
+ *  @endcode
+ *
+ *  @see CA::Dense_Cell_Storage::view() in `tpl_ca_storage.H` for the
+ *       cellular-automata lattice application.
+ *  @see Examples/mdspan_matrix_view_example.cc for the matrix-view case.
+ *  @ingroup Utilities
+ *  @author Leandro Rabindranath Leon
+ */
+
+#ifndef AH_MDSPAN_H
+#define AH_MDSPAN_H
+
+#include <array>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+#include <ah-cpp-compat.H>
+#include <ah-errors.H>
+
+#if ALEPH_HAS_STD_MDSPAN
+#  include <mdspan>
+#endif
+
+namespace Aleph
+{
+
+#if ALEPH_HAS_STD_MDSPAN
+
+inline constexpr size_t dynamic_extent = std::dynamic_extent;
+
+template <class IndexType, size_t... Exts>
+using extents = std::extents<IndexType, Exts...>;
+
+template <class IndexType, size_t Rank>
+using dextents = std::dextents<IndexType, Rank>;
+
+using layout_right = std::layout_right;
+using layout_left = std::layout_left;
+
+template <class ElementType>
+using default_accessor = std::default_accessor<ElementType>;
+
+template <class T, class Extents, class LayoutPolicy = std::layout_right,
+          class AccessorPolicy = std::default_accessor<T>>
+using mdspan = std::mdspan<T, Extents, LayoutPolicy, AccessorPolicy>;
+
+#else  // !ALEPH_HAS_STD_MDSPAN: native C++20 polyfill
+
+/// Sentinel marking an axis whose extent is only known at run time.
+inline constexpr size_t dynamic_extent = static_cast<size_t>(-1);
+
+/// @cond INTERNAL
+namespace mdspan_detail
+{
+template <size_t... Exts>
+inline constexpr size_t count_dynamic = (size_t{0} + ... + (Exts == dynamic_extent ? 1 : 0));
+}  // namespace mdspan_detail
+/// @endcond
+
+/** @brief Shape (per-axis sizes) of an `mdspan`, mixing compile-time and
+ *         run-time extents.
+ *
+ *  @tparam IndexType signed or unsigned integral type used for indices.
+ *  @tparam Exts one size per axis: either a fixed value known at compile
+ *          time, or `Aleph::dynamic_extent` for an axis whose size is
+ *          only known at construction time. `rank()` is `sizeof...(Exts)`.
+ *
+ *  @note Simplification vs. `std::extents`: every axis (static or
+ *        dynamic) is stored at run time in this polyfill, so the object
+ *        does not shrink when axes are marked static. This has no effect
+ *        on any currently-supported Aleph use case, which always uses
+ *        `dextents` (fully dynamic).
+ */
+template <class IndexType, size_t... Exts>
+class extents
+{
+  static_assert(std::is_integral_v<IndexType>,
+                "Aleph::extents: IndexType must be an integral type");
+
+  static constexpr std::array<size_t, sizeof...(Exts)> Static{Exts...};
+
+  std::array<IndexType, sizeof...(Exts)> values_{};
+
+public:
+  using index_type = IndexType;
+  using size_type = std::make_unsigned_t<IndexType>;
+  using rank_type = size_t;
+
+  /// Number of axes (compile-time constant).
+  static constexpr rank_type rank() noexcept { return sizeof...(Exts); }
+
+  /// Number of axes whose extent is `dynamic_extent` (compile-time constant).
+  static constexpr rank_type rank_dynamic() noexcept
+  {
+    return mdspan_detail::count_dynamic<Exts...>;
+  }
+
+  /// Compile-time size of axis `r`, or `dynamic_extent` if axis `r` is dynamic.
+  static constexpr size_t static_extent(rank_type r) noexcept { return Static[r]; }
+
+  /// All-static-or-default-initialised extents (dynamic axes start at 0).
+  constexpr extents() noexcept
+  {
+    for (rank_type r = 0; r < rank(); ++r)
+      values_[r] = Static[r] == dynamic_extent ? IndexType{0} : static_cast<IndexType>(Static[r]);
+  }
+
+  /** @brief Construct providing a value for each dynamic axis, in rank order.
+   *
+   *  @param dyn one value per axis for which `static_extent(r) ==
+   *         dynamic_extent`, in increasing rank order. Static axes need no
+   *         argument; their compile-time value is used unconditionally.
+   */
+  template <class... IndexTypes>
+    requires(sizeof...(IndexTypes) == mdspan_detail::count_dynamic<Exts...> and
+             (std::is_convertible_v<IndexTypes, IndexType> and ...))
+  constexpr explicit extents(IndexTypes... dyn) noexcept
+  {
+    const std::array<IndexType, sizeof...(IndexTypes)> given{static_cast<IndexType>(dyn)...};
+    rank_type k = 0;
+    for (rank_type r = 0; r < rank(); ++r)
+      values_[r] = Static[r] == dynamic_extent ? given[k++] : static_cast<IndexType>(Static[r]);
+  }
+
+  /** @brief Construct providing every dynamic axis's value packed in an array.
+   *
+   *  @param dyn one value per dynamic axis, in rank order; `dyn.size()`
+   *         must equal `rank_dynamic()`.
+   */
+  template <class OtherIndexType>
+    requires std::is_convertible_v<const OtherIndexType &, IndexType>
+  constexpr explicit extents(
+    const std::array<OtherIndexType, mdspan_detail::count_dynamic<Exts...>> &dyn) noexcept
+  {
+    rank_type k = 0;
+    for (rank_type r = 0; r < rank(); ++r)
+      values_[r] = Static[r] == dynamic_extent ? static_cast<IndexType>(dyn[k++])
+                                                : static_cast<IndexType>(Static[r]);
+  }
+
+  /// Run-time size of axis `r`.
+  [[nodiscard]] constexpr index_type extent(rank_type r) const noexcept { return values_[r]; }
+
+  [[nodiscard]] friend constexpr bool operator==(const extents &a, const extents &b) noexcept
+  {
+    return a.values_ == b.values_;
+  }
+};
+
+/// @cond INTERNAL
+namespace mdspan_detail
+{
+template <class IndexType, size_t... Is>
+struct dextents_helper
+{
+  using type = extents<IndexType, ((void) Is, dynamic_extent)...>;
+};
+
+// Declared, never defined: used only inside decltype() below to expand an
+// index_sequence<Is...> into dextents_helper<IndexType, Is...> without
+// resorting to a lambda in an unevaluated operand.
+template <class IndexType, size_t... Is>
+dextents_helper<IndexType, Is...> dextents_of(std::index_sequence<Is...>);
+}  // namespace mdspan_detail
+/// @endcond
+
+/// `extents<IndexType, ...>` with all `Rank` axes dynamic — the common case.
+template <class IndexType, size_t Rank>
+using dextents =
+  typename decltype(mdspan_detail::dextents_of<IndexType>(
+    std::make_index_sequence<Rank>{}))::type;
+
+/** @brief Row-major layout: the last axis varies fastest (C convention).
+ *
+ *  Matches `CA::Dense_Cell_Storage`'s own layout and `std::mdspan`'s
+ *  default. This is a *layout policy*: a tag type whose nested
+ *  `mapping<Extents>` converts a multi-index into a linear offset.
+ */
+struct layout_right
+{
+  template <class Extents>
+  class mapping
+  {
+    Extents exts_{};
+
+  public:
+    using extents_type = Extents;
+    using index_type = typename Extents::index_type;
+    using rank_type = typename Extents::rank_type;
+    using layout_type = layout_right;
+
+    constexpr mapping() noexcept = default;
+    constexpr explicit mapping(const Extents &e) noexcept : exts_(e) {}
+
+    [[nodiscard]] constexpr const extents_type &extents() const noexcept { return exts_; }
+
+    template <class... Indices>
+    [[nodiscard]] constexpr index_type operator()(Indices... idxs) const noexcept
+    {
+      const index_type idx[]{static_cast<index_type>(idxs)...};
+      index_type offset = 0;
+      for (rank_type r = 0; r < Extents::rank(); ++r)
+        offset = offset * exts_.extent(r) + idx[r];
+      return offset;
+    }
+
+    [[nodiscard]] constexpr index_type required_span_size() const noexcept
+    {
+      index_type total = 1;
+      for (rank_type r = 0; r < Extents::rank(); ++r)
+        total *= exts_.extent(r);
+      return total;
+    }
+
+    static constexpr bool is_always_unique() noexcept { return true; }
+    static constexpr bool is_always_exhaustive() noexcept { return true; }
+    static constexpr bool is_always_strided() noexcept { return true; }
+  };
+};
+
+/** @brief Column-major layout: the first axis varies fastest (Fortran
+ *         convention). Useful to view buffers produced by
+ *         column-major-expecting numerical code (e.g. BLAS/LAPACK-style
+ *         routines) without transposing any data.
+ */
+struct layout_left
+{
+  template <class Extents>
+  class mapping
+  {
+    Extents exts_{};
+
+  public:
+    using extents_type = Extents;
+    using index_type = typename Extents::index_type;
+    using rank_type = typename Extents::rank_type;
+    using layout_type = layout_left;
+
+    constexpr mapping() noexcept = default;
+    constexpr explicit mapping(const Extents &e) noexcept : exts_(e) {}
+
+    [[nodiscard]] constexpr const extents_type &extents() const noexcept { return exts_; }
+
+    template <class... Indices>
+    [[nodiscard]] constexpr index_type operator()(Indices... idxs) const noexcept
+    {
+      const index_type idx[]{static_cast<index_type>(idxs)...};
+      index_type offset = 0;
+      for (rank_type ri = 0; ri < Extents::rank(); ++ri)
+        {
+          const rank_type r = Extents::rank() - 1 - ri;
+          offset = offset * exts_.extent(r) + idx[r];
+        }
+      return offset;
+    }
+
+    [[nodiscard]] constexpr index_type required_span_size() const noexcept
+    {
+      index_type total = 1;
+      for (rank_type r = 0; r < Extents::rank(); ++r)
+        total *= exts_.extent(r);
+      return total;
+    }
+
+    static constexpr bool is_always_unique() noexcept { return true; }
+    static constexpr bool is_always_exhaustive() noexcept { return true; }
+    static constexpr bool is_always_strided() noexcept { return true; }
+  };
+};
+
+/** @brief Trivial accessor policy: `access(p, i)` is just `p[i]`.
+ *
+ *  This is the only accessor policy this polyfill provides (matching
+ *  `std::default_accessor`); custom accessors (atomic views, checked
+ *  views, ...) are out of scope for this header.
+ */
+template <class ElementType>
+struct default_accessor
+{
+  using offset_policy = default_accessor;
+  using element_type = ElementType;
+  using reference = ElementType &;
+  using data_handle_type = ElementType *;
+
+  constexpr default_accessor() noexcept = default;
+
+  template <class OtherElementType>
+    requires std::is_convertible_v<OtherElementType (*)[], element_type (*)[]>
+  constexpr default_accessor(default_accessor<OtherElementType>) noexcept
+  {}
+
+  [[nodiscard]] constexpr reference access(data_handle_type p, size_t i) const noexcept
+  {
+    return p[i];
+  }
+
+  [[nodiscard]] constexpr data_handle_type offset(data_handle_type p, size_t i) const noexcept
+  {
+    return p + i;
+  }
+};
+
+/** @brief Non-owning view of a contiguous buffer as a multidimensional grid.
+ *
+ *  See the file-level documentation for the overview, the rationale for
+ *  `operator()` over multi-argument `operator[]`, and the bounds-checking
+ *  policy (`operator()` is unchecked, `.at()` is checked).
+ *
+ *  @tparam T element type (may be `const`-qualified for a read-only view).
+ *  @tparam Extents an `Aleph::extents<IndexType, ...>` (typically
+ *          `Aleph::dextents<IndexType, Rank>`).
+ *  @tparam LayoutPolicy `Aleph::layout_right` (default, row-major) or
+ *          `Aleph::layout_left` (column-major).
+ *  @tparam AccessorPolicy `Aleph::default_accessor<T>` (default).
+ */
+template <class T, class Extents, class LayoutPolicy = layout_right,
+          class AccessorPolicy = default_accessor<T>>
+class mdspan
+{
+public:
+  using extents_type = Extents;
+  using layout_type = LayoutPolicy;
+  using accessor_type = AccessorPolicy;
+  using mapping_type = typename layout_type::template mapping<extents_type>;
+  using element_type = T;
+  using value_type = std::remove_cv_t<T>;
+  using index_type = typename extents_type::index_type;
+  using rank_type = typename extents_type::rank_type;
+  using data_handle_type = typename accessor_type::data_handle_type;
+  using reference = typename accessor_type::reference;
+
+private:
+  data_handle_type ptr_{};
+  mapping_type map_{};
+  accessor_type acc_{};
+
+public:
+  /// Empty view: `data_handle() == nullptr`, every extent is 0.
+  constexpr mdspan() noexcept = default;
+
+  constexpr mdspan(const mdspan &) noexcept = default;
+  constexpr mdspan(mdspan &&) noexcept = default;
+  constexpr mdspan &operator=(const mdspan &) noexcept = default;
+  constexpr mdspan &operator=(mdspan &&) noexcept = default;
+
+  /** @brief Converting constructor: view a non-`const` element type as a
+   *         `const`-qualified one (`mdspan<T,...>` -> `mdspan<const T,...>`),
+   *         mirroring how `T*` converts to `const T*`.
+   *
+   *  Only participates when `OtherT` actually converts to `T` (so this
+   *  does not become a silent implicit cast between unrelated element
+   *  types) and the shapes/layouts/accessors match.
+   */
+  template <class OtherT, class OtherAccessor>
+    requires(not std::is_same_v<OtherT, T> and std::is_convertible_v<OtherT (*)[], T (*)[]>)
+  constexpr mdspan(const mdspan<OtherT, Extents, LayoutPolicy, OtherAccessor> &other) noexcept
+    : ptr_(other.data_handle()), map_(other.mapping()), acc_(other.accessor())
+  {}
+
+  /// View `p` through the shape `e`.
+  constexpr mdspan(data_handle_type p, const extents_type &e) noexcept
+    : ptr_(p), map_(e)
+  {}
+
+  /// View `p` through an already-built mapping (shares the mapping's extents).
+  constexpr mdspan(data_handle_type p, const mapping_type &m) noexcept
+    : ptr_(p), map_(m)
+  {}
+
+  /// View `p` through mapping `m`, reading via accessor `a`.
+  constexpr mdspan(data_handle_type p, const mapping_type &m, const accessor_type &a) noexcept
+    : ptr_(p), map_(m), acc_(a)
+  {}
+
+  /** @brief View `p` as a grid with the given per-axis sizes.
+   *
+   *  Convenience constructor equivalent to `mdspan(p, extents_type(exts...))`.
+   *  @param p pointer to the first element of the buffer to view.
+   *  @param exts one size per **dynamic** axis of `Extents`, in rank order.
+   */
+  template <class... IndexTypes>
+    requires(sizeof...(IndexTypes) >= 1 and
+             (std::is_convertible_v<IndexTypes, index_type> and ...))
+  constexpr explicit mdspan(data_handle_type p, IndexTypes... exts) noexcept
+    : ptr_(p), map_(extents_type(static_cast<index_type>(exts)...))
+  {}
+
+  /** @brief View `p` as a grid whose dynamic axes are packed in an array.
+   *
+   *  Convenience constructor equivalent to `mdspan(p, extents_type(dyn))`.
+   *  Matches `CA::Dense_Cell_Storage::extents_type` (a `std::array` of all
+   *  per-axis sizes for a fully-dynamic `dextents` shape), so a lattice's
+   *  own extents can be forwarded directly without unpacking them.
+   */
+  template <class OtherIndexType>
+    requires std::is_convertible_v<const OtherIndexType &, index_type>
+  constexpr mdspan(data_handle_type p,
+                    const std::array<OtherIndexType, extents_type::rank_dynamic()> &dyn) noexcept
+    : ptr_(p), map_(extents_type(dyn))
+  {}
+
+  /// Number of axes (compile-time constant).
+  [[nodiscard]] static constexpr rank_type rank() noexcept { return extents_type::rank(); }
+
+  /// Run-time size of axis `r`.
+  [[nodiscard]] constexpr index_type extent(rank_type r) const noexcept
+  {
+    return map_.extents().extent(r);
+  }
+
+  /// The shape of this view.
+  [[nodiscard]] constexpr const extents_type &extents() const noexcept { return map_.extents(); }
+
+  /// The index-to-offset mapping (layout + shape) of this view.
+  [[nodiscard]] constexpr const mapping_type &mapping() const noexcept { return map_; }
+
+  /// The element-access policy of this view.
+  [[nodiscard]] constexpr const accessor_type &accessor() const noexcept { return acc_; }
+
+  /// Underlying pointer to the first element (`nullptr` for a default-built view).
+  [[nodiscard]] constexpr data_handle_type data_handle() const noexcept { return ptr_; }
+
+  /// \overload data_handle() — mirrors the common `Array`/`std::vector`-style name.
+  [[nodiscard]] constexpr data_handle_type data() const noexcept { return ptr_; }
+
+  /// Total element count: the product of every `extent(r)`.
+  [[nodiscard]] constexpr index_type size() const noexcept
+  {
+    index_type total = 1;
+    for (rank_type r = 0; r < rank(); ++r)
+      total *= extent(r);
+    return total;
+  }
+
+  /// `true` if any axis has extent 0 (so the view has no elements).
+  [[nodiscard]] constexpr bool empty() const noexcept
+  {
+    for (rank_type r = 0; r < rank(); ++r)
+      if (extent(r) == 0)
+        return true;
+    return false;
+  }
+
+  /** @brief Unchecked element access.
+   *
+   *  @param idxs one index per axis, in rank order.
+   *  @warning Undefined behavior if any `idxs[r]` is outside
+   *           `[0, extent(r))` — matches `std::mdspan::operator[]`'s
+   *           contract exactly. Use `at()` for a bounds-checked variant.
+   */
+  template <class... Indices>
+    requires(sizeof...(Indices) == 0 ? extents_type::rank() == 0 : sizeof...(Indices) >= 1)
+  [[nodiscard]] constexpr reference operator()(Indices... idxs) const
+  {
+    return acc_.access(ptr_, map_(static_cast<index_type>(idxs)...));
+  }
+
+  /** @brief Bounds-checked element access.
+   *
+   *  @param idxs one index per axis, in rank order.
+   *  @throws std::out_of_range if any `idxs[r]` is outside `[0, extent(r))`.
+   */
+  template <class... Indices>
+    requires(sizeof...(Indices) == extents_type::rank())
+  [[nodiscard]] constexpr reference at(Indices... idxs) const
+  {
+    const index_type idx[]{static_cast<index_type>(idxs)...};
+    for (rank_type r = 0; r < rank(); ++r)
+      ah_out_of_range_error_if(idx[r] < 0 or idx[r] >= extent(r))
+        << "Aleph::mdspan::at(): index[" << r << "]=" << idx[r] << " out of [0, "
+        << extent(r) << ")";
+    return acc_.access(ptr_, map_(idxs...));
+  }
+};
+
+#endif  // ALEPH_HAS_STD_MDSPAN
+
+}  // namespace Aleph
+
+#endif  // AH_MDSPAN_H

--- a/ah-mdspan.H
+++ b/ah-mdspan.H
@@ -264,10 +264,10 @@ public:
   {
     const index_type idx[]{static_cast<index_type>(idxs)...};
     for (rank_type r = 0; r < rank(); ++r)
-      ah_out_of_range_error_if(idx[r] < 0 or idx[r] >= extent(r))
+      ah_out_of_range_error_if(std::cmp_less(idx[r], 0) or idx[r] >= extent(r))
         << "Aleph::mdspan::at(): index[" << r << "]=" << idx[r] << " out of [0, "
         << extent(r) << ")";
-    return impl_[idxs...];
+    return impl_[static_cast<index_type>(idxs)...];
   }
 };
 
@@ -742,10 +742,10 @@ public:
   {
     const index_type idx[]{static_cast<index_type>(idxs)...};
     for (rank_type r = 0; r < rank(); ++r)
-      ah_out_of_range_error_if(idx[r] < 0 or idx[r] >= extent(r))
+      ah_out_of_range_error_if(std::cmp_less(idx[r], 0) or idx[r] >= extent(r))
         << "Aleph::mdspan::at(): index[" << r << "]=" << idx[r] << " out of [0, "
         << extent(r) << ")";
-    return acc_.access(ptr_, map_(idxs...));
+    return acc_.access(ptr_, map_(static_cast<index_type>(idxs)...));
   }
 };
 

--- a/docs/ci_sanitizer_policy.md
+++ b/docs/ci_sanitizer_policy.md
@@ -42,6 +42,18 @@ table without also updating the inline comment is a review block.
 | `hash_statistical_test`                         | Long-running statistical sweep; 10× the runtime under TSan with no race signal. |
 | `tpl_ca_parallel_engine_test.*Stress`           | Intentionally oversubscribes the work-stealing pool; the relaxations there are benign and produce noise rather than findings. |
 
+`prefix_tree_test` also skips 4 individual cases (`InsertWordCleansDetachedPathOnAllocationFailure`,
+`CloneCleansPartialCopyOnAllocationFailure`, `OwnsRootAndDestroysNodes`,
+`CopyAssignmentKeepsOldTreeOnAllocationFailure`) via `GTEST_SKIP()` inside
+the test source itself, not a `ctest -E` regex: those tests rely on
+`prefix_tree_test.cc`'s own global `operator new`/`delete` overrides to
+inject allocation failures, which collide at link time ("multiple
+definition") with TSan's own strong `operator new`/`delete` replacements
+(`tsan_new_delete.cpp.o`). The overrides are compiled out under TSan
+(detected via `__SANITIZE_THREAD__` / `__has_feature(thread_sanitizer)`),
+so the whole binary still links; the 4 cases that depend on them report
+`SKIPPED` at run time instead.
+
 ### `ubsan` (UndefinedBehaviorSanitizer)
 
 | Test (CTest regex)                              | Reason for skip |

--- a/grid.H
+++ b/grid.H
@@ -70,6 +70,7 @@
 #ifndef GRID_H
 #define GRID_H
 
+#include <vector>
 #include <ah-errors.H>
 #include <aleph-graph.H>
 
@@ -190,16 +191,16 @@ public:
    */
   void operator () (GT &g, const size_t &width, const size_t &height)
   {
-    ah_domain_error_if(g.get_num_nodes() != 0) << "There is nodes in graph";
+    ah_domain_error_if(g.get_num_nodes() != 0) << "There are nodes in graph";
 
-    ah_length_error_if(width < 2 or height < 2) << "The minimun size must be 2 x 2";
+    ah_length_error_if(width < 2 or height < 2) << "The minimum size must be 2 x 2";
 
-    typename GT::Node ***map = new typename GT::Node **[height];
-    for (size_t i = 0; i < height; ++i)
+    std::vector<std::vector<typename GT::Node*>> map(height, std::vector<typename GT::Node*>(width, nullptr));
+
+    try
       {
-        try
+        for (size_t i = 0; i < height; ++i)
           {
-            map[i] = new typename GT::Node *[width];
             for (size_t j = 0; j < width; ++j)
               {
                 typename GT::Node *n = g.insert_node(typename GT::Node_Type());
@@ -227,19 +228,12 @@ public:
                   }
               }
           }
-        catch (...)
-          {
-            for (size_t k = i; k-- > 0;)
-              delete[] map[k];
-            delete[] map;
-            clear_graph(g);
-            throw;
-          }
       }
-
-    for (size_t i = 0; i < height; ++i)
-      delete[] map[i];
-    delete[] map;
+    catch (...)
+      {
+        clear_graph(g);
+        throw;
+      }
   }
 };
 

--- a/grid.H
+++ b/grid.H
@@ -29,7 +29,6 @@
   SOFTWARE.
 */
 
-
 /** @file grid.H
  *  @brief 2D grid graph generation with 8-connectivity.
  *
@@ -68,11 +67,13 @@
  *  @author Alejandro Mujica
  */
 
-# ifndef GRID_H
-# define GRID_H
+#ifndef GRID_H
+#define GRID_H
 
-namespace Aleph 
-{ 
+#include <ah-errors.H>
+#include <aleph-graph.H>
+
+namespace Aleph {
 
 /**
  * @brief Default no-op operation for node initialization.
@@ -92,7 +93,13 @@ struct Default_Operation_On_Node
    * @param[in] row Row index of node (0-based)
    * @param[in] col Column index of node (0-based)
    */
-  void operator () (GT & g, typename GT::Node * n, const size_t & row, const size_t & col) { (void)g; (void)n; (void)row; (void)col; }
+  void operator () (GT &g, typename GT::Node *n, const size_t &row, const size_t &col)
+  {
+    (void) g;
+    (void) n;
+    (void) row;
+    (void) col;
+  }
 };
 
 /**
@@ -113,7 +120,13 @@ struct Default_Operation_On_Arc
    * @param[in] row Row index of source node (0-based)
    * @param[in] col Column index of source node (0-based)
    */
-  void operator () (GT & g, typename GT::Arc * a, const size_t & row, const size_t & col) { (void)g; (void)a; (void)row; (void)col; }
+  void operator () (GT &g, typename GT::Arc *a, const size_t &row, const size_t &col)
+  {
+    (void) g;
+    (void) a;
+    (void) row;
+    (void) col;
+  }
 };
 
 /**
@@ -156,15 +169,11 @@ struct Default_Operation_On_Arc
  * @ingroup Graphs
  * @author Alejandro Mujica
  */
-template <
-          class GT,
-          class Operation_On_Node = Default_Operation_On_Node<GT>,
-          class Operation_On_Arc = Default_Operation_On_Arc<GT>
-         >
+template <class GT, class Operation_On_Node = Default_Operation_On_Node<GT>,
+          class Operation_On_Arc = Default_Operation_On_Arc<GT>>
 class Build_Grid
 {
 public:
-
   /**
    * @brief Build a grid graph.
    *
@@ -179,63 +188,61 @@ public:
    *
    * @post g contains width*height nodes with grid connectivity
    */
-  void operator () (GT & g, const size_t & width, const size_t & height)
+  void operator () (GT &g, const size_t &width, const size_t &height)
   {
-    ah_domain_error_if(g.get_num_nodes() != 0)
-        << "There is nodes in graph";
+    ah_domain_error_if(g.get_num_nodes() != 0) << "There is nodes in graph";
 
-    ah_length_error_if(width < 2 or height < 2)
-        << "The minimun size must be 2 x 2";
+    ah_length_error_if(width < 2 or height < 2) << "The minimun size must be 2 x 2";
 
-    typename GT::Node *** map = new typename GT::Node **[height];
+    typename GT::Node ***map = new typename GT::Node **[height];
     for (size_t i = 0; i < height; ++i)
       {
-	try
-	  {
-	    map[i] = new typename GT::Node *[width];
-	    for (size_t j = 0; j < width; ++j)
-	      {
-		typename GT::Node * n = g.insert_node(typename GT::Node_Type());
-		Operation_On_Node()(g, n, i, j);
-		map[i][j] = n;
-		if (j > 0) // Connect to left neighbor
-		  {
-		    typename GT::Arc * a = g.insert_arc(n, map[i][j - 1]);
-		    Operation_On_Arc()(g, a, i, j);
-		  }
-		if (i > 0) // Connect to upper neighbor
-		  {
-		    typename GT::Arc * a = g.insert_arc(n, map[i - 1][j]);
-		    Operation_On_Arc()(g, a, i, j);
-		  }
-		if (i > 0 and j > 0) // Connect to upper-left diagonal
-		  {
-		    typename GT::Arc * a = g.insert_arc(n, map[i - 1][j - 1]);
-		    Operation_On_Arc()(g, a, i, j);
-		  }
-		if (j + 1 < width and i > 0) // Connect to upper-right diagonal
-		  {
-		    typename GT::Arc * a = g.insert_arc(n, map[i - 1][j + 1]);
-		    Operation_On_Arc()(g, a, i, j);
-		  }
-	      }
-	  }
-	catch (...)
-	  {
-	    for (size_t k = i; k-- > 0; )
-	      delete [] map[k];
-	    delete [] map;
-	    clear_graph(g);
-	    throw;
-	  }
+        try
+          {
+            map[i] = new typename GT::Node *[width];
+            for (size_t j = 0; j < width; ++j)
+              {
+                typename GT::Node *n = g.insert_node(typename GT::Node_Type());
+                Operation_On_Node()(g, n, i, j);
+                map[i][j] = n;
+                if (j > 0)  // Connect to left neighbor
+                  {
+                    typename GT::Arc *a = g.insert_arc(n, map[i][j - 1]);
+                    Operation_On_Arc()(g, a, i, j);
+                  }
+                if (i > 0)  // Connect to upper neighbor
+                  {
+                    typename GT::Arc *a = g.insert_arc(n, map[i - 1][j]);
+                    Operation_On_Arc()(g, a, i, j);
+                  }
+                if (i > 0 and j > 0)  // Connect to upper-left diagonal
+                  {
+                    typename GT::Arc *a = g.insert_arc(n, map[i - 1][j - 1]);
+                    Operation_On_Arc()(g, a, i, j);
+                  }
+                if (j + 1 < width and i > 0)  // Connect to upper-right diagonal
+                  {
+                    typename GT::Arc *a = g.insert_arc(n, map[i - 1][j + 1]);
+                    Operation_On_Arc()(g, a, i, j);
+                  }
+              }
+          }
+        catch (...)
+          {
+            for (size_t k = i; k-- > 0;)
+              delete[] map[k];
+            delete[] map;
+            clear_graph(g);
+            throw;
+          }
       }
 
     for (size_t i = 0; i < height; ++i)
-      delete [] map[i];
-    delete [] map;
+      delete[] map[i];
+    delete[] map;
   }
 };
 
-}
+}  // namespace Aleph
 
-# endif
+#endif

--- a/grid.H
+++ b/grid.H
@@ -70,9 +70,9 @@
 #ifndef GRID_H
 #define GRID_H
 
-#include <vector>
 #include <ah-errors.H>
 #include <aleph-graph.H>
+#include <tpl_array.H>
 
 namespace Aleph {
 
@@ -195,7 +195,10 @@ public:
 
     ah_length_error_if(width < 2 or height < 2) << "The minimum size must be 2 x 2";
 
-    std::vector<std::vector<typename GT::Node*>> map(height, std::vector<typename GT::Node*>(width, nullptr));
+    // Flat, single-allocation lookup table (row-major: map[i * width + j])
+    // instead of a vector-of-vectors, avoiding height+1 separate
+    // allocations and keeping the whole table contiguous.
+    Array<typename GT::Node*> map(width * height, nullptr);
 
     try
       {
@@ -205,25 +208,25 @@ public:
               {
                 typename GT::Node *n = g.insert_node(typename GT::Node_Type());
                 Operation_On_Node()(g, n, i, j);
-                map[i][j] = n;
+                map[i * width + j] = n;
                 if (j > 0)  // Connect to left neighbor
                   {
-                    typename GT::Arc *a = g.insert_arc(n, map[i][j - 1]);
+                    typename GT::Arc *a = g.insert_arc(n, map[i * width + (j - 1)]);
                     Operation_On_Arc()(g, a, i, j);
                   }
                 if (i > 0)  // Connect to upper neighbor
                   {
-                    typename GT::Arc *a = g.insert_arc(n, map[i - 1][j]);
+                    typename GT::Arc *a = g.insert_arc(n, map[(i - 1) * width + j]);
                     Operation_On_Arc()(g, a, i, j);
                   }
                 if (i > 0 and j > 0)  // Connect to upper-left diagonal
                   {
-                    typename GT::Arc *a = g.insert_arc(n, map[i - 1][j - 1]);
+                    typename GT::Arc *a = g.insert_arc(n, map[(i - 1) * width + (j - 1)]);
                     Operation_On_Arc()(g, a, i, j);
                   }
                 if (j + 1 < width and i > 0)  // Connect to upper-right diagonal
                   {
-                    typename GT::Arc *a = g.insert_arc(n, map[i - 1][j + 1]);
+                    typename GT::Arc *a = g.insert_arc(n, map[(i - 1) * width + (j + 1)]);
                     Operation_On_Arc()(g, a, i, j);
                   }
               }

--- a/grid.H
+++ b/grid.H
@@ -191,7 +191,7 @@ public:
    */
   void operator () (GT &g, const size_t &width, const size_t &height)
   {
-    ah_domain_error_if(g.get_num_nodes() != 0) << "There are nodes in graph";
+    ah_domain_error_if(g.get_num_nodes() != 0) << "Build_Grid requires an empty graph";
 
     ah_length_error_if(width < 2 or height < 2) << "The minimum size must be 2 x 2";
 

--- a/prefix-tree.H
+++ b/prefix-tree.H
@@ -775,6 +775,18 @@ namespace Aleph
       // empty
     }
 
+    /** @brief Move-construct, taking ownership of another tree's root.
+     *
+     * @param[in,out] other Tree to move from. Left owning no root; the
+     *                      only valid operations on `other` afterward are
+     *                      destruction or assignment.
+     */
+    Prefix_Tree(Prefix_Tree &&other) noexcept
+      : root_(other.root_)
+    {
+      other.root_ = nullptr;
+    }
+
     /** @brief Destroy the owned root and all descendants.
      *
      * This destructor does not throw.
@@ -802,6 +814,24 @@ namespace Aleph
       Cnode *new_root = other.root_->clone();
       destroy_root(root_);
       root_ = new_root;
+      return *this;
+    }
+
+    /** @brief Move-assign, taking ownership of another tree's root.
+     *
+     * @param[in,out] other Tree to move from. Left owning no root; the
+     *                      only valid operations on `other` afterward are
+     *                      destruction or assignment.
+     * @return Reference to this tree.
+     */
+    Prefix_Tree &operator=(Prefix_Tree &&other) noexcept
+    {
+      if (this == &other)
+        return *this;
+
+      destroy_root(root_);
+      root_ = other.root_;
+      other.root_ = nullptr;
       return *this;
     }
 

--- a/prefix-tree.H
+++ b/prefix-tree.H
@@ -34,7 +34,8 @@
  *  @brief Trie (prefix tree) implementation.
  *
  *  Efficient string prefix search structure for autocomplete,
- *  dictionary lookup, and prefix matching.
+ *  dictionary lookup, and prefix matching. Prefer Prefix_Tree for ordinary
+ *  use; Cnode remains available as the low-level node API.
  *
  *  ## Features
  *  - O(k) lookup for k-length strings
@@ -48,19 +49,30 @@
 #ifndef PREFIX_TREE_H
 #define PREFIX_TREE_H
 
+# include <cassert>
+# include <cstddef>
+# include <iostream>
+# include <string>
+# include <tuple>
+
 # include <tpl_tree_node.H>
 # include <tpl_dynArray.H>
 # include <tpl_dynList.H>
-# include <tpl_arrayStack.H>
 # include <ah-errors.H>
 
 namespace Aleph
 {
-  /** @brief Prefix tree (Trie) node for storing character sequences.
+  /** @brief Low-level prefix tree node for storing character sequences.
    *
    * Cnode implements a prefix tree (also known as a trie or digital tree)
    * where each node represents a character. Words are stored as paths
-   * from the root, with a special '$' character marking word endings.
+   * from the root. A node-local flag marks complete word endings, so every
+   * character value can be used as ordinary input data.
+   *
+   * This is the legacy/manual node API. A Cnode does not own its descendants in
+   * its destructor; callers that build trees directly with Cnode must call
+   * destroy() before the root node is destroyed. Prefer Prefix_Tree when a
+   * normal owning container is desired.
    *
    * ## Features
    *
@@ -69,10 +81,10 @@ namespace Aleph
    * - **Prefix search**: O(m) where m is prefix length
    * - **Space**: O(ALPHABET_SIZE * N * M) worst case
    *
-   * ## Usage Example
+   * ## Low-level Usage Example
    *
    * ```cpp
-   * // Create root node (typically with a sentinel character)
+   * // Create a manual root node. Its symbol is not part of stored words.
    * Cnode root('\0');
    *
    * // Insert words
@@ -94,21 +106,218 @@ namespace Aleph
    * auto [node, remaining] = root.search_prefix("hel");
    * // node points to 'l' in "hel", remaining is ""
    *
-   * // Clean up
+   * // Manual cleanup is required when using Cnode directly.
    * root.destroy();
    * ```
    *
    * ## Implementation Details
    *
    * - Children are stored in sorted order by character for efficient lookup
-   * - Word endings are marked with a '$' sentinel child node
+   * - Word endings are marked by state stored in the terminal node
    * - The tree uses a leftmost-child, right-sibling representation
+   * - to_str() reports structural nodes only; word-ending flags are not shown
+   *   as sentinel children
    *
+   * @see Prefix_Tree
    * @see Tree_Node
    * @ingroup Trees
    */
   class Cnode : public Tree_Node<char>
   {
+    bool ends_word_ = false;
+
+    /** @brief Shared implementation for mutable and const prefix searches.
+     *
+     * @tparam Node Either `Cnode` or `const Cnode`.
+     * @param[in] root Node where the search starts.
+     * @param[in] prefix Null-terminated prefix to search for.
+     * @return Tuple of (node reached, remaining unmatched suffix).
+     *         If the entire prefix was found, remaining is "".
+     *
+     * @pre `root` and `prefix` must not be nullptr.
+     */
+    template <typename Node>
+    [[nodiscard]] static std::tuple<Node *, const char *>
+    search_prefix_impl(Node *root, const char *prefix) noexcept
+    {
+      assert(root != nullptr);
+      assert(prefix != nullptr);
+
+      auto node = root;
+      for (const char *ptr = prefix; *ptr != '\0'; ++ptr)
+        {
+          auto *child = node->search_child(*ptr);
+          if (child == nullptr)
+            return std::make_tuple(node, ptr);
+          node = child;
+        }
+
+      return std::make_tuple(node, "");
+    }
+
+    /** @brief Shared implementation for mutable and const child lookup.
+     *
+     * @tparam Node Either `Cnode` or `const Cnode`.
+     * @param[in] root Node whose children are searched.
+     * @param[in] c Character to search for.
+     * @return Pointer to the matching child, or nullptr if not found.
+     *
+     * @pre `root` must not be nullptr.
+     */
+    template <typename Node>
+    [[nodiscard]] static Node * search_child_impl(Node *root, const char c) noexcept
+    {
+      assert(root != nullptr);
+
+      for (auto *child = root->get_left_child(); child != nullptr;
+           child = child->get_right_sibling())
+        {
+          const char key = child->get_key();
+          if (key == c)
+            return static_cast<Node *>(child);
+          if (key > c)
+            return nullptr;
+        }
+
+      return nullptr;
+    }
+
+    /** @brief Shared implementation for mutable and const sorted-child lookup.
+     *
+     * @tparam Node Either `Cnode` or `const Cnode`.
+     * @param[in] root Node whose children are searched.
+     * @param[in] c Character threshold.
+     * @return Pointer to the first child with char > c, or nullptr.
+     *
+     * @pre `root` must not be nullptr.
+     */
+    template <typename Node>
+    [[nodiscard]] static Node * greater_child_impl(Node *root, const char c) noexcept
+    {
+      assert(root != nullptr);
+
+      for (auto *child = root->get_left_child(); child != nullptr;
+           child = child->get_right_sibling())
+        if (child->get_key() > c)
+          return static_cast<Node *>(child);
+      return nullptr;
+    }
+
+    /** @brief Own a detached subtree until it is committed elsewhere.
+     *
+     * The guarded node must be a standalone tree root, not a node already
+     * linked into a live parent.
+     */
+    class Detached_Subtree_Guard
+    {
+      Cnode *root_ = nullptr;
+
+    public:
+      explicit Detached_Subtree_Guard(Cnode *root) noexcept
+        : root_(root)
+      {
+        // empty
+      }
+
+      ~Detached_Subtree_Guard()
+      {
+        if (root_ != nullptr)
+          {
+            root_->destroy();
+            delete root_;
+          }
+      }
+
+      [[nodiscard]] Cnode *get() const noexcept { return root_; }
+
+      [[nodiscard]] Cnode *release() noexcept
+      {
+        Cnode *ret = root_;
+        root_ = nullptr;
+        return ret;
+      }
+    };
+
+    /** @brief Own standalone nodes until an insertion path is committed. */
+    class Pending_Path_Guard
+    {
+      Cnode **nodes_ = nullptr;
+      size_t count_ = 0;
+      bool owns_nodes_ = true;
+
+    public:
+      explicit Pending_Path_Guard(const size_t count)
+        : nodes_(new Cnode *[count]), count_(count)
+      {
+        for (size_t i = 0; i < count_; ++i)
+          nodes_[i] = nullptr;
+      }
+
+      ~Pending_Path_Guard()
+      {
+        if (owns_nodes_)
+          for (size_t i = 0; i < count_; ++i)
+            delete nodes_[i];
+        delete [] nodes_;
+      }
+
+      [[nodiscard]] Cnode *operator[](const size_t i) const noexcept
+      {
+        return nodes_[i];
+      }
+
+      void set(const size_t i, Cnode *node) noexcept
+      {
+        nodes_[i] = node;
+      }
+
+      void release_nodes() noexcept
+      {
+        owns_nodes_ = false;
+      }
+    };
+
+    /** @brief Restore a clone target if appending cloned children fails. */
+    class Clone_Target_Rollback
+    {
+      Cnode *target_ = nullptr;
+      Tree_Node<char> *previous_rightmost_ = nullptr;
+      bool previous_ends_word_ = false;
+      bool active_ = true;
+
+    public:
+      explicit Clone_Target_Rollback(Cnode *target) noexcept
+        : target_(target)
+      {
+        assert(target_ != nullptr);
+        previous_rightmost_ = target_->get_right_child();
+        previous_ends_word_ = target_->ends_word_;
+      }
+
+      void release() noexcept { active_ = false; }
+
+      ~Clone_Target_Rollback()
+      {
+        if (not active_)
+          return;
+
+        while (target_->get_right_child() != previous_rightmost_)
+          {
+            auto *child = static_cast<Cnode *>(target_->get_right_child());
+            const bool child_was_leftmost = child->is_leftmost();
+            destroy_tree(child);
+            if (child_was_leftmost)
+              {
+                if (previous_rightmost_ == nullptr)
+                  target_->set_is_leaf(true);
+                break;
+              }
+          }
+
+        target_->ends_word_ = previous_ends_word_;
+      }
+    };
+
   public:
     /** @brief Construct a node with the given character.
      *
@@ -149,108 +358,133 @@ namespace Aleph
     [[nodiscard]] std::string to_str() const
     {
       std::string ret(1, symbol());
-      children().for_each([&ret](Cnode *p)
-                            {
-                              ret += "(" + p->to_str() + ")";
-                            });
+      for_each_child([&ret](const Tree_Node<char> *p)
+                       {
+                         const auto *node = static_cast<const Cnode *>(p);
+                         ret += "(" + node->to_str() + ")";
+                       });
       return ret;
     }
 
     /** @brief Check if this node marks the end of a word.
      *
-     * A word ending is marked by having a '$' child node.
+     * A word ending is stored as node state instead of as a child sentinel.
      *
      * @return true if this node ends a word, false otherwise.
      */
     [[nodiscard]] bool is_end_word() const noexcept
     {
-      Tree_Node<char> *child = get_left_child();
-      if (child == nullptr)
-        return false;
-      return child->get_key() == '$';
+      return ends_word_;
     }
 
     /** @brief Mark this node as the end of a word.
      *
-     * Inserts a '$' sentinel child node.
+     * Sets the node-local word-ending flag.
      *
      * @pre The node must not already be marked as a word ending.
      */
     void mark_end_word()
     {
       assert(not is_end_word());
-      insert_leftmost_child(new Cnode('$'));
+      ends_word_ = true;
     }
 
-    /** @brief Search for a child with the given character.
+    /** @brief Search for a mutable child with the given character.
      *
      * @param[in] c Character to search for.
      * @return Pointer to the child node, or nullptr if not found.
      */
-    [[nodiscard]] Cnode * search_child(const char c) const noexcept
+    [[nodiscard]] Cnode * search_child(const char c) noexcept
     {
-      for (Tree_Node<char> *child = get_left_child(); child != nullptr;
-           child = child->get_right_sibling())
-        if (child->get_key() == c)
-          return static_cast<Cnode *>(child);
-
-      return nullptr;
+      return search_child_impl(this, c);
     }
 
-    /** @brief Find the first child with a character greater than c.
+    /** @brief Search for a const child with the given character.
+     *
+     * @param[in] c Character to search for.
+     * @return Const pointer to the child node, or nullptr if not found.
+     */
+    [[nodiscard]] const Cnode * search_child(const char c) const noexcept
+    {
+      return search_child_impl(this, c);
+    }
+
+    /** @brief Find the first mutable child with a character greater than c.
      *
      * Used for maintaining sorted order of children.
      *
      * @param[in] c Character threshold.
      * @return Pointer to the first child with char > c, or nullptr.
      */
-    [[nodiscard]] Cnode * greater_child(const char c) const noexcept
+    [[nodiscard]] Cnode * greater_child(const char c) noexcept
     {
-      for (Tree_Node<char> *child = get_left_child(); child != nullptr;
-           child = child->get_right_sibling())
-        if (child->get_key() > c)
-          return static_cast<Cnode *>(child);
-      return nullptr;
+      return greater_child_impl(this, c);
     }
 
-    /** @brief Search for a prefix in the tree.
+    /** @brief Find the first const child with a character greater than c.
+     *
+     * Used for inspecting the sorted child order.
+     *
+     * @param[in] c Character threshold.
+     * @return Const pointer to the first child with char > c, or nullptr.
+     */
+    [[nodiscard]] const Cnode * greater_child(const char c) const noexcept
+    {
+      return greater_child_impl(this, c);
+    }
+
+    /** @brief Search for a prefix in the mutable tree.
      *
      * Traverses the tree following the characters in prefix.
      *
      * @param[in] prefix Null-terminated string to search for.
      * @return Tuple of (node reached, remaining unmatched suffix).
      *         If the entire prefix was found, remaining is "".
+     *
+     * @pre `prefix` must not be nullptr.
+     */
+    [[nodiscard]] std::tuple<Cnode *, const char *>
+    search_prefix(const char *prefix) noexcept
+    {
+      return search_prefix_impl(this, prefix);
+    }
+
+    /** @brief Search for a prefix in the const tree.
+     *
+     * Traverses the tree following the characters in prefix.
+     *
+     * @param[in] prefix Null-terminated string to search for.
+     * @return Tuple of (node reached, remaining unmatched suffix).
+     *         If the entire prefix was found, remaining is "".
+     *
+     * @pre `prefix` must not be nullptr.
      */
     [[nodiscard]] std::tuple<const Cnode *, const char *>
     search_prefix(const char *prefix) const noexcept
     {
-      assert(prefix != nullptr);
-
-      if (*prefix == '\0')
-        return std::make_tuple(this, "");
-
-      const Cnode *p = search_child(*prefix);
-      if (p == nullptr)
-        return std::make_tuple(this, prefix);
-
-      return p->search_prefix(prefix + 1);
+      return search_prefix_impl(this, prefix);
     }
 
     /** @brief Search for a complete word in the tree.
      *
      * @param[in] word Null-terminated string to search for.
      * @return Pointer to the ending node if found, nullptr otherwise.
+     *
+     * @pre `word` must not be nullptr.
      */
     [[nodiscard]] const Cnode * search_word(const char *word) const noexcept
     {
-      if (*word == '\0')
-        return is_end_word() ? this : nullptr;
+      assert(word != nullptr);
 
-      const Cnode *ptr = search_child(*word);
-      if (ptr == nullptr)
-        return nullptr;
+      auto node = this;
+      for (const char *ptr = word; *ptr != '\0'; ++ptr)
+        {
+          node = node->search_child(*ptr);
+          if (node == nullptr)
+            return nullptr;
+        }
 
-      return ptr->search_word(word + 1);
+      return node->is_end_word() ? node : nullptr;
     }
 
     /** @brief Check if a word exists in the tree.
@@ -282,6 +516,10 @@ namespace Aleph
      * @param[in] prefix Prefix to search for.
      * @param[in] max_word_length Maximum expected word length (default 2048).
      * @return Array of words that start with prefix.
+     *
+     * @note An empty prefix returns the same set of words as words().
+     * @pre `max_word_length` must be at least `prefix.size()` and large
+     *      enough for every emitted word when assertions are enabled.
      */
     [[nodiscard]] DynArray<std::string> words_with_prefix(
         const std::string & prefix,
@@ -293,15 +531,12 @@ namespace Aleph
       if (*remaining != '\0')
         return {};
 
-      // Get all words from the prefix node and prepend the prefix
-      FixedStack<char> stack(max_word_length);
+      assert(prefix.size() <= max_word_length);
       DynArray<std::string> ret_val;
+      std::string word(prefix);
+      word.reserve(max_word_length);
 
-      // Push prefix (except last char which will be pushed by words_impl)
-      for (size_t i = 0; i + 1 < prefix.size(); ++i)
-        stack.push(prefix[i]);
-
-      node->words_impl(stack, ret_val);
+      node->words_impl(word, ret_val, max_word_length);
       return ret_val;
     }
 
@@ -334,6 +569,10 @@ namespace Aleph
      * @return true if the word was inserted, false if it already existed.
      *
      * @throw std::bad_alloc If memory allocation fails.
+     *
+     * @note Provides the strong guarantee for allocation failures: if inserting
+     *       a new path throws, the trie is restored to its previous logical
+     *       contents.
      */
     bool insert_word(const std::string & word)
     {
@@ -343,16 +582,28 @@ namespace Aleph
         {
           if (pp->is_end_word())
             return false;
-          const_cast<Cnode *>(pp)->mark_end_word();
+          pp->mark_end_word();
           return true;
         }
 
-      // Insert nodes directly without intermediate list
-      auto *parent = const_cast<Cnode *>(pp);
+      size_t n = 0;
       for (const char *ptr = rem; *ptr; ++ptr)
-        parent = parent->insert_child(new Cnode(*ptr));
+        ++n;
 
-      parent->mark_end_word();
+      Pending_Path_Guard path(n);
+      for (size_t i = 0; i < n; ++i)
+        path.set(i, new Cnode(rem[i]));
+
+      path[n - 1]->mark_end_word();
+      path.release_nodes();
+
+      auto *parent = pp->insert_child(path[0]);
+      for (size_t i = 1; i < n; ++i)
+        {
+          parent->insert_rightmost_child(path[i]);
+          parent = path[i];
+        }
+
       return true;
     }
 
@@ -363,36 +614,31 @@ namespace Aleph
      */
     void destroy() noexcept
     {
-      // Must copy children list first - can't iterate while deleting
-      children().for_each([](Cnode *p) { destroy_tree(p); });
+      for (Cnode *p = static_cast<Cnode *>(get_right_child()); p != nullptr;)
+        {
+          Cnode *to_delete = p;
+          p = static_cast<Cnode *>(p->get_left_sibling());
+          destroy_tree(to_delete);
+        }
+      this->set_is_leaf(true);
     }
 
   private:
-    static std::string extract_word_from_stack(FixedStack<char> & stack)
+    void words_impl(std::string & word, DynArray<std::string> & l,
+                    const size_t max_word_length) const
     {
-      std::string ret_val;
-      ret_val.reserve(stack.size());
-
-      const char *ptr = &stack.base();
-      const char *last = &stack.top();
-      while (ptr <= last)
-        ret_val.append(1, *ptr++);
-
-      return ret_val;
-    }
-
-    void words_impl(FixedStack<char> & stack, DynArray<std::string> & l) const
-    {
-      if (symbol() == '$')
-        l.append(extract_word_from_stack(stack));
-
-      stack.push(symbol());
+      if (is_end_word())
+        l.append(word);
 
       for (const Tree_Node<char> *child = get_left_child(); child != nullptr;
            child = child->get_right_sibling())
-        static_cast<const Cnode *>(child)->words_impl(stack, l);
-
-      stack.pop();
+        {
+          assert(word.size() < max_word_length);
+          const auto *node = static_cast<const Cnode *>(child);
+          word.push_back(node->symbol());
+          node->words_impl(word, l, max_word_length);
+          word.pop_back();
+        }
     }
 
   public:
@@ -401,17 +647,17 @@ namespace Aleph
      * @param[in] max_word_length Maximum expected word length (default 2048).
      * @return Array containing all words.
      *
-     * @note Uses a temporary stack for traversal.
+     * @note Reuses a single temporary string buffer during traversal.
+     * @pre `max_word_length` must be large enough for every stored word when
+     *      assertions are enabled.
      */
     [[nodiscard]] DynArray<std::string> words(size_t max_word_length = 2048) const
     {
-      FixedStack<char> stack(max_word_length);
       DynArray<std::string> ret_val;
+      std::string word;
+      word.reserve(max_word_length);
 
-      for_each_child([&](Tree_Node<char> *p)
-                       {
-                         static_cast<const Cnode *>(p)->words_impl(stack, ret_val);
-                       });
+      words_impl(word, ret_val, max_word_length);
 
       return ret_val;
     }
@@ -432,24 +678,32 @@ namespace Aleph
      *
      * @param[in] src Source node to copy from.
      * @param[out] tgt Target node to copy to.
+     *
+     * @throw std::bad_alloc If memory allocation fails.
+     *
+     * @note Provides the strong guarantee for `tgt`: if cloning throws, any
+     *       children appended by this call are removed and the previous
+     *       word-ending flag is restored.
      */
     static void clone(const Tree_Node<char> *src, Tree_Node<char> *tgt)
     {
-      // First, create all children in target
-      src->for_each_child([tgt](auto s)
-                            {
-                              tgt->insert_rightmost_child(new Cnode(s->get_key()));
-                            });
+      const auto *src_node = static_cast<const Cnode *>(src);
+      auto *tgt_node = static_cast<Cnode *>(tgt);
+      Clone_Target_Rollback rollback(tgt_node);
+      tgt_node->ends_word_ = src_node->ends_word_;
 
-      // Then recursively clone each child subtree
-      const Tree_Node<char> *src_child = src->get_left_child();
-      Tree_Node<char> *tgt_child = tgt->get_left_child();
-      while (src_child != nullptr)
+      for (const Tree_Node<char> *src_child = src_node->get_left_child();
+           src_child != nullptr; src_child = src_child->get_right_sibling())
         {
-          clone(src_child, tgt_child);
-          src_child = src_child->get_right_sibling();
-          tgt_child = tgt_child->get_right_sibling();
+          const auto *child = static_cast<const Cnode *>(src_child);
+          Detached_Subtree_Guard cloned_child(new Cnode(child->symbol()));
+          Cnode *tgt_child = cloned_child.get();
+          tgt_node->insert_rightmost_child(tgt_child);
+          (void) cloned_child.release();
+          clone(child, tgt_child);
         }
+
+      rollback.release();
     }
 
     /** @brief Create a deep copy of this subtree.
@@ -457,12 +711,187 @@ namespace Aleph
      * @return Pointer to the cloned tree root.
      *
      * @throw std::bad_alloc If memory allocation fails.
+     *
+     * @note Provides the strong guarantee: no partially cloned tree leaks if
+     *       allocation fails.
      */
     [[nodiscard]] Cnode * clone() const
     {
-      auto *ret = new Cnode(symbol());
-      clone(this, ret);
-      return ret;
+      Detached_Subtree_Guard ret(new Cnode(symbol()));
+      clone(this, ret.get());
+      return ret.release();
+    }
+  };
+
+  /** @brief Owning prefix tree wrapper.
+   *
+   * Prefix_Tree owns a root Cnode and destroys all descendant nodes in its
+   * destructor. It provides the same common word-level operations as Cnode,
+   * while preserving Cnode as the low-level node API for legacy code and
+   * manual tree manipulation.
+   *
+   * Copies are deep copies. The root returned by root() is non-owning; callers
+   * must not delete it or call destroy_tree() on it.
+   *
+   * @ingroup Trees
+   */
+  class Prefix_Tree
+  {
+    Cnode *root_ = nullptr;
+
+    /** @brief Destroy an owned root and all its descendants. */
+    static void destroy_root(Cnode *root) noexcept
+    {
+      if (root == nullptr)
+        return;
+
+      root->destroy();
+      delete root;
+    }
+
+  public:
+    /** @brief Construct an empty prefix tree.
+     *
+     * The root node uses the conventional `'\0'` symbol; the symbol is not
+     * part of any stored word.
+     *
+     * @throw std::bad_alloc If allocating the root node fails.
+     */
+    Prefix_Tree()
+      : root_(new Cnode('\0'))
+    {
+      // empty
+    }
+
+    /** @brief Construct a deep copy of another prefix tree.
+     *
+     * @param[in] other Tree to copy.
+     *
+     * @throw std::bad_alloc If allocating any copied node fails.
+     */
+    Prefix_Tree(const Prefix_Tree &other)
+      : root_(other.root_->clone())
+    {
+      // empty
+    }
+
+    /** @brief Destroy the owned root and all descendants.
+     *
+     * This destructor does not throw.
+     */
+    ~Prefix_Tree() noexcept
+    {
+      destroy_root(root_);
+    }
+
+    /** @brief Replace this tree with a deep copy of another tree.
+     *
+     * @param[in] other Tree to copy from.
+     * @return Reference to this tree.
+     *
+     * @throw std::bad_alloc If allocating any copied node fails.
+     *
+     * @note Provides the strong guarantee: if copying fails, this tree keeps
+     *       its previous contents.
+     */
+    Prefix_Tree &operator=(const Prefix_Tree &other)
+    {
+      if (this == &other)
+        return *this;
+
+      Cnode *new_root = other.root_->clone();
+      destroy_root(root_);
+      root_ = new_root;
+      return *this;
+    }
+
+    /** @brief Insert a word into the tree.
+     *
+     * @param[in] word Word to insert.
+     * @return true if the word was inserted, false if it already existed.
+     *
+     * @throw std::bad_alloc If memory allocation fails.
+     */
+    bool insert_word(const std::string &word)
+    {
+      return root_->insert_word(word);
+    }
+
+    /** @brief Check whether a word exists in the tree.
+     *
+     * @param[in] word Word to search for.
+     * @return true if the word exists, false otherwise.
+     */
+    [[nodiscard]] bool contains(const std::string &word) const noexcept
+    {
+      return root_->contains(word);
+    }
+
+    /** @brief Get all words stored in the tree.
+     *
+     * @param[in] max_word_length Maximum expected word length (default 2048).
+     * @return Array containing all words.
+     *
+     * @throw std::bad_alloc If memory allocation fails.
+     *
+     * @pre `max_word_length` must be large enough for every stored word when
+     *      assertions are enabled.
+     */
+    [[nodiscard]] DynArray<std::string> words(
+        const size_t max_word_length = 2048) const
+    {
+      return root_->words(max_word_length);
+    }
+
+    /** @brief Get all words with a given prefix.
+     *
+     * @param[in] prefix Prefix to search for.
+     * @param[in] max_word_length Maximum expected word length (default 2048).
+     * @return Array containing all matching words.
+     *
+     * @throw std::bad_alloc If memory allocation fails.
+     *
+     * @pre `max_word_length` must be at least `prefix.size()` and large
+     *      enough for every emitted word when assertions are enabled.
+     */
+    [[nodiscard]] DynArray<std::string> words_with_prefix(
+        const std::string &prefix,
+        const size_t max_word_length = 2048) const
+    {
+      return root_->words_with_prefix(prefix, max_word_length);
+    }
+
+    /** @brief Count the words stored in the tree.
+     *
+     * @return Number of complete words.
+     */
+    [[nodiscard]] size_t count() const noexcept
+    {
+      return root_->count();
+    }
+
+    /** @brief Return the mutable root node.
+     *
+     * @return Non-owning pointer to the root node.
+     *
+     * @note The returned root remains owned by this Prefix_Tree. Do not delete
+     *       it or call destroy_tree() on it.
+     */
+    [[nodiscard]] Cnode *root() noexcept
+    {
+      return root_;
+    }
+
+    /** @brief Return the const root node.
+     *
+     * @return Non-owning pointer to the root node.
+     *
+     * @note The returned root remains owned by this Prefix_Tree. Do not delete
+     *       it or call destroy_tree() on it.
+     */
+    [[nodiscard]] const Cnode *root() const noexcept
+    {
+      return root_;
     }
   };
 } // end namespace Aleph

--- a/random_tree.H
+++ b/random_tree.H
@@ -57,7 +57,7 @@
  *
  *  // ... use tree ...
  *
- *  destroyRec(tree);  // Clean up
+ *  destroy_tree(tree);  // Clean up
  *  ```
  *
  *  @see tpl_tree_node.H General tree node
@@ -178,7 +178,7 @@ public:
    * RandTree<int> gen(42);
    * Tree_Node<int>* tree = gen(100);
    * // ... use tree ...
-   * destroyRec(tree);  // Don't forget to clean up!
+   * destroy_tree(tree);  // Don't forget to clean up!
    * @endcode
    */
   Tree_Node<T> * operator () (size_t n)

--- a/tpl_ca_storage.H
+++ b/tpl_ca_storage.H
@@ -84,7 +84,7 @@ namespace CA {
  *  @tparam N number of axes (1, 2 or 3 are the typical values).
  *
  *  @par Complexity
- *  - `at`, `set`, `linear_index`, `data`, `size`, `extents`: O(1).
+ *  - `at`, `set`, `linear_index`, `data`, `size`, `extents`, `view`: O(1).
  *  - `swap`: O(1) (swaps the internal `Array<T>` pointers).
  *  - `fill`: O(size()).
  *
@@ -275,7 +275,7 @@ public:
   /// Non-owning, zero-copy read-only `N`-dimensional view of this storage's buffer.
   using const_view_type = Aleph::mdspan<const T, Aleph::dextents<ca_size_t, N>>;
 
-  /** @brief Return a mutable `Aleph::mdspan` view of this storage.
+   /** @brief Return a mutable `Aleph::mdspan` view of this storage.
    *
    *  The view is a pointer plus the current `extents()`: it aliases this
    *  object's buffer directly (no allocation, no copy). It is invalidated
@@ -283,6 +283,9 @@ public:
    *  another storage, or `this` being destroyed) but not by an in-place
    *  `set()`/`fill()`/`at()` through the original storage or through the
    *  view itself — both read and write the same cells.
+   *
+   *  @par Complexity
+   *  O(1).
    *
    *  @par Example
    *  @code
@@ -294,10 +297,19 @@ public:
    *      std::cout << v(i, j) << " ";
    *  @endcode
    */
-  [[nodiscard]] view_type view() noexcept { return view_type(data(), ext_); }
+  [[nodiscard]] view_type view() noexcept
+  {
+    return view_type(data(), typename view_type::extents_type(ext_));
+  }
 
   /// \overload view() — read-only view over a `const` storage.
-  [[nodiscard]] const_view_type view() const noexcept { return const_view_type(data(), ext_); }
+  ///
+  /// @par Complexity
+  /// O(1).
+  [[nodiscard]] const_view_type view() const noexcept
+  {
+    return const_view_type(data(), typename const_view_type::extents_type(ext_));
+  }
 
   /// O(1) swap with another storage of the same type.
   void swap(Dense_Cell_Storage &other) noexcept

--- a/tpl_ca_storage.H
+++ b/tpl_ca_storage.H
@@ -59,6 +59,7 @@
 #include <utility>
 
 #include <ah-errors.H>
+#include <ah-mdspan.H>
 #include <tpl_array.H>
 
 #include <ca-traits.H>
@@ -267,6 +268,36 @@ public:
   {
     return total_cells_ == 0 ? nullptr : &buffer_[0];
   }
+
+  /// Non-owning, zero-copy `N`-dimensional view of this storage's buffer.
+  using view_type = Aleph::mdspan<T, Aleph::dextents<ca_size_t, N>>;
+
+  /// Non-owning, zero-copy read-only `N`-dimensional view of this storage's buffer.
+  using const_view_type = Aleph::mdspan<const T, Aleph::dextents<ca_size_t, N>>;
+
+  /** @brief Return a mutable `Aleph::mdspan` view of this storage.
+   *
+   *  The view is a pointer plus the current `extents()`: it aliases this
+   *  object's buffer directly (no allocation, no copy). It is invalidated
+   *  by anything that would also invalidate `data()` (e.g. `swap()` with
+   *  another storage, or `this` being destroyed) but not by an in-place
+   *  `set()`/`fill()`/`at()` through the original storage or through the
+   *  view itself — both read and write the same cells.
+   *
+   *  @par Example
+   *  @code
+   *  Dense_Cell_Storage<double, 2> grid({3, 4});
+   *  auto v = grid.view();
+   *  v(1, 2) = 5.0;              // same cell as grid.at({1, 2})
+   *  for (ca_size_t i = 0; i < v.extent(0); ++i)
+   *    for (ca_size_t j = 0; j < v.extent(1); ++j)
+   *      std::cout << v(i, j) << " ";
+   *  @endcode
+   */
+  [[nodiscard]] view_type view() noexcept { return view_type(data(), ext_); }
+
+  /// \overload view() — read-only view over a `const` storage.
+  [[nodiscard]] const_view_type view() const noexcept { return const_view_type(data(), ext_); }
 
   /// O(1) swap with another storage of the same type.
   void swap(Dense_Cell_Storage &other) noexcept

--- a/tpl_tree_node.H
+++ b/tpl_tree_node.H
@@ -29,7 +29,6 @@
   SOFTWARE.
 */
 
-
 /** @file tpl_tree_node.H
  *  @brief General tree (n-ary tree) node.
  *
@@ -41,1259 +40,1386 @@
  *  @author Leandro Rabindranath León
  */
 
-# ifndef TPL_TREE_H
-# define TPL_TREE_H
+#ifndef TPL_TREE_H
+#define TPL_TREE_H
 
-# include <stdexcept>
-# include <dlink.H>
-# include <ahDry.H>
-# include <ah-dry-mixin.H>
-# include <ahIterator.H>
-# include <ahFunction.H>
-# include <ahFunctional.H>
-# include <htlist.H>
-# include <tpl_dynListStack.H>
-# include <tpl_dynListQueue.H>
-# include <tpl_binNode.H>
-# include <ah-errors.H>
+#include <stdexcept>
+#include <dlink.H>
+#include <ahDry.H>
+#include <ah-dry-mixin.H>
+#include <ahIterator.H>
+#include <ahFunction.H>
+#include <ahFunctional.H>
+#include <htlist.H>
+#include <tpl_dynListStack.H>
+#include <tpl_dynListQueue.H>
+#include <tpl_binNode.H>
+#include <ah-errors.H>
 
-# define ISROOT(p)      ((p)->is_root())
-# define ISLEAF(p)      ((p)->is_leaf())
-# define ISLEFTMOST(p)  ((p)->is_leftmost())
-# define ISRIGHTMOST(p) ((p)->is_rightmost())
+#define ISROOT(p) ((p)->is_root())
+#define ISLEAF(p) ((p)->is_leaf())
+#define ISLEFTMOST(p) ((p)->is_leftmost())
+#define ISRIGHTMOST(p) ((p)->is_rightmost())
 
-# define SIBLING_LIST(p) ((p)->get_sibling_list())
-# define CHILD_LIST(p)   ((p)->get_child_list())
-# define SIBLING_LINK(p) ((p)->get_sibling_list())
-# define LCHILD(p)       ((p)->get_left_child())
-# define RSIBLING(p)     ((p)->get_right_sibling())
-# define IS_UNIQUE_SIBLING(p) (RSIBLING(p) == (p))
+#define SIBLING_LIST(p) ((p)->get_sibling_list())
+#define CHILD_LIST(p) ((p)->get_child_list())
+#define SIBLING_LINK(p) ((p)->get_sibling_list())
+#define LCHILD(p) ((p)->get_left_child())
+#define RSIBLING(p) ((p)->get_right_sibling())
+#define IS_UNIQUE_SIBLING(p) (SIBLING_LIST(p)->is_empty())
 
-namespace Aleph
+namespace Aleph {
+
+template <class T>
+class Tree_Node;  // Forward declaration for CRTP
+
+/** Generic m-ary tree node.
+
+    The Tree_Node<Key> class defines general trees of any order. Each
+    node owns two intrusive Dlink members: `sibling`, which links the
+    node with the other children of the same parent, and `child`, which
+    serves as the header of the node's child list.
+
+    @par Internal link invariants
+
+    The representation deliberately avoids storing an explicit parent
+    pointer. To make `get_parent()` O(1), the embedded `child` link also
+    participates in the chain from a parent to its leftmost descendant.
+    If a node is the leftmost child of its parent, that node's `child`
+    link is connected with the parent's child-list header. Walking left
+    across siblings to the leftmost node and then following this shared
+    child-list spine yields the parent.
+
+    Consequently, functions that change the first child or the first
+    sibling must preserve both structures at once:
+    - the horizontal sibling list described by `sibling`;
+    - the vertical leftmost-child spine described by `child`.
+
+    In particular, `insert_leftmost_child()`, `insert_rightmost_child()`,
+    `insert_left_sibling()`, `insert_right_sibling()`, `join()`, and
+    `insert_tree_to_right()` must keep the manual root/leaf/leftmost/
+    rightmost flags synchronized with the Dlink topology. A stale flag can
+    make navigation such as `get_parent()` return the wrong node or trip an
+    internal assertion.
+
+    @tparam T data type stored in each tree node.
+
+    @ingroup Trees
+*/
+template <class T>
+class Tree_Node : public FunctionalMixin<Tree_Node<T>, Tree_Node<T> *>
 {
+  T data;
+  Dlink child;
+  Dlink sibling;
 
-  /** Generic m-ary trees.
-
-      The Tree_Node<Key> class defines general trees of any order,
-      represented by linked lists.
-
-      @param Key the data type stored in each tree node.
-
-      @ingroup Trees
-  */
-  template <class T>
-  class Tree_Node;  // Forward declaration for CRTP
-
-  template <class T>
-  class Tree_Node : public FunctionalMixin<Tree_Node<T>, Tree_Node<T>*>
+  struct Flags
   {
-    T data;
-    Dlink child;
-    Dlink sibling;
+    unsigned int is_root : 1;
+    unsigned int is_leaf : 1;
+    unsigned int is_leftmost : 1;
+    unsigned int is_rightmost : 1;
+    Flags() noexcept : is_root(1), is_leaf(1), is_leftmost(1), is_rightmost(1) {}
+  };
 
-    struct Flags
-    {
-      unsigned int is_root          : 1;
-      unsigned int is_leaf          : 1;
-      unsigned int is_leftmost      : 1;
-      unsigned int is_rightmost     : 1;
-      Flags() noexcept
-      : is_root(1), is_leaf(1), is_leftmost(1), is_rightmost(1) {}
-    };
+  Flags flags;
 
-    Flags flags;
+  LINKNAME_TO_TYPE(Tree_Node, child);
+  LINKNAME_TO_TYPE(Tree_Node, sibling);
 
-    LINKNAME_TO_TYPE(Tree_Node, child);
-    LINKNAME_TO_TYPE(Tree_Node, sibling);
+  Tree_Node *upper_link() const noexcept
+  {
+    return child_to_Tree_Node(child.get_prev());
+  }
 
-    Tree_Node * upper_link() const noexcept
-    {
-      return child_to_Tree_Node(child.get_prev());
-    }
+  Tree_Node *lower_link() const noexcept
+  {
+    return child_to_Tree_Node(child.get_next());
+  }
 
-    Tree_Node * lower_link() const noexcept
-    {
-      return child_to_Tree_Node(child.get_next());
-    }
+  Tree_Node *left_link() const noexcept
+  {
+    return sibling_to_Tree_Node(sibling.get_prev());
+  }
 
-    Tree_Node * left_link() const noexcept
-    {
-      return sibling_to_Tree_Node(sibling.get_prev());
-    }
+  Tree_Node *right_link() const noexcept
+  {
+    return sibling_to_Tree_Node(sibling.get_next());
+  }
 
-    Tree_Node * right_link() const noexcept
-    {
-      return sibling_to_Tree_Node(sibling.get_next());
-    }
+public:
+  using Item_Type = Tree_Node *;
 
-  public:
+  /// Returns a modifiable reference to the node contents.
+  T &get_key() noexcept
+  {
+    return get_data();
+  }
 
-    using Item_Type = Tree_Node*;
+  [[nodiscard]] constexpr const T &get_key() const noexcept
+  {
+    return get_data();
+  }
 
-    /// Returns a modifiable reference to the node contents.
-    T & get_key() noexcept { return get_data(); }
+  /// Returns a modifiable reference to the node contents.
+  T &get_data() noexcept
+  {
+    return data;
+  }
 
-    [[nodiscard]] constexpr const T & get_key() const noexcept { return get_data(); }
+  [[nodiscard]] constexpr const T &get_data() const noexcept
+  {
+    return data;
+  }
 
-    /// Returns a modifiable reference to the node contents.
-    T & get_data() noexcept { return data; }
+  /// Generic data type stored in the node.
+  using key_type = T;
 
-    [[nodiscard]] constexpr const T & get_data() const noexcept { return data; }
+  /** Returns the embedded child-list link.
 
-    /// Generic data type stored in the node.
-    using key_type = T;
+      This is a low-level structural primitive used by tree algorithms and
+      tests. It is not a stable child iterator. Mutating the returned Dlink
+      directly requires preserving the child/sibling topology and the
+      root/leaf/leftmost/rightmost flags described in the class invariants.
 
-    Dlink * get_child_list() noexcept { return &child; }
+      @return pointer to the embedded Dlink used as this node's child-list
+      header and, for leftmost children, as part of the upward spine.
+  */
+  Dlink *get_child_list() noexcept
+  {
+    return &child;
+  }
 
-    Dlink * get_sibling_list() noexcept { return &sibling; }
+  /** Returns the embedded sibling-list link.
 
-    /// Returns true if this is the root of the general tree.
-    [[nodiscard]] constexpr bool is_root() const noexcept { return flags.is_root; }
+      This is a low-level structural primitive used by tree algorithms and
+      tests. It is not a public sibling iterator. Mutating the returned Dlink
+      directly requires keeping neighboring sibling flags and parent-spine
+      links consistent.
 
-    /// Returns true if this is a leaf node.
-    [[nodiscard]] constexpr bool is_leaf() const noexcept { return flags.is_leaf; }
+      @return pointer to the embedded Dlink that links this node with its
+      left and right siblings, or with adjacent roots when this node belongs
+      to a forest.
+  */
+  Dlink *get_sibling_list() noexcept
+  {
+    return &sibling;
+  }
 
-    /// Returns true if this is the leftmost node among its siblings.
-    [[nodiscard]] constexpr bool is_leftmost() const noexcept { return flags.is_leftmost; }
+  /// Returns true if this is the root of the general tree.
+  [[nodiscard]] constexpr bool is_root() const noexcept
+  {
+    return flags.is_root;
+  }
 
-    /// Returns true if this is the rightmost node among its siblings.
-    [[nodiscard]] constexpr bool is_rightmost() const noexcept { return flags.is_rightmost; }
+  /// Returns true if this is a leaf node.
+  [[nodiscard]] constexpr bool is_leaf() const noexcept
+  {
+    return flags.is_leaf;
+  }
 
-    void set_is_root(bool value) noexcept { flags.is_root = value; }
+  /// Returns true if this is the leftmost node among its siblings.
+  [[nodiscard]] constexpr bool is_leftmost() const noexcept
+  {
+    return flags.is_leftmost;
+  }
 
-    void set_is_leaf(bool value) noexcept { flags.is_leaf = value; }
+  /// Returns true if this is the rightmost node among its siblings.
+  [[nodiscard]] constexpr bool is_rightmost() const noexcept
+  {
+    return flags.is_rightmost;
+  }
 
-    void set_is_leftmost(bool value) noexcept { flags.is_leftmost = value; }
+  /** Sets the root flag.
 
-    void set_is_rightmost(bool value) noexcept { flags.is_rightmost = value; }
+      This is a low-level structural operation. It must only be used when the
+      Dlink topology already represents the same root/non-root state.
 
-    /// Empty constructor (undefined key).
-    Tree_Node() = default;
+      @param[in] value new root flag value.
+  */
+  void set_is_root(bool value) noexcept
+  {
+    flags.is_root = value;
+  }
 
-    /// Constructor with data value __data
-    Tree_Node(const T & d)
-      : data(d) { /* empty */ }
+  /** Sets the leaf flag.
 
-    Tree_Node(T && d)
-      : data(std::move(d)) { /* empty */ }
+      This is a low-level structural operation. It must only be used when the
+      child-list topology already represents the same leaf/non-leaf state.
 
-    /// Returns the left sibling of this.
-    Tree_Node * get_left_sibling() const noexcept
-    {
-      if (is_leftmost())
-        return nullptr;
+      @param[in] value new leaf flag value.
+  */
+  void set_is_leaf(bool value) noexcept
+  {
+    flags.is_leaf = value;
+  }
 
-      return left_link();
-    }
+  /** Sets the leftmost-sibling flag.
 
-    /// Returns the right sibling of this.
-    Tree_Node * get_right_sibling() const noexcept
-    {
-      if (is_rightmost())
-        return nullptr;
+      This is a low-level structural operation. It must only be used when the
+      sibling list and the leftmost-child parent spine already represent the
+      same state.
 
-      return right_link();
-    }
+      @param[in] value new leftmost flag value.
+  */
+  void set_is_leftmost(bool value) noexcept
+  {
+    flags.is_leftmost = value;
+  }
 
-    /// Returns the leftmost child of this.
-    Tree_Node * get_left_child() const noexcept
-    {
-      if (is_leaf())
-        return nullptr;
+  /** Sets the rightmost-sibling flag.
 
-      return lower_link();
-    }
+      This is a low-level structural operation. It must only be used when the
+      sibling list already represents the same rightmost/non-rightmost state.
 
-    /// Returns the rightmost child of this.
-    Tree_Node * get_right_child() const noexcept
-    {
-      if (is_leaf())
-        return nullptr;
+      @param[in] value new rightmost flag value.
+  */
+  void set_is_rightmost(bool value) noexcept
+  {
+    flags.is_rightmost = value;
+  }
 
-      const Tree_Node * left_child = lower_link();
+  /// Empty constructor (undefined key).
+  Tree_Node() = default;
 
-      assert(ISLEFTMOST(left_child));
+  /// Constructor with data value __data
+  Tree_Node(const T &d) : data(d)
+  { /* empty */
+  }
 
-      return left_child->left_link();
-    }
+  Tree_Node(T &&d) : data(std::move(d))
+  { /* empty */
+  }
 
-    /** Returns the i-th child of this.
+  /// Returns the left sibling of this.
+  Tree_Node *get_left_sibling() const noexcept
+  {
+    if (is_leftmost())
+      return nullptr;
 
-        Returns the i-th child of this.
+    return left_link();
+  }
 
-        @param[in] i ordinal of the child to access.
-        @return pointer to the i-th child of this; nullptr if it does not exist.
-    */
-    Tree_Node * get_child(const size_t i) const noexcept
-    {
-      Tree_Node * c = get_left_child();
-      for (size_t j = 0; c != nullptr and j < i; ++j)
-        c = c->get_right_sibling();
+  /// Returns the right sibling of this.
+  Tree_Node *get_right_sibling() const noexcept
+  {
+    if (is_rightmost())
+      return nullptr;
 
-      return c;
-    }
+    return right_link();
+  }
 
-    /// Returns the parent of this.
-    Tree_Node * get_parent() const noexcept
-    {
-      if (is_root())
-        return nullptr;
+  /// Returns the leftmost child of this.
+  Tree_Node *get_left_child() const noexcept
+  {
+    if (is_leaf())
+      return nullptr;
 
-      auto *  p = const_cast<Tree_Node*>(this);
-      while (not ISLEFTMOST(p)) // go down to the leftmost node
-        p = p->left_link();
+    return lower_link();
+  }
 
-      assert(not ISROOT(p));
-      assert(not CHILD_LIST(p)->is_empty());
+  /// Returns the rightmost child of this.
+  Tree_Node *get_right_child() const noexcept
+  {
+    if (is_leaf())
+      return nullptr;
 
-      return p->upper_link();
-    }
+    const Tree_Node *left_child = lower_link();
 
-    /** Inserts p as the right sibling of this.
+    assert(ISLEFTMOST(left_child));
 
-        Inserts p as the right sibling of this.
+    return left_child->left_link();
+  }
 
-        @param[in] p node to insert as right sibling.
-    */
-    void insert_right_sibling(Tree_Node * p) noexcept
-    {
-      if (p == nullptr)
+  /** Returns the i-th child of this.
+
+      Returns the i-th child of this.
+
+      @param[in] i ordinal of the child to access.
+      @return pointer to the i-th child of this; nullptr if it does not exist.
+  */
+  Tree_Node *get_child(const size_t i) const noexcept
+  {
+    Tree_Node *c = get_left_child();
+    for (size_t j = 0; c != nullptr and j < i; ++j)
+      c = c->get_right_sibling();
+
+    return c;
+  }
+
+  /// Returns the parent of this.
+  Tree_Node *get_parent() const noexcept
+  {
+    if (is_root())
+      return nullptr;
+
+    auto *p = const_cast<Tree_Node *>(this);
+    while (not ISLEFTMOST(p))  // go down to the leftmost node
+      p = p->left_link();
+
+    assert(not ISROOT(p));
+    assert(not CHILD_LIST(p)->is_empty());
+
+    return p->upper_link();
+  }
+
+  /** Inserts p to the right of this node.
+
+      If this node is not a root, `p` is inserted as the next sibling in the
+      same child list and therefore stops being a root. If this node is a
+      root, `p` is inserted as the next root in the same forest, preserving
+      `p->is_root()`.
+
+      @param[in] p node to insert as right sibling.
+  */
+  void insert_right_sibling(Tree_Node *p) noexcept
+  {
+    if (p == nullptr)
+      return;
+
+    assert(CHILD_LIST(p)->is_empty());
+    assert(SIBLING_LIST(p)->is_empty());
+    assert(p->is_rightmost() and p->is_leftmost() and p->is_root() and p->is_leaf());
+
+    if (this->is_root())
+      {
+        this->insert_tree_to_right(p);
         return;
-
-      assert(CHILD_LIST(p)->is_empty());
-      assert(SIBLING_LIST(p)->is_empty());
-      assert(p->is_rightmost() and p->is_leftmost() and p->is_root() and
-             p->is_leaf());
-
-      p->set_is_root(false);
-      p->set_is_leftmost(false);
-
-      Tree_Node * old_next_node = get_right_sibling();
-      if (old_next_node != nullptr)
-        {
-          assert(not this->is_rightmost());
-          p->set_is_rightmost(false);
-        }
-      else
-        {
-          assert(this->is_rightmost());
-          p->set_is_rightmost(true);
-        }
-
-      this->set_is_rightmost(false);
-      this->sibling.insert(SIBLING_LIST(p));
-    }
-
-    /** Inserts p as the left sibling of this.
-
-        Inserts p as the left sibling of this.
-
-        @param[in] p node to insert as left sibling.
-    */
-    void insert_left_sibling(Tree_Node * p)
-    {
-      if (p == nullptr)
-        return;
-
-      ah_domain_error_if(this->is_root())
-        << "Cannot insert sibling of a root";
-
-      assert(CHILD_LIST(p)->is_empty());
-      assert(SIBLING_LIST(p)->is_empty());
-      assert(p->is_rightmost() and p->is_leftmost() and p->is_root() and
-             p->is_leaf());
-
-      p->set_is_root(false);
-      p->set_is_rightmost(false);
-
-      Tree_Node * old_prev_node = this->get_left_sibling();
-      if (old_prev_node != nullptr)
-        {
-          assert(not this->is_leftmost());
-          p->set_is_leftmost(false);
-        }
-      else
-        { // this is the leftmost ==> p must become the first child
-          assert(this->is_leftmost());
-
-          Tree_Node * parent = this->get_parent();
-
-          // Find the tree root. To do so, we look for the leaf of this
-          Tree_Node * leaf = this;
-          while (not leaf->is_leaf())
-            {
-              leaf = leaf->get_left_child();
-              assert(leaf != nullptr);
-            }
-
-          Tree_Node * root = leaf->lower_link();
-          assert(root != nullptr);
-
-          Dlink tree = CHILD_LIST(root)->cut_list(CHILD_LIST(this));
-          tree.del();
-          CHILD_LIST(parent)->insert(CHILD_LIST(p));
-          p->set_is_leftmost(true);
-
-          assert(p->get_parent() == parent);
-        }
-
-      this->set_is_leftmost(false);
-      this->sibling.append(SIBLING_LIST(p));
-    }
-
-    /** Inserts p as the leftmost child of this.
-
-        @param[in] p node to insert.
-    */
-    void insert_leftmost_child(Tree_Node * p) noexcept
-    {
-      if (p == nullptr)
-        return;
-
-      assert(CHILD_LIST(p)->is_empty());
-      assert(SIBLING_LIST(p)->is_empty());
-      assert(p->is_rightmost() and p->is_leftmost() and p->is_root() and
-             p->is_leaf());
-
-      p->set_is_root(false);
-      if (this->is_leaf())
-        {
-          this->set_is_leaf(false);
-          CHILD_LIST(this)->insert(CHILD_LIST(p));
-        }
-      else
-        {
-          Tree_Node * old_left_child = this->lower_link();
-          Tree_Node * leaf = old_left_child;
-          while (not leaf->is_leaf())
-            leaf = leaf->get_left_child();
-
-          Tree_Node * root = leaf->lower_link();
-          Dlink subtree = CHILD_LIST(root)->cut_list(CHILD_LIST(old_left_child));
-          subtree.del();
-          CHILD_LIST(this)->insert(CHILD_LIST(p));
-          SIBLING_LIST(old_left_child)->append(SIBLING_LIST(p));
-          old_left_child->set_is_leftmost(false);
-          p->set_is_rightmost(false);
-          assert(p->get_right_sibling() == old_left_child);
-          assert(old_left_child->get_left_sibling() == p);
-        }
-      assert(p->is_leftmost());
-    }
-
-    /** Inserts p as the rightmost child of this.
-
-        @param[in] p node to insert.
-    */
-    void insert_rightmost_child(Tree_Node * p) noexcept
-    {
-      if (p == nullptr)
-        return;
-
-      assert(CHILD_LIST(p)->is_empty());
-      assert(SIBLING_LIST(p)->is_empty());
-      assert(p->is_rightmost() and p->is_leftmost() and p->is_root() and
-             p->is_leaf());
-
-      p->set_is_root(false);
-
-      if (this->is_leaf())
-        {
-          this->set_is_leaf(false);
-          CHILD_LIST(this)->insert(CHILD_LIST(p));
-        }
-      else
-        {
-          Tree_Node * old_right_child_node = this->lower_link()->left_link();
-          old_right_child_node->set_is_rightmost(false);
-          p->set_is_leftmost(false);
-          SIBLING_LIST(old_right_child_node)->insert(SIBLING_LIST(p));
-        }
-    }
-
-    /// join `tree` as subtree of root `this`
-    Tree_Node * join(Tree_Node * tree)
-    {
-      assert(this->is_root());
-      assert(tree != nullptr);
-      assert(tree->is_root() and tree->is_leftmost() and tree->is_rightmost());
-
-      tree->set_is_root(false);
-
-      if (this->is_leaf())
-        {
-          assert(CHILD_LIST(this)->is_empty() and
-                 SIBLING_LIST(this)->is_empty());
-          this->set_is_leaf(false);
-          CHILD_LIST(this)->splice(CHILD_LIST(tree));
-        }
-      else
-        {
-          Tree_Node * right_child = this->lower_link()->left_link();
-          right_child->set_is_rightmost(false);
-          tree->set_is_leftmost(false);
-          SIBLING_LINK(right_child)->splice(SIBLING_LINK(tree));
-        }
-
-      return this;
-    }
-
-    /** Insert `tree` to the right of `this`
-
-        Assuming that `this` is part of a forrest, this method
-        insert `tree` to the right of this.
-
-        Be careful with the fact that `tree` will not always be
-        inserted as the rightmost tree, but as the tree to right of
-        `this`.
-
-        @param[in] tree the tree to insert
-        @throw domain_error if tree is not root
-    */
-    void insert_tree_to_right(Tree_Node * tree)
-    {
-      if (tree == nullptr)
-        return;
-
-      ah_domain_error_if(not this->is_root())
-        << "\"this\" is not root";
-
-      tree->set_is_leftmost(false);
-      Tree_Node * old_next_tree = this->get_right_tree();
-      if (old_next_tree != nullptr)
-        {
-          assert(not this->is_rightmost());
-          tree->set_is_rightmost(false);
-        }
-
-      this->set_is_rightmost(false);
-      SIBLING_LIST(this)->insert(SIBLING_LIST(tree));
-    }
-
-    /// Returns the tree to the left of this.
-    Tree_Node * get_left_tree() const noexcept
-    {
-      if (is_leftmost())
-        return nullptr;
-      assert(not is_leftmost());
-      return left_link();
-    }
-
-    /// Returns the tree to the right of this.
-    Tree_Node * get_right_tree() const noexcept
-    {
-      if (is_rightmost())
-        return nullptr;
-
-      assert(not is_rightmost());
-      return right_link();
-    }
-
-    /// Returns the rightmost tree of the forest containing this.
-    /// Throws range_error if this is not the leftmost tree of the forest.
-    Tree_Node * get_last_tree() const
-    {
-      ah_range_error_if(not is_leftmost())
-        << "\"this\" is not the leftmost tree in the forest";
-
-      return left_link();
-    }
-
-    /// Return a list with all trees belonging to the forrest
-    template <template <typename> class Container = DynList>
-    Container<Tree_Node*> trees() const
-    {
-      Container<Tree_Node*> ret;
-      for (auto t = const_cast<Tree_Node*>(this); t != nullptr;
-           t = t->get_right_tree())
-        ret.append(t);
-      return ret;
-    }
-
-    /// Visits each child of this and executes the operation on the child node.
-    template <typename Operation>
-    void for_each_child(Operation & op) const
-    {
-      for (Tree_Node * child = get_left_child(); child != nullptr;
-           child = child->get_right_sibling())
-        op(child);
-    }
-
-    template <typename Operation>
-    void for_each_child(Operation && op = Operation()) const
-    {
-      for_each_child<Operation>(op);
-    }
-
-    /// Returns a list with the child nodes of this.
-    template <template <typename> class Container = DynList>
-    Container<Tree_Node*> children_nodes() const
-    {
-      Container<Tree_Node*> ret_val;
-      this->for_each_child([&ret_val] (Tree_Node * p) { ret_val.append(p); });
-      return ret_val;
-    }
-
-    /// Returns a list with the contents of the children of this.
-    template <template <typename> class Container = DynList>
-    Container<T> children() const
-    {
-      Container<T> ret_val;
-      this->for_each_child([&ret_val] (Tree_Node * p)
-                           {
-                             ret_val.append(p->get_key());
-                           });
-      return ret_val;
-    }
-
-  private:
-
-    template <class Operation> static
-    bool preorder(const Tree_Node * root, Operation & op)
-    {
-      if (root == nullptr)
-        return true;
-
-      if (not op(root))
-        return false;
-
-      for (Tree_Node * child = root->get_left_child(); child != nullptr;
-           child = child->get_right_sibling())
-        if (not preorder(child, op))
-          return false;
-
-      return true;
-    }
-
-  public:
-
-    /// Preorder traversal over all nodes executing op.
-    template <class Operation>
-    bool traverse(Operation op)
-    {
-      return preorder(this, op);
-    }
-
-    template <class Operation>
-    bool traverse(Operation op) const
-    {
-      return const_cast<Tree_Node*>(this)->traverse(op);
-    }
-
-    template <class Op> bool level_traverse(Op op)
-    {
-      DynListQueue<Tree_Node*> q;
-      q.put(this);
-      while (not q.is_empty())
-        {
-          Tree_Node * p = q.get();
-          if (not op(p))
-            return false;
-          p->for_each_child([&q] (auto cptr) { q.put(cptr); });
-        }
-      return true;
-    }
-
-    template <class Op> bool level_traverse(Op op) const
-    {
-      return const_cast<Tree_Node*>(this)->level_traverse(op);
-    }
-
-    // Note: for_each(), all(), exists(), maps(), filter(), foldl(), 
-    // fold(), partition(), take(), drop(), rev(), length() are now 
-    // provided by FunctionalMixin<Tree_Node<T>, Tree_Node<T>*>
-
-    /** Iterator over the children of this
-
-     */
-    class Children_Iterator
-    {
-      Tree_Node * curr = nullptr;
-
-    public:
-
-      Children_Iterator(const Tree_Node & p) noexcept
-        : curr(p.get_left_child()) {}
-
-      Children_Iterator(Tree_Node & p) noexcept
-        : curr(p.get_left_child()) {}
-
-      Children_Iterator(Tree_Node * p) noexcept
-        : curr(p->get_left_child()) {}
-
-      Children_Iterator(const Children_Iterator & it) noexcept
-        : curr(const_cast<Children_Iterator&>(it).curr) {}
-
-      [[nodiscard]] bool has_curr() const noexcept { return curr != nullptr; }
-
-      Tree_Node * get_curr_ne() const noexcept { return curr; }
-
-      Tree_Node * get_curr() const
-      {
-        ah_overflow_error_if(curr == nullptr) << "Children_Iterator::get_curr()";
-        return get_curr_ne();
       }
 
-      void next_ne() noexcept { curr = curr->get_right_sibling(); }
+    p->set_is_root(false);
+    p->set_is_leftmost(false);
 
-      void next()
+    Tree_Node *old_next_node = get_right_sibling();
+    if (old_next_node != nullptr)
       {
-        ah_overflow_error_if(curr == nullptr) << "Children_Iterator::next()";
-        next_ne();
+        assert(not this->is_rightmost());
+        p->set_is_rightmost(false);
       }
-    };
-
-    Children_Iterator children_it() const
-    {
-      return Children_Iterator(*this);
-    }
-
-    struct Children_Set // trick to use Pair_Iterator
-    {
-      Children_Set(const Tree_Node &&) {}
-      Children_Set(const Tree_Node &) {}
-      struct Iterator : public Children_Iterator
+    else
       {
-        using Children_Iterator::Children_Iterator;
-      };
-    };
-
-    class Iterator
-    {
-      Tree_Node * root = nullptr;
-      Tree_Node * curr = nullptr;
-      long pos = 0;
-      DynListStack<Tree_Node*> s;
-
-    public:
-
-      using Item_Type = Tree_Node*;
-
-      void swap(Iterator & it) noexcept
-      {
-        std::swap(root, it.root);
-        std::swap(curr, it.curr);
-        std::swap(pos, it.pos);
-        s.swap(it.s);
+        assert(this->is_rightmost());
+        p->set_is_rightmost(true);
       }
 
-      Iterator(Tree_Node * r = nullptr) noexcept
-        : root(r), curr(root)
+    this->set_is_rightmost(false);
+    this->sibling.insert(SIBLING_LIST(p));
+  }
+
+  /** Inserts p as the left sibling of this.
+
+      Inserts p as the left sibling of this.
+
+      @param[in] p node to insert as left sibling.
+  */
+  void insert_left_sibling(Tree_Node *p)
+  {
+    if (p == nullptr)
+      return;
+
+    ah_domain_error_if(this->is_root()) << "Cannot insert sibling of a root";
+
+    assert(CHILD_LIST(p)->is_empty());
+    assert(SIBLING_LIST(p)->is_empty());
+    assert(p->is_rightmost() and p->is_leftmost() and p->is_root() and p->is_leaf());
+
+    p->set_is_root(false);
+    p->set_is_rightmost(false);
+
+    Tree_Node *old_prev_node = this->get_left_sibling();
+    if (old_prev_node != nullptr)
       {
-        // empty
+        assert(not this->is_leftmost());
+        p->set_is_leftmost(false);
       }
+    else
+      {  // this is the leftmost ==> p must become the first child
+        assert(this->is_leftmost());
 
-      Iterator(Tree_Node & root) : Iterator(&root) {}
+        Tree_Node *parent = this->get_parent();
 
-      Iterator(const Iterator & it)
-        : root(it.root), curr(it.curr), pos(it.pos), s(it.s)
-      {
-        // empty
-      }
-
-      Iterator(Iterator && it) noexcept
-        : root(nullptr), curr(nullptr), pos(0), s()
-      {
-        swap(it);
-      }
-
-      Iterator & operator = (Iterator it)
-      {
-        it.swap(*this);
-        return *this;
-      }
-
-      void reset_first() noexcept
-      {
-        s.empty();
-        pos = 0;
-        curr = root;
-      }
-
-      [[nodiscard]] bool has_curr() const noexcept { return curr != nullptr; }
-
-      Tree_Node * get_curr_ne() const noexcept { return curr; }
-
-      Tree_Node * get_curr() const
-      {
-        ah_overflow_error_if(not has_curr()) << "Iterator overflow";
-        return get_curr_ne();
-      }
-
-      void next_ne() noexcept
-      {
-        ++pos;
-        Tree_Node * lchild = curr->get_left_child();
-        if (lchild == nullptr)
+        // Find the tree root. To do so, we look for the leaf of this
+        Tree_Node *leaf = this;
+        while (not leaf->is_leaf())
           {
-            if (s.is_empty())
-              curr = nullptr;
-            else
-              curr = s.pop();
-
-            return;
+            leaf = leaf->get_left_child();
+            assert(leaf != nullptr);
           }
 
-        for (auto p = curr->get_right_child(); p != lchild;
-             p = p->get_left_sibling())
-          s.push(p);
+        Tree_Node *root = leaf->lower_link();
+        assert(root != nullptr);
 
-        curr = lchild;
+        Dlink tree = CHILD_LIST(root)->cut_list(CHILD_LIST(this));
+        tree.del();
+        CHILD_LIST(parent)->insert(CHILD_LIST(p));
+        p->set_is_leftmost(true);
+
+        assert(p->get_parent() == parent);
       }
 
-      void next()
-      {
-        ah_overflow_error_if(not has_curr()) << "Iterator overflow";
-        next_ne();
-      }
+    this->set_is_leftmost(false);
+    this->sibling.append(SIBLING_LIST(p));
+  }
 
-      void end()
-      {
-        curr = nullptr;
-        s.empty();
-        pos = -1;
-      }
+  /** Inserts p as the leftmost child of this.
 
-      /// Return the current position of the iterator. Only valid if
-      // has_curr() == true
-      [[nodiscard]] size_t get_pos() const { return pos; }
-    };
-
-    Iterator get_it() const
-    {
-      return Iterator(const_cast<Tree_Node*>(this));
-    }
-
-    STL_ALEPH_ITERATOR(Tree_Node);
-  };
-
-  template <typename T>
-  struct Tree_Node_Vtl : public Tree_Node<T>
+      @param[in] p node to insert.
+  */
+  void insert_leftmost_child(Tree_Node *p) noexcept
   {
-    virtual ~Tree_Node_Vtl() = default;
-  };
+    if (p == nullptr)
+      return;
 
-  template <class Node> static inline
-  void clone_tree(Node * src, Node * tgt)
-  {
-    using It = typename Node::Children_Iterator;
-    for (It it(src); it.has_curr(); it.next_ne())
-      tgt->insert_rightmost_child(new Node(it.get_curr()->get_key()));
+    assert(CHILD_LIST(p)->is_empty());
+    assert(SIBLING_LIST(p)->is_empty());
+    assert(p->is_rightmost() and p->is_leftmost() and p->is_root() and p->is_leaf());
 
-    using PItor = Pair_Iterator<It>;
-    for (PItor itor{It(*src), It(*tgt)}; itor.has_curr(); itor.next_ne())
+    p->set_is_root(false);
+    if (this->is_leaf())
       {
-        auto p = itor.get_curr();
-        clone_tree(p.first, p.second);
+        this->set_is_leaf(false);
+        CHILD_LIST(this)->insert(CHILD_LIST(p));
+      }
+    else
+      {
+        Tree_Node *old_left_child = this->lower_link();
+        Tree_Node *leaf = old_left_child;
+        while (not leaf->is_leaf())
+          leaf = leaf->get_left_child();
+
+        Tree_Node *root = leaf->lower_link();
+        Dlink subtree = CHILD_LIST(root)->cut_list(CHILD_LIST(old_left_child));
+        subtree.del();
+        CHILD_LIST(this)->insert(CHILD_LIST(p));
+        SIBLING_LIST(old_left_child)->append(SIBLING_LIST(p));
+        old_left_child->set_is_leftmost(false);
+        p->set_is_rightmost(false);
+        assert(p->get_right_sibling() == old_left_child);
+        assert(old_left_child->get_left_sibling() == p);
+      }
+    assert(p->is_leftmost());
+  }
+
+  /** Inserts p as the rightmost child of this.
+
+      @param[in] p node to insert.
+  */
+  void insert_rightmost_child(Tree_Node *p) noexcept
+  {
+    if (p == nullptr)
+      return;
+
+    assert(CHILD_LIST(p)->is_empty());
+    assert(SIBLING_LIST(p)->is_empty());
+    assert(p->is_rightmost() and p->is_leftmost() and p->is_root() and p->is_leaf());
+
+    p->set_is_root(false);
+
+    if (this->is_leaf())
+      {
+        this->set_is_leaf(false);
+        CHILD_LIST(this)->insert(CHILD_LIST(p));
+      }
+    else
+      {
+        Tree_Node *old_right_child_node = this->lower_link()->left_link();
+        old_right_child_node->set_is_rightmost(false);
+        p->set_is_leftmost(false);
+        SIBLING_LIST(old_right_child_node)->insert(SIBLING_LIST(p));
       }
   }
 
-  template <class Node>
-  Node * clone_tree(Node * root)
+  /// join `tree` as subtree of root `this`
+  Tree_Node *join(Tree_Node *tree)
   {
-    if (root == nullptr)
+    assert(this->is_root());
+    assert(tree != nullptr);
+    assert(tree->is_root() and tree->is_leftmost() and tree->is_rightmost());
+
+    tree->set_is_root(false);
+
+    if (this->is_leaf())
+      {
+        assert(CHILD_LIST(this)->is_empty() and SIBLING_LIST(this)->is_empty());
+        this->set_is_leaf(false);
+        CHILD_LIST(this)->splice(CHILD_LIST(tree));
+      }
+    else
+      {
+        Tree_Node *right_child = this->lower_link()->left_link();
+        right_child->set_is_rightmost(false);
+        tree->set_is_leftmost(false);
+        SIBLING_LINK(right_child)->splice(SIBLING_LINK(tree));
+      }
+
+    return this;
+  }
+
+  /** Insert `tree` to the right of `this`
+
+      Assuming that `this` is part of a forrest, this method
+      insert `tree` to the right of this.
+
+      Be careful with the fact that `tree` will not always be
+      inserted as the rightmost tree, but as the tree to right of
+      `this`.
+
+      @param[in] tree the tree to insert
+      @throw domain_error if tree is not root
+  */
+  void insert_tree_to_right(Tree_Node *tree)
+  {
+    if (tree == nullptr)
+      return;
+
+    ah_domain_error_if(not this->is_root()) << "\"this\" is not root";
+
+    tree->set_is_leftmost(false);
+    Tree_Node *old_next_tree = this->get_right_tree();
+    if (old_next_tree != nullptr)
+      {
+        assert(not this->is_rightmost());
+        tree->set_is_rightmost(false);
+      }
+
+    this->set_is_rightmost(false);
+    SIBLING_LIST(this)->insert(SIBLING_LIST(tree));
+  }
+
+  /// Returns the tree to the left of this.
+  Tree_Node *get_left_tree() const noexcept
+  {
+    if (is_leftmost())
       return nullptr;
-    Node * ret = new Node(root->get_key());
-    clone_tree(root, ret);
+    assert(not is_leftmost());
+    return left_link();
+  }
+
+  /// Returns the tree to the right of this.
+  Tree_Node *get_right_tree() const noexcept
+  {
+    if (is_rightmost())
+      return nullptr;
+
+    assert(not is_rightmost());
+    return right_link();
+  }
+
+  /// Returns the rightmost tree of the forest containing this.
+  /// Throws range_error if this is not the leftmost tree of the forest.
+  Tree_Node *get_last_tree() const
+  {
+    ah_range_error_if(not is_leftmost()) << "\"this\" is not the leftmost tree in the forest";
+
+    return left_link();
+  }
+
+  /// Return a list with all trees belonging to the forrest
+  template <template <typename> class Container = DynList>
+  Container<Tree_Node *> trees() const
+  {
+    Container<Tree_Node *> ret;
+    for (auto t = const_cast<Tree_Node *>(this); t != nullptr; t = t->get_right_tree())
+      ret.append(t);
     return ret;
   }
 
-  template <class Node> static inline
-  void __tree_preorder_traversal(Node * root, const int & level,
-                                 const int & child_index,
-                                 void (*visitFct)(Node *, int, int))
+  /// Visits each child of this and executes the operation on the child node.
+  template <typename Operation>
+  void for_each_child(Operation &op) const
   {
-    (*visitFct)(root, level, child_index);
-    Node * child = root->get_left_child();
-    for (int i = 0; child != nullptr; ++i, child = child->get_right_sibling())
-      __tree_preorder_traversal(child, level + 1, i, visitFct);
+    for (Tree_Node *child = get_left_child(); child != nullptr; child = child->get_right_sibling())
+      op(child);
   }
 
-  /** Preorder traversal of a tree.
-
-      tree_preorder_traversal((root,visit) performs a preorder traversal
-      over the tree rooted at root. If visitFct is specified,
-      then for each visited node the function is invoked.
-
-      The visit function has the following specification:
-
-      void (*visitFct)(Node* p, int level, int pos)
-
-      Where:
-      -# p: pointer to the currently visited node.
-      -# level: the level of p in the tree.
-      -# child_index: index of p among its siblings.
-
-      @param[in] root root of the tree to traverse.
-      @param[in] visitFct pointer to the visit function.
-      @see forest_preorder_traversal() tree_postorder_traversal()
-      @see forest_postorder_traversal()
-      @throw domain_error if root is not a root node of a tree.
-      @ingroup Trees
-  */
-  template <class Node> inline
-  void tree_preorder_traversal(Node * root, void (*visitFct)(Node *, int, int))
+  template <typename Operation>
+  void for_each_child(Operation &&op = Operation()) const
   {
-
-    ah_domain_error_if(not root->is_root())
-      << "root is not root";
-
-    __tree_preorder_traversal(root, 0, 0, visitFct);
+    for_each_child<Operation>(op);
   }
 
-  /** Preorder traversal of a forest.
-
-      forest_preorder_traversal((root,visit) performs a preorder traversal
-      over the forest whose first tree is root. If visitFct is specified,
-      then for each visited node the function is invoked.
-
-      The visit function has the following specification:
-
-      void (*visitFct)(Node* p, int level, int pos)
-
-      Where:
-      -# p: pointer to the currently visited node.
-      -# level: the level of p in the tree.
-      -# child_index: index of p among its siblings.
-
-      @param[in] root root of the first tree in the forest.
-      @param[in] visitFct pointer to the visit function.
-      @throw domain_error if root is not a root node of a tree.
-      @see tree_preorder_traversal() tree_postorder_traversal()
-      @see forest_postorder_traversal()
-      @ingroup Trees
-  */
-  template <class Node> inline
-  void forest_preorder_traversal(Node * root,
-                                 void (*visitFct)(Node *, int, int))
+  /// Returns a list with the child nodes of this.
+  template <template <typename> class Container = DynList>
+  Container<Tree_Node *> children_nodes() const
   {
-    ah_domain_error_if(not root->is_root()) << "root is not root";
-
-    for (/* nothing */; root != nullptr; root = root->get_right_tree())
+    Container<Tree_Node *> ret_val;
+    this->for_each_child([&ret_val](Tree_Node *p)
       {
-        assert(root->is_root());
-        __tree_preorder_traversal(root, 0, 0, visitFct);
-      }
+        ret_val.append(p);
+      });
+    return ret_val;
   }
 
-  template <class Node> static inline
-  void __tree_postorder_traversal(Node * node, const int & level,
-                                  const int & child_index,
-                                  void (*visitFct)(Node *, int, int))
+  /// Returns a list with the contents of the children of this.
+  template <template <typename> class Container = DynList>
+  Container<T> children() const
   {
-    Node * child = node->get_left_child();
-
-    for (int i = 0; child not_eq nullptr;
-         i++, child = child->get_right_sibling())
-      __tree_postorder_traversal(child, level + 1, i, visitFct);
-
-    (*visitFct)(node, level, child_index);
-  }
-
-  /** Postorder traversal of a tree.
-
-      tree_postorder_traversal((root,visit) performs a postorder traversal
-      over the tree rooted at root. If visitFct is specified,
-      then for each visited node the function is invoked.
-
-      The visit function has the following specification:
-
-      void (*visitFct)(Node* p, int level, int pos)
-
-      Where:
-      -# p: pointer to the currently visited node.
-      -# level: the level of p in the tree.
-      -# child_index: index of p among its siblings.
-
-      @param[in] root root of the tree to traverse.
-      @param[in] visitFct pointer to the visit function.
-      @see forest_preorder_traversal() tree_preorder_traversal()
-      @see forest_postorder_traversal()
-      @ingroup Trees
-  */
-  template <class Node> inline
-  void tree_postorder_traversal(Node * root, void (*visitFct)(Node *, int, int))
-  {
-    __tree_postorder_traversal(root, 0, 0, visitFct);
-  }
-
-  /** Postorder traversal of a forest.
-
-      forest_postorder_traversal((root,visit) performs a postorder traversal
-      over the forest whose first tree is root. If visitFct is specified,
-      then for each visited node the function is invoked.
-
-      The visit function has the following specification:
-
-      void (*visitFct)(Node* p, int level, int pos)
-
-      Where:
-      -# p: pointer to the currently visited node.
-      -# level: the level of p in the tree.
-      -# child_index: index of p among its siblings.
-
-      @param[in] root root of the tree to traverse.
-      @param[in] visitFct pointer to the visit function.
-      @see forest_preorder_traversal() tree_preorder_traversal()
-      @see tree_postorder_traversal()
-      @throw domain_error if root is not the root node of the leftmost tree
-      of the forest.
-      @ingroup Trees
-  */
-  template <class Node> inline
-  void forest_postorder_traversal(Node * root, void (*visitFct)(Node *, int, int))
-  {
-    ah_domain_error_if(not root->is_leftmost()) << "root is not the leftmost node of forest";
-
-    ah_domain_error_if(not root->is_root()) << "root is not root";
-
-    for (/* nothing */; root not_eq nullptr; root = root->get_right_sibling())
+    Container<T> ret_val;
+    this->for_each_child([&ret_val](Tree_Node *p)
       {
-        assert(root->is_root());
-        __tree_postorder_traversal(root, 0, 0, visitFct);
-      }
+        ret_val.append(p->get_key());
+      });
+    return ret_val;
   }
 
-  /** Returns true if t1 is equal to t2
-
-      @ingroup Trees
-  */
-  template <class Node, class Eq>
-  inline bool are_tree_equal(Node * t1, Node * t2, Eq & eq)
+private:
+  template <class Operation>
+  static bool preorder(const Tree_Node *root, Operation &op)
   {
-    if (t1 == nullptr)
-      return t2 == nullptr;
+    if (root == nullptr)
+      return true;
 
-    if (t2 == nullptr)
+    if (not op(root))
       return false;
 
-    if (not eq(t1->get_key(), t2->get_key()))
-      return false;
-
-    try
-      {
-        return zipEq(t1->children_nodes(), t2->children_nodes()).
-          all([&eq] (auto p)
-              {
-                return are_tree_equal(p.first, p.second, eq);
-              });
-      }
-    catch (const std::length_error &)
-      {
+    for (Tree_Node *child = root->get_left_child(); child != nullptr;
+         child = child->get_right_sibling())
+      if (not preorder(child, op))
         return false;
-      }
+
+    return true;
   }
 
-  template <class Node,
-            class Eq = std::equal_to<typename Node::key_type>>
-  inline bool are_tree_equal(Node * t1, Node * t2, Eq && eq = Eq())
+public:
+  /// Preorder traversal over all nodes executing op.
+  template <class Operation>
+  bool traverse(Operation op)
   {
-    return are_tree_equal<Node, Eq>(t1, t2, eq);
+    return preorder(this, op);
   }
 
-  /** Destroys (frees memory) the tree whose root is root.
-
-      destroy_tree(root) frees all the memory occupied by the
-      tree whose root is root.
-
-      @param[in] root root of the tree to be freed.
-      @ingroup Trees
-  */
-  template <class Node> inline
-  void destroy_tree(Node * root)
+  template <class Operation>
+  bool traverse(Operation op) const
   {
-    if (root == nullptr)
-      return;
+    return const_cast<Tree_Node *>(this)->traverse(op);
+  }
 
-    if (not IS_UNIQUE_SIBLING(root))
-      SIBLING_LIST(root)->del(); // no ==> remove from sibling list
-
-    // traverse subtrees from right to left
-    for (Node * p = static_cast<Node *>(root->get_right_child()); p != nullptr; /* nada */)
+  template <class Op>
+  bool level_traverse(Op op)
+  {
+    DynListQueue<Tree_Node *> q;
+    q.put(this);
+    while (not q.is_empty())
       {
-        Node * to_delete = p;      // backup subtree to delete
-        p = static_cast<Node *>(p->get_left_sibling()); // advance to left sibling
-        destroy_tree(to_delete);   // recursively delete tree
+        Tree_Node *p = q.get();
+        if (not op(p))
+          return false;
+        p->for_each_child([&q](auto cptr)
+          {
+            q.put(cptr);
+          });
       }
-
-    if (root->is_leftmost()) // remove children list?
-      CHILD_LIST(root)->del();
-
-    delete root;
+    return true;
   }
 
-  /** Destroys (frees memory) the forest whose first tree is root.
+  template <class Op>
+  bool level_traverse(Op op) const
+  {
+    return const_cast<Tree_Node *>(this)->level_traverse(op);
+  }
 
-      destroy_forest(root) frees all the memory occupied by the
-      forest whose first tree has root as its root.
+  // Note: for_each(), all(), exists(), maps(), filter(), foldl(),
+  // fold(), partition(), take(), drop(), rev(), length() are now
+  // provided by FunctionalMixin<Tree_Node<T>, Tree_Node<T>*>
 
-      @param[in] root root of the first tree of the forest
-      to be destroyed.
-      @throw domain_error if root is not the root node of the leftmost
-      tree of the forest.
-      @ingroup Trees
+  /** Iterator over the children of this
+
+   */
+  class Children_Iterator
+  {
+    Tree_Node *curr = nullptr;
+
+  public:
+    Children_Iterator(const Tree_Node &p) noexcept : curr(p.get_left_child()) {}
+
+    Children_Iterator(Tree_Node &p) noexcept : curr(p.get_left_child()) {}
+
+    Children_Iterator(Tree_Node *p) noexcept : curr(p->get_left_child()) {}
+
+    Children_Iterator(const Children_Iterator &it) noexcept
+      : curr(it.curr)
+    {}
+
+    [[nodiscard]] bool has_curr() const noexcept
+    {
+      return curr != nullptr;
+    }
+
+    Tree_Node *get_curr_ne() const noexcept
+    {
+      return curr;
+    }
+
+    Tree_Node *get_curr() const
+    {
+      ah_overflow_error_if(curr == nullptr) << "Children_Iterator::get_curr()";
+      return get_curr_ne();
+    }
+
+    void next_ne() noexcept
+    {
+      curr = curr->get_right_sibling();
+    }
+
+    void next()
+    {
+      ah_overflow_error_if(curr == nullptr) << "Children_Iterator::next()";
+      next_ne();
+    }
+  };
+
+  Children_Iterator children_it() const
+  {
+    return Children_Iterator(*this);
+  }
+
+  /** Adapter that exposes a node's children through an Iterator type.
+
+      This small wrapper exists for generic iterator utilities that expect a
+      container-like type with a nested `Iterator`, such as Pair_Iterator-based
+      code. It does not own nodes and does not change the tree.
   */
-  template <class Node> inline
-  void destroy_forest(Node * root)
+  struct Children_Set
   {
-    if (root == nullptr)
-      return;
+    Children_Set(const Tree_Node &&) {}
+    Children_Set(const Tree_Node &) {}
+    struct Iterator : public Children_Iterator
+    {
+      using Children_Iterator::Children_Iterator;
+    };
+  };
 
-    ah_domain_error_if(not root->is_leftmost()) << "root is not the leftmost tree of forest";
+  class Iterator
+  {
+    Tree_Node *root = nullptr;
+    Tree_Node *curr = nullptr;
+    long pos = 0;
+    DynListStack<Tree_Node *> s;
 
-    ah_domain_error_if(not root->is_root()) << "root is not root";
+  public:
+    using Item_Type = Tree_Node *;
 
-    while (root != nullptr) // traverse trees from left to right
-      {
-        Node * to_delete = root;          // backup root
-        root = (Node*) root->get_right_sibling(); // advance to next tree
-        SIBLING_LIST(to_delete)->del();   // remove from tree list
-        destroy_tree(to_delete);          // delete the tree
-      }
+    void swap(Iterator &it) noexcept
+    {
+      std::swap(root, it.root);
+      std::swap(curr, it.curr);
+      std::swap(pos, it.pos);
+      s.swap(it.s);
+    }
+
+    Iterator(Tree_Node *r = nullptr) noexcept : root(r), curr(root)
+    {
+      // empty
+    }
+
+    Iterator(Tree_Node &root) : Iterator(&root) {}
+
+    Iterator(const Iterator &it) : root(it.root), curr(it.curr), pos(it.pos), s(it.s)
+    {
+      // empty
+    }
+
+    Iterator(Iterator &&it) noexcept : root(nullptr), curr(nullptr), pos(0), s()
+    {
+      swap(it);
+    }
+
+    Iterator &operator = (Iterator it)
+    {
+      it.swap(*this);
+      return *this;
+    }
+
+    void reset_first() noexcept
+    {
+      s.empty();
+      pos = 0;
+      curr = root;
+    }
+
+    [[nodiscard]] bool has_curr() const noexcept
+    {
+      return curr != nullptr;
+    }
+
+    Tree_Node *get_curr_ne() const noexcept
+    {
+      return curr;
+    }
+
+    Tree_Node *get_curr() const
+    {
+      ah_overflow_error_if(not has_curr()) << "Iterator overflow";
+      return get_curr_ne();
+    }
+
+    void next_ne() noexcept
+    {
+      ++pos;
+      Tree_Node *lchild = curr->get_left_child();
+      if (lchild == nullptr)
+        {
+          if (s.is_empty())
+            curr = nullptr;
+          else
+            curr = s.pop();
+
+          return;
+        }
+
+      for (auto p = curr->get_right_child(); p != lchild; p = p->get_left_sibling())
+        s.push(p);
+
+      curr = lchild;
+    }
+
+    void next()
+    {
+      ah_overflow_error_if(not has_curr()) << "Iterator overflow";
+      next_ne();
+    }
+
+    void end()
+    {
+      curr = nullptr;
+      s.empty();
+      pos = -1;
+    }
+
+    /// Return the current position of the iterator. Only valid if
+    // has_curr() == true
+    [[nodiscard]] size_t get_pos() const
+    {
+      return pos;
+    }
+  };
+
+  Iterator get_it() const
+  {
+    return Iterator(const_cast<Tree_Node *>(this));
   }
 
-  /** Computes the height of the tree root.
+  STL_ALEPH_ITERATOR(Tree_Node);
+};
 
-      @param[in] root tree root.
-      @return height of the tree rooted at root.
-      @ingroup Trees
-  */
-  template <class Node>
-  size_t compute_height(Node * root)
-  {
-    if (root == nullptr)
-      return 0;
+/** Tree_Node variant with a virtual destructor.
 
-    size_t temp_h, max_h = 0;
-    for (Node * aux = root->get_left_child(); aux != nullptr;
-         aux = aux->get_right_sibling())
-      if ((temp_h = compute_height(aux)) > max_h)
-        max_h = temp_h;
+    Use this type when nodes are extended polymorphically and may be deleted
+    through a pointer to the base tree-node type. Plain Tree_Node keeps the
+    non-virtual destructor for minimal overhead.
 
-    return max_h + 1;
-  }
+    @tparam T data type stored in each tree node.
+    @ingroup Trees
+*/
+template <typename T>
+struct Tree_Node_Vtl : public Tree_Node<T>
+{
+  virtual ~Tree_Node_Vtl() = default;
+};
 
-  template <class Node> static inline
-  Node * __deway_search(Node * node, int path [],
-                        const int & idx, const size_t & size)
-  {
-    if (node == nullptr)
-      return nullptr;
+template <class Node>
+static inline void clone_tree(Node *src, Node *tgt)
+{
+  using It = typename Node::Children_Iterator;
+  for (It it(src); it.has_curr(); it.next_ne())
+    tgt->insert_rightmost_child(new Node(it.get_curr()->get_key()));
 
-    ah_out_of_range_error_if(static_cast<size_t>(idx) >= size)
-      << "index out of maximum range";
+  using PItor = Pair_Iterator<It>;
+  for (PItor itor{It(*src), It(*tgt)}; itor.has_curr(); itor.next_ne())
+    {
+      auto p = itor.get_curr();
+      clone_tree(p.first, p.second);
+    }
+}
 
-    if (path[idx] < 0) // check whether the node has been reached
-      return node;
-    // advance to the next child path[0]
-    Node * child = node->get_left_child();
-    for (int i = 0; i < path[idx] and child != nullptr; ++i)
-      child = child->get_right_sibling();
-
-    return __deway_search(child, path, idx + 1, size); // next level
-  }
-
-  /** Returns a node of a forest given its Dewey number.
-
-      deway_search(root,path,size) takes the Dewey number stored
-      in path, of length size, and searches in the forest whose first
-      tree is root for the node that corresponds to the given Dewey number.
-
-      @param[in] root root of the first tree of the forest.
-      @param[in] path array containing the Dewey number.
-      @param[in] size length of the Dewey number.
-      @return pointer to the node corresponding to the given Dewey number;
-      nullptr if it does not exist,
-      @ingroup Trees
-  */
-  template <class Node> inline
-  Node * deway_search(Node * root, int path [], const size_t & size)
-  {
-    for (int i = 0; root != nullptr; i++, root = root->get_right_sibling())
-      if (path[0] == i)
-        return __deway_search(root, path, 1, size);
-
+template <class Node>
+Node *clone_tree(Node *root)
+{
+  if (root == nullptr)
     return nullptr;
-  }
+  Node *ret = new Node(root->get_key());
+  clone_tree(root, ret);
+  return ret;
+}
 
-  template <class Node, class Equal> inline static
-  Node * __search_deway(Node * root, const typename Node::key_type & key,
-                        const size_t & current_level, int deway [],
-                        const size_t & size, size_t & n);
+template <class Node>
+static inline void __tree_preorder_traversal(Node *root, const int &level, const int &child_index,
+                                             void (*visitFct)(Node *, int, int))
+{
+  (*visitFct)(root, level, child_index);
+  Node *child = root->get_left_child();
+  for (int i = 0; child != nullptr; ++i, child = child->get_right_sibling())
+    __tree_preorder_traversal(child, level + 1, i, visitFct);
+}
 
-  /** Searches key in a forest and computes the Dewey number of the
-      node containing the key.
+/** Preorder traversal of a tree.
 
-      search_deway(root,key,deway,n) searches in the forest
-      whose first tree is root a node containing the key.
-      If the node is found, then the routine stores in deway[]
-      the Dewey number of the found node.
+    tree_preorder_traversal((root,visit) performs a preorder traversal
+    over the tree rooted at root. If visitFct is specified,
+    then for each visited node the function is invoked.
 
-      The search is performed using the equality criterion Equal()().
+    The visit function has the following specification:
 
-      @param[in] root root of the first tree of the forest.
-      @param[in] key key to search.
-      @param[out] deway array that stores the Dewey number.
-      @param[in] size maximum length of the Dewey number.
-      @param[out] n length of the computed Dewey number (if the node is found).
-      @return pointer to the node containing key;
-      nullptr if there is no node with key,
-      @throw overflow_error if size is not sufficient to store the Dewey sequence.
-      @ingroup Trees
-  */
-  template <class Node,
-            class Equal = Aleph::equal_to<typename Node::key_type> > inline
-  Node * search_deway(Node * root, const typename Node::key_type & key,
-                      int deway [], const size_t & size, size_t & n)
-  {
-    n = 1; // initial length value of the Dewey number
+    void (*visitFct)(Node* p, int level, int pos)
 
-    ah_overflow_error_if(size < n) << "there is no enough space for deway array";
+    Where:
+    -# p: pointer to the currently visited node.
+    -# level: the level of p in the tree.
+    -# child_index: index of p among its siblings.
 
-    for (int i = 0; root != nullptr; i++, root = root->get_right_sibling())
-      {
-        deway[0] = i;
-        Node * result =
-          __search_deway <Node, Equal> (root, key, 0, deway, size, n);
-        if (result != nullptr)
-          return result;
-      }
+    @param[in] root root of the tree to traverse.
+    @param[in] visitFct pointer to the visit function.
+    @see forest_preorder_traversal() tree_postorder_traversal()
+    @see forest_postorder_traversal()
+    @throw domain_error if root is not a root node of a tree.
+    @ingroup Trees
+*/
+template <class Node>
+inline void tree_preorder_traversal(Node *root, void (*visitFct)(Node *, int, int))
+{
+  ah_domain_error_if(not root->is_root()) << "root is not root";
 
+  __tree_preorder_traversal(root, 0, 0, visitFct);
+}
+
+/** Preorder traversal of a forest.
+
+    forest_preorder_traversal((root,visit) performs a preorder traversal
+    over the forest whose first tree is root. If visitFct is specified,
+    then for each visited node the function is invoked.
+
+    The visit function has the following specification:
+
+    void (*visitFct)(Node* p, int level, int pos)
+
+    Where:
+    -# p: pointer to the currently visited node.
+    -# level: the level of p in the tree.
+    -# child_index: index of p among its siblings.
+
+    @param[in] root root of the first tree in the forest.
+    @param[in] visitFct pointer to the visit function.
+    @throw domain_error if root is not a root node of a tree.
+    @see tree_preorder_traversal() tree_postorder_traversal()
+    @see forest_postorder_traversal()
+    @ingroup Trees
+*/
+template <class Node>
+inline void forest_preorder_traversal(Node *root, void (*visitFct)(Node *, int, int))
+{
+  ah_domain_error_if(not root->is_root()) << "root is not root";
+
+  for (/* nothing */; root != nullptr; root = root->get_right_tree())
+    {
+      assert(root->is_root());
+      __tree_preorder_traversal(root, 0, 0, visitFct);
+    }
+}
+
+template <class Node>
+static inline void __tree_postorder_traversal(Node *node, const int &level, const int &child_index,
+                                              void (*visitFct)(Node *, int, int))
+{
+  Node *child = node->get_left_child();
+
+  for (int i = 0; child not_eq nullptr; i++, child = child->get_right_sibling())
+    __tree_postorder_traversal(child, level + 1, i, visitFct);
+
+  (*visitFct)(node, level, child_index);
+}
+
+/** Postorder traversal of a tree.
+
+    tree_postorder_traversal((root,visit) performs a postorder traversal
+    over the tree rooted at root. If visitFct is specified,
+    then for each visited node the function is invoked.
+
+    The visit function has the following specification:
+
+    void (*visitFct)(Node* p, int level, int pos)
+
+    Where:
+    -# p: pointer to the currently visited node.
+    -# level: the level of p in the tree.
+    -# child_index: index of p among its siblings.
+
+    @param[in] root root of the tree to traverse.
+    @param[in] visitFct pointer to the visit function.
+    @see forest_preorder_traversal() tree_preorder_traversal()
+    @see forest_postorder_traversal()
+    @ingroup Trees
+*/
+template <class Node>
+inline void tree_postorder_traversal(Node *root, void (*visitFct)(Node *, int, int))
+{
+  __tree_postorder_traversal(root, 0, 0, visitFct);
+}
+
+/** Postorder traversal of a forest.
+
+    forest_postorder_traversal((root,visit) performs a postorder traversal
+    over the forest whose first tree is root. If visitFct is specified,
+    then for each visited node the function is invoked.
+
+    The visit function has the following specification:
+
+    void (*visitFct)(Node* p, int level, int pos)
+
+    Where:
+    -# p: pointer to the currently visited node.
+    -# level: the level of p in the tree.
+    -# child_index: index of p among its siblings.
+
+    @param[in] root root of the tree to traverse.
+    @param[in] visitFct pointer to the visit function.
+    @see forest_preorder_traversal() tree_preorder_traversal()
+    @see tree_postorder_traversal()
+    @throw domain_error if root is not the root node of the leftmost tree
+    of the forest.
+    @ingroup Trees
+*/
+template <class Node>
+inline void forest_postorder_traversal(Node *root, void (*visitFct)(Node *, int, int))
+{
+  ah_domain_error_if(not root->is_leftmost()) << "root is not the leftmost node of forest";
+
+  ah_domain_error_if(not root->is_root()) << "root is not root";
+
+  for (/* nothing */; root not_eq nullptr; root = root->get_right_sibling())
+    {
+      assert(root->is_root());
+      __tree_postorder_traversal(root, 0, 0, visitFct);
+    }
+}
+
+/** Returns true if t1 is equal to t2
+
+    @ingroup Trees
+*/
+template <class Node, class Eq>
+inline bool are_tree_equal(Node *t1, Node *t2, Eq &eq)
+{
+  if (t1 == nullptr)
+    return t2 == nullptr;
+
+  if (t2 == nullptr)
+    return false;
+
+  if (not eq(t1->get_key(), t2->get_key()))
+    return false;
+
+  try
+    {
+      return zipEq(t1->children_nodes(), t2->children_nodes())
+        .all([&eq](auto p)
+        {
+          return are_tree_equal(p.first, p.second, eq);
+        });
+    }
+  catch (const std::length_error &)
+    {
+      return false;
+    }
+}
+
+template <class Node, class Eq = std::equal_to<typename Node::key_type>>
+inline bool are_tree_equal(Node *t1, Node *t2, Eq &&eq = Eq())
+{
+  return are_tree_equal<Node, Eq>(t1, t2, eq);
+}
+
+/** Destroys (frees memory) the tree whose root is root.
+
+    destroy_tree(root) frees all the memory occupied by the
+    tree whose root is root.
+
+    @param[in] root root of the tree to be freed.
+    @ingroup Trees
+*/
+template <class Node>
+inline void destroy_tree(Node *root)
+{
+  if (root == nullptr)
+    return;
+
+  if (not IS_UNIQUE_SIBLING(root))
+    SIBLING_LIST(root)->del();  // no ==> remove from sibling list
+
+  // traverse subtrees from right to left
+  for (Node *p = static_cast<Node *>(root->get_right_child()); p != nullptr; /* nada */)
+    {
+      Node *to_delete = p;                             // backup subtree to delete
+      p = static_cast<Node *>(p->get_left_sibling());  // advance to left sibling
+      destroy_tree(to_delete);                         // recursively delete tree
+    }
+
+  if (root->is_leftmost())  // remove children list?
+    CHILD_LIST(root)->del();
+
+  delete root;
+}
+
+/** Destroys (frees memory) the forest whose first tree is root.
+
+    destroy_forest(root) frees all the memory occupied by the
+    forest whose first tree has root as its root.
+
+    @param[in] root root of the first tree of the forest
+    to be destroyed.
+    @throw domain_error if root is not the root node of the leftmost
+    tree of the forest.
+    @ingroup Trees
+*/
+template <class Node>
+inline void destroy_forest(Node *root)
+{
+  if (root == nullptr)
+    return;
+
+  ah_domain_error_if(not root->is_leftmost()) << "root is not the leftmost tree of forest";
+
+  ah_domain_error_if(not root->is_root()) << "root is not root";
+
+  while (root != nullptr)  // traverse trees from left to right
+    {
+      Node *to_delete = root;                     // backup root
+      root = (Node *) root->get_right_sibling();  // advance to next tree
+      SIBLING_LIST(to_delete)->del();             // remove from tree list
+      destroy_tree(to_delete);                    // delete the tree
+    }
+}
+
+/** Computes the height of the tree root.
+
+    @param[in] root tree root.
+    @return height of the tree rooted at root.
+    @ingroup Trees
+*/
+template <class Node>
+size_t compute_height(Node *root)
+{
+  if (root == nullptr)
+    return 0;
+
+  size_t temp_h, max_h = 0;
+  for (Node *aux = root->get_left_child(); aux != nullptr; aux = aux->get_right_sibling())
+    if ((temp_h = compute_height(aux)) > max_h)
+      max_h = temp_h;
+
+  return max_h + 1;
+}
+
+template <class Node>
+static inline Node *__deway_search(Node *node, int path[], const int &idx, const size_t &size)
+{
+  if (node == nullptr)
     return nullptr;
-  }
 
-  template <class Node, class Equal> inline static
-  Node * __search_deway(Node * root,
-                        const typename Node::key_type & key,
-                        const size_t & current_level, int deway [],
-                        const size_t & size, size_t & n)
-  {
+  ah_out_of_range_error_if(static_cast<size_t>(idx) >= size) << "index out of maximum range";
 
-    ah_overflow_error_if(current_level >= size) << "there is no enough space for deway array";
+  if (path[idx] < 0)  // check whether the node has been reached
+    return node;
+  // advance to the next child path[0]
+  Node *child = node->get_left_child();
+  for (int i = 0; i < path[idx] and child != nullptr; ++i)
+    child = child->get_right_sibling();
 
-    if (root == nullptr)
-      return nullptr;
+  return __deway_search(child, path, idx + 1, size);  // next level
+}
 
-    if (Equal()(root->get_key(), key))
-      {
-        n = current_level + 1; // length of the deway array
-        return root;
-      }
+/** Returns a node of a forest given its Dewey number.
 
-    Node * child = root->get_left_child();
-    for (int i = 0; child != nullptr;
-         i++, child = child->get_right_sibling())
-      {
-        ah_overflow_error_if(current_level + 1 >= size)
-          << "there is no enough space for deway array";
-        deway[current_level + 1] = i;
-        Node * result = __search_deway <Node, Equal>
-          (child, key, current_level + 1, deway, size, n);
+    deway_search(root,path,size) takes the Dewey number stored
+    in path, of length size, and searches in the forest whose first
+    tree is root for the node that corresponds to the given Dewey number.
 
-        if (result!= nullptr)
-          return result;
-      }
+    @param[in] root root of the first tree of the forest.
+    @param[in] path array containing the Dewey number.
+    @param[in] size length of the Dewey number.
+    @return pointer to the node corresponding to the given Dewey number;
+    nullptr if it does not exist,
+    @ingroup Trees
+*/
+template <class Node>
+inline Node *deway_search(Node *root, int path[], const size_t &size)
+{
+  for (int i = 0; root != nullptr; i++, root = root->get_right_sibling())
+    if (path[0] == i)
+      return __deway_search(root, path, 1, size);
 
+  return nullptr;
+}
+
+template <class Node, class Equal>
+inline static Node *__search_deway(Node *root, const typename Node::key_type &key,
+                                   const size_t &current_level, int deway[], const size_t &size,
+                                   size_t &n);
+
+/** Searches key in a forest and computes the Dewey number of the
+    node containing the key.
+
+    search_deway(root,key,deway,n) searches in the forest
+    whose first tree is root a node containing the key.
+    If the node is found, then the routine stores in deway[]
+    the Dewey number of the found node.
+
+    The search is performed using the equality criterion Equal()().
+
+    @param[in] root root of the first tree of the forest.
+    @param[in] key key to search.
+    @param[out] deway array that stores the Dewey number.
+    @param[in] size maximum length of the Dewey number.
+    @param[out] n length of the computed Dewey number (if the node is found).
+    @return pointer to the node containing key;
+    nullptr if there is no node with key,
+    @throw overflow_error if size is not sufficient to store the Dewey sequence.
+    @ingroup Trees
+*/
+template <class Node, class Equal = Aleph::equal_to<typename Node::key_type>>
+inline Node *search_deway(Node *root, const typename Node::key_type &key, int deway[],
+                          const size_t &size, size_t &n)
+{
+  n = 1;  // initial length value of the Dewey number
+
+  ah_overflow_error_if(size < n) << "there is no enough space for deway array";
+
+  for (int i = 0; root != nullptr; i++, root = root->get_right_sibling())
+    {
+      deway[0] = i;
+      Node *result = __search_deway<Node, Equal>(root, key, 0, deway, size, n);
+      if (result != nullptr)
+        return result;
+    }
+
+  return nullptr;
+}
+
+template <class Node, class Equal>
+inline static Node *__search_deway(Node *root, const typename Node::key_type &key,
+                                   const size_t &current_level, int deway[], const size_t &size,
+                                   size_t &n)
+{
+  ah_overflow_error_if(current_level >= size) << "there is no enough space for deway array";
+
+  if (root == nullptr)
     return nullptr;
-  }
 
-  /** Converts a forest to its equivalent binary tree.
+  if (Equal()(root->get_key(), key))
+    {
+      n = current_level + 1;  // length of the deway array
+      return root;
+    }
 
-      forest_to_bin(root) takes a forest derived from Tree_Node
-      and converts it to its equivalent binary tree.
+  Node *child = root->get_left_child();
+  for (int i = 0; child != nullptr; i++, child = child->get_right_sibling())
+    {
+      ah_overflow_error_if(current_level + 1 >= size) << "there is no enough space for deway array";
+      deway[current_level + 1] = i;
+      Node *result = __search_deway<Node, Equal>(child, key, current_level + 1, deway, size, n);
 
-      The routine takes two type parameters:
-      -# TNode: tree type based on Tree_Node.
-      -# BNode: binary tree type based on BinNode.
+      if (result != nullptr)
+        return result;
+    }
 
-      The procedure assumes that both types share the same key type.
+  return nullptr;
+}
 
-      @param[in] root root of the first tree belonging to
-      the forest to convert.
-      @return root of the binary tree equivalent to the given forest.
-      @throw bad_alloc if there is not enough memory.
-      @see bin_to_forest()
-      @ingroup Trees
-  */
-  template <class TNode, class BNode>
-  BNode * forest_to_bin(TNode * root)
-  {
-    if (root == nullptr)
-      return BNode::NullPtr;
+/** Converts a forest to its equivalent binary tree.
 
-    auto * result = new BNode (root->get_key());
-    LLINK(result) = static_cast<BNode *>(forest_to_bin<TNode, BNode>(root->get_left_child()));
-    RLINK(result) = forest_to_bin<TNode, BNode>(root->get_right_sibling());
+    forest_to_bin(root) takes a forest derived from Tree_Node
+    and converts it to its equivalent binary tree.
 
-    return result;
-  }
+    The routine takes two type parameters:
+    -# TNode: tree type based on Tree_Node.
+    -# BNode: binary tree type based on BinNode.
 
-  template <class TNode, class BNode> inline static
-  void insert_child(BNode * lnode, TNode * tree_node)
-  {
-    if (lnode == BNode::NullPtr)
-      return;
+    The procedure assumes that both types share the same key type.
 
-    auto * child = new TNode(KEY(lnode));
-    tree_node->insert_leftmost_child(child);
-  }
+    @param[in] root root of the first tree belonging to
+    the forest to convert.
+    @return root of the binary tree equivalent to the given forest.
+    @throw bad_alloc if there is not enough memory.
+    @see bin_to_forest()
+    @ingroup Trees
+*/
+template <class TNode, class BNode>
+BNode *forest_to_bin(TNode *root)
+{
+  if (root == nullptr)
+    return BNode::NullPtr;
 
-  template <class TNode, class BNode> inline static
-  void insert_sibling(BNode * rnode, TNode * tree_node)
-  {
-    if (rnode == BNode::NullPtr)
-      return;
+  auto *result = new BNode(root->get_key());
+  LLINK(result) = static_cast<BNode *>(forest_to_bin<TNode, BNode>(root->get_left_child()));
+  RLINK(result) = forest_to_bin<TNode, BNode>(root->get_right_sibling());
 
-    auto * sibling = new TNode(KEY(rnode));
-    tree_node->insert_right_sibling(sibling);
-  }
+  return result;
+}
 
-  template <class TNode, class BNode> inline static
-  void bin_to_tree(BNode * broot, TNode * troot)
-  {
-    if (broot == BNode::NullPtr)
-      return;
+template <class TNode, class BNode>
+inline static void insert_child(BNode *lnode, TNode *tree_node)
+{
+  if (lnode == BNode::NullPtr)
+    return;
 
-    insert_child(LLINK(broot), troot);
-    TNode * left_child =  troot->get_left_child();
+  auto *child = new TNode(KEY(lnode));
+  tree_node->insert_leftmost_child(child);
+}
 
-    bin_to_tree(LLINK(broot), left_child);
+template <class TNode, class BNode>
+inline static void insert_sibling(BNode *rnode, TNode *tree_node)
+{
+  if (rnode == BNode::NullPtr)
+    return;
 
-    insert_sibling(RLINK(broot), troot);
-    TNode * right_sibling = troot->get_right_sibling();
+  auto *sibling = new TNode(KEY(rnode));
+  tree_node->insert_right_sibling(sibling);
+}
 
-    bin_to_tree(RLINK(broot), right_sibling);
-  }
+template <class TNode, class BNode>
+inline static void bin_to_tree(BNode *broot, TNode *troot)
+{
+  if (broot == BNode::NullPtr)
+    return;
 
-  /** Converts a binary tree to its equivalent forest.
+  insert_child(LLINK(broot), troot);
+  TNode *left_child = troot->get_left_child();
 
-      bin_to_forest(root) takes a binary tree derived from BinNode
-      and converts it to its equivalent forest.
+  bin_to_tree(LLINK(broot), left_child);
 
-      The routine takes two type parameters:
-      -# TNode: tree type based on Tree_Node.
-      -# BNode: binary tree type based on BinNode.
+  insert_sibling(RLINK(broot), troot);
+  TNode *right_sibling = troot->get_right_sibling();
 
-      The procedure assumes that both types share the same key type.
+  bin_to_tree(RLINK(broot), right_sibling);
+}
 
-      @param[in] broot root of the binary tree to convert.
-      @return root of the first tree equivalent to the given binary tree.
-      @throw bad_alloc if there is not enough memory.
-      @see forest_to_bin()
-      @ingroup Trees
-  */
-  template <class TNode, class BNode> inline
-  TNode * bin_to_forest(BNode * broot)
-  {
-    if (broot == BNode::NullPtr)
-      return nullptr;
+/** Converts a binary tree to its equivalent forest.
 
-    auto * troot = new TNode (KEY(broot));
-    bin_to_tree(broot, troot);
-    return troot;
-  }
+    bin_to_forest(root) takes a binary tree derived from BinNode
+    and converts it to its equivalent forest.
 
-} // end namespace Aleph
+    The routine takes two type parameters:
+    -# TNode: tree type based on Tree_Node.
+    -# BNode: binary tree type based on BinNode.
 
-# endif // TPL_TREE_H
+    The procedure assumes that both types share the same key type.
 
+    @param[in] broot root of the binary tree to convert.
+    @return root of the first tree equivalent to the given binary tree.
+    @throw bad_alloc if there is not enough memory.
+    @see forest_to_bin()
+    @ingroup Trees
+*/
+template <class TNode, class BNode>
+inline TNode *bin_to_forest(BNode *broot)
+{
+  if (broot == BNode::NullPtr)
+    return nullptr;
+
+  auto *troot = new TNode(KEY(broot));
+  bin_to_tree(broot, troot);
+  return troot;
+}
+
+}  // end namespace Aleph
+
+#endif  // TPL_TREE_H

--- a/tpl_tree_node.H
+++ b/tpl_tree_node.H
@@ -43,7 +43,9 @@
 #ifndef TPL_TREE_H
 #define TPL_TREE_H
 
+#include <cassert>
 #include <stdexcept>
+#include <utility>
 #include <dlink.H>
 #include <ahDry.H>
 #include <ah-dry-mixin.H>
@@ -70,6 +72,7 @@
 
 namespace Aleph {
 
+/// Forward declaration used by CRTP helpers before the full node definition.
 template <class T>
 class Tree_Node;  // Forward declaration for CRTP
 
@@ -773,7 +776,7 @@ public:
     return Children_Iterator(*this);
   }
 
-  /** Adapter that exposes a node's children through an Iterator type.
+  /** @brief Adapter that exposes a node's children through an Iterator type.
 
       This small wrapper exists for generic iterator utilities that expect a
       container-like type with a nested `Iterator`, such as Pair_Iterator-based
@@ -783,12 +786,19 @@ public:
   {
     Children_Set(const Tree_Node &&) {}
     Children_Set(const Tree_Node &) {}
+    /// Child iterator adapter used by generic iterator utilities.
     struct Iterator : public Children_Iterator
     {
       using Children_Iterator::Children_Iterator;
     };
   };
 
+  /** Preorder iterator over a tree rooted at a Tree_Node.
+
+      The iterator owns an explicit stack of pending children and visits nodes
+      in root-before-children order. It does not own or copy tree nodes, so the
+      underlying tree must outlive the iterator.
+  */
   class Iterator
   {
     Tree_Node *root = nullptr;
@@ -902,7 +912,7 @@ public:
   STL_ALEPH_ITERATOR(Tree_Node);
 };
 
-/** Tree_Node variant with a virtual destructor.
+/** @brief Tree_Node variant with a virtual destructor.
 
     Use this type when nodes are extended polymorphically and may be deleted
     through a pointer to the base tree-node type. Plain Tree_Node keeps the

--- a/tpl_tree_node.H
+++ b/tpl_tree_node.H
@@ -560,8 +560,8 @@ public:
 
   /** Insert `tree` to the right of `this`
 
-      Assuming that `this` is part of a forrest, this method
-      insert `tree` to the right of this.
+      Assuming that `this` is part of a forest, this method
+      inserts `tree` to the right of this.
 
       Be careful with the fact that `tree` will not always be
       inserted as the rightmost tree, but as the tree to right of
@@ -617,7 +617,7 @@ public:
     return left_link();
   }
 
-  /// Return a list with all trees belonging to the forrest
+  /// Return a list with all trees belonging to the forest
   template <template <typename> class Container = DynList>
   Container<Tree_Node *> trees() const
   {
@@ -1152,8 +1152,54 @@ inline void destroy_tree(Node *root)
   if (root == nullptr)
     return;
 
+  // If `root` is the leftmost child of a live parent, its `child` field is
+  // spine-linked to that parent (see the class-level note on the shared
+  // spine trick): removing `root` must hand that spine slot to its right
+  // sibling, promoted below to the new leftmost child. Captured before the
+  // sibling list is touched; only usable once `root`'s own children have
+  // been recursively destroyed (see below), so it is applied at the
+  // `CHILD_LIST` cleanup near the end of this function, not here.
+  Node *promoted_leftmost = nullptr;
+
   if (not IS_UNIQUE_SIBLING(root))
-    SIBLING_LIST(root)->del();  // no ==> remove from sibling list
+    {
+      // `root` is about to be unlinked from its sibling list. If it was an
+      // extremal sibling, the neighbor taking its place must inherit the
+      // corresponding flag -- otherwise that neighbor is left with
+      // is_rightmost()/is_leftmost() == false while actually being the new
+      // extremum, so get_right_sibling()/get_left_sibling() no longer
+      // short-circuit to nullptr and instead wrap around the remaining
+      // circular sibling list, corrupting any get_right_sibling()-based
+      // traversal (for_each_child(), Children_Iterator, ...) into an
+      // infinite loop.
+      if (root->is_rightmost())
+        if (auto *new_last = root->get_left_sibling(); new_last != nullptr)
+          new_last->set_is_rightmost(true);
+
+      if (root->is_leftmost())
+        if (auto *new_first = root->get_right_sibling(); new_first != nullptr)
+          {
+            new_first->set_is_leftmost(true);
+            // Only a child-of-a-parent's `child` field is spine-linked (a
+            // top-level forest tree's `child` field is purely private, no
+            // spine to hand over), and only when the promoted sibling is
+            // itself a leaf can that hand-over be done with a single
+            // Dlink::swap(): when the promoted sibling already has its own
+            // children, its `child` field is already the head of its own
+            // (unrelated) spine, and swap() would splice root's parent
+            // directly to that spine's *other* end, orphaning the
+            // promoted sibling's real children -- a separate, deeper,
+            // pre-existing gap in destroy_tree() (reproducible even
+            // without this fix: destroying any node that has its own
+            // children while its parent survives already corrupts the
+            // parent's child spine). Left as a known gap, tracked
+            // separately, rather than risking new corruption here.
+            if (not root->is_root() and new_first->is_leaf())
+              promoted_leftmost = static_cast<Node *>(new_first);
+          }
+
+      SIBLING_LIST(root)->del();  // no ==> remove from sibling list
+    }
 
   // traverse subtrees from right to left
   for (Node *p = static_cast<Node *>(root->get_right_child()); p != nullptr; /* nada */)
@@ -1163,7 +1209,14 @@ inline void destroy_tree(Node *root)
       destroy_tree(to_delete);                         // recursively delete tree
     }
 
-  if (root->is_leftmost())  // remove children list?
+  if (promoted_leftmost != nullptr)
+    // root's own children are gone by now, so CHILD_LIST(root) is just its
+    // spine pairing with its (live) parent; hand that slot to the promoted
+    // sibling in one swap (promoted_leftmost is a leaf, i.e. its own
+    // CHILD_LIST is empty, so Dlink::swap() simply relocates root's pairing
+    // there instead of merging two unrelated non-empty lists).
+    CHILD_LIST(root)->swap(CHILD_LIST(promoted_leftmost));
+  else if (root->is_leftmost())  // remove children list?
     CHILD_LIST(root)->del();
 
   delete root;


### PR DESCRIPTION
Add new ah-mdspan.H header for mdspan functionality. Introduce new examples for mdspan_ca_lattice_view and mdspan_matrix_view. Add corresponding tests for ah_mdspan and grid functionalities. Update existing headers (grid.H, random_tree.H, tpl_ca_storage.H, tpl_tree_node.H) to support new features and refactorations. Update CMakeLists.txt and README files for documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Se incorpora `Aleph::mdspan` como vista multidimensional *zero-copy* (con compatibilidad cuando no hay `std::mdspan`), con ejemplos completos de vistas 2D y retículas.
  * `Dense_Cell_Storage` añade `view()`/`const view()` para indexado tipo `grid(i, j)` sin copias.
* **Tests**
  * Nuevas pruebas para `mdspan`, grids y utilidades de concurrencia; se amplía la cobertura de `Prefix_Tree`.
* **Documentation**
  * `README` (ES/EN) actualiza la referencia de gestión de memoria con las nuevas vistas/cabeceras.
* **Bug Fixes / Refactor**
  * Mejoras y robustez en construcción/limpieza de estructuras y en ejemplos de trie/prefix-tree.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->