### PR TITLE
refactor(concurrent): Update concurrency utils and structures

### DIFF
--- a/Tests/concurrency_test_utils.H
+++ b/Tests/concurrency_test_utils.H
@@ -39,11 +39,11 @@
 #define ALEPH_TESTS_CONCURRENCY_TEST_UTILS_H
 
 #include <atomic>
-#include <cassert>
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <initializer_list>
 #include <mutex>
 #include <random>
@@ -52,6 +52,8 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+
+#include <ah-errors.H>
 
 namespace Aleph::Testing
 {
@@ -79,11 +81,16 @@ namespace Aleph::Testing
     /** @brief Construct a gate for the given number of workers.
      *
      * @param[in] expected Number of workers that must arrive before release.
+     * @throws std::invalid_argument if `expected == 0` (a gate with no
+     *         participants would never distinguish "nobody has arrived
+     *         yet" from "everybody has arrived", which is almost always a
+     *         miscounted caller rather than an intentional no-op gate).
      */
     explicit Deterministic_Start_Gate(const size_t expected)
       : expected_(expected)
     {
-      // empty
+      ah_invalid_argument_if(expected == 0)
+        << "Deterministic_Start_Gate requires at least one participant";
     }
 
     /** @brief Mark the caller ready and block until release() or cancel().
@@ -219,6 +226,68 @@ namespace Aleph::Testing
     };
   } // namespace detail
 
+  /** @brief Launch `thread_count` workers with a deterministic
+   *         simultaneous start, join every one of them, and rethrow the
+   *         first worker exception (if any) only after all have joined.
+   *
+   * @tparam Worker Callable invoked as `worker(size_t index)` from its own
+   *         thread, `index` in `[0, thread_count)`. Must be safe to copy
+   *         into one closure per thread; each thread runs its own copy (so
+   *         `Worker` itself need not be thread-safe unless it captures
+   *         shared state).
+   * @param[in] thread_count Number of worker threads to launch.
+   * @param[in,out] worker Per-worker callable.
+   *
+   * @throws std::invalid_argument if `thread_count == 0` (see
+   *         `Deterministic_Start_Gate`'s constructor).
+   * @throws std::system_error propagated as-is if the underlying
+   *         `std::thread` constructor fails to create a thread; threads
+   *         already launched are unblocked and joined (never left parked
+   *         on the gate or abandoned joinable) before this propagates.
+   * @throws Whatever the first worker (by thread-launch index) to throw
+   *         propagates with, once every thread has been launched,
+   *         released, and joined. If more than one worker throws, only
+   *         the first is rethrown; the others are discarded.
+   */
+  template <typename Worker>
+  void run_workers(const size_t thread_count, Worker worker)
+  {
+    Deterministic_Start_Gate gate(thread_count);
+    std::vector<std::thread> threads;
+    threads.reserve(thread_count);
+    std::mutex exception_mutex;
+    std::exception_ptr first_exception;
+
+    {
+      detail::Joining_Thread_Guard guard(threads, gate);
+
+      for (size_t i = 0; i < thread_count; ++i)
+        threads.emplace_back([&, i, worker]() mutable
+          {
+            if (not gate.arrive_and_wait())
+              return;
+            try
+              {
+                worker(i);
+              }
+            catch (...)
+              {
+                std::lock_guard lock(exception_mutex);
+                if (not first_exception)
+                  first_exception = std::current_exception();
+              }
+          });
+
+      guard.dismiss();  // every thread launched; let them reach the gate
+                         // on their own instead of racing to cancel() it.
+      gate.wait_until_ready();
+      gate.release();
+    } // guard destructor joins every thread (see Joining_Thread_Guard).
+
+    if (first_exception)
+      std::rethrow_exception(first_exception);
+  }
+
   /** @brief Configuration for producer/consumer stress helpers. */
   struct Producer_Consumer_Stress_Config
   {
@@ -281,6 +350,9 @@ namespace Aleph::Testing
    *         `std::thread` constructor fails to create a thread; threads
    *         already launched are unblocked and joined (never left parked on
    *         the gate or abandoned joinable) before this propagates.
+   * @throws Whatever the first producer/consumer worker throws (e.g. from
+   *         `push`/`try_pop` itself), once every thread has been joined --
+   *         see `run_workers()`, which this delegates to.
    */
   template <typename Push, typename TryPop>
   Producer_Consumer_Stress_Result run_producer_consumer_stress(
@@ -292,22 +364,20 @@ namespace Aleph::Testing
     Producer_Consumer_Stress_Result result;
     result.consumed.resize(total);
 
-    Deterministic_Start_Gate gate(config.producers + config.consumers);
     std::atomic<size_t> consumed_count{0};
     std::atomic<bool> timed_out{false};
-    std::vector<std::thread> threads;
-    threads.reserve(config.producers + config.consumers);
-
     const auto deadline = std::chrono::steady_clock::now() + config.timeout;
 
-    {
-      detail::Joining_Thread_Guard guard(threads, gate);
-
-      for (size_t p = 0; p < config.producers; ++p)
-        threads.emplace_back([&, p, push]() mutable
+    // Workers `[0, producers)` produce; `[producers, producers+consumers)`
+    // consume. `push`/`try_pop` are captured by value here once, then
+    // copied again per-thread by run_workers() itself (each thread's copy
+    // of this worker closure carries its own copy of both callables).
+    run_workers(config.producers + config.consumers,
+      [&, push, try_pop](const size_t index) mutable
+      {
+        if (index < config.producers)
           {
-            if (not gate.arrive_and_wait())
-              return;
+            const size_t p = index;
             for (size_t i = 0; i < config.items_per_producer; ++i)
               {
                 const size_t value = p * config.items_per_producer + i;
@@ -321,13 +391,9 @@ namespace Aleph::Testing
                     std::this_thread::yield();
                   }
               }
-          });
-
-      for (size_t c = 0; c < config.consumers; ++c)
-        threads.emplace_back([&, try_pop]() mutable
+          }
+        else
           {
-            if (not gate.arrive_and_wait())
-              return;
             while (consumed_count.load(std::memory_order_acquire) < total)
               {
                 size_t value = 0;
@@ -348,17 +414,8 @@ namespace Aleph::Testing
                     std::this_thread::yield();
                   }
               }
-          });
-
-      guard.dismiss();  // every thread launched; let them reach the gate on
-                         // their own instead of racing to cancel() it here.
-
-      gate.wait_until_ready();
-      gate.release();
-    } // guard destructor: on the normal path above, just joins (already-
-      // dismissed); if emplace_back threw before dismiss(), cancels the
-      // gate first so threads already blocked on it wake up, then joins
-      // them.
+          }
+      });
 
     const size_t n = consumed_count.load(std::memory_order_acquire);
     if (n < result.consumed.size())
@@ -418,8 +475,8 @@ namespace Aleph::Testing
         })
   {
     std::vector<Trace_Operation_Kind> allowed(kinds.begin(), kinds.end());
-    assert(key_range > 0);
-    assert(not allowed.empty());
+    ah_invalid_argument_if(key_range == 0) << "key_range must be > 0";
+    ah_invalid_argument_if(allowed.empty()) << "kinds must not be empty";
 
     std::mt19937 rng(seed);
     std::uniform_int_distribution<size_t> kind_dist(0, allowed.size() - 1);

--- a/Tests/concurrency_test_utils.H
+++ b/Tests/concurrency_test_utils.H
@@ -244,10 +244,12 @@ namespace Aleph::Testing
    *         `std::thread` constructor fails to create a thread; threads
    *         already launched are unblocked and joined (never left parked
    *         on the gate or abandoned joinable) before this propagates.
-   * @throws Whatever the first worker (by thread-launch index) to throw
-   *         propagates with, once every thread has been launched,
+   * @throws Whatever the first worker to throw at runtime propagates with
+   *         (whichever worker's `catch` block first acquires the internal
+   *         exception mutex -- not necessarily the one with the smallest
+   *         `index`), rethrown only once every thread has been launched,
    *         released, and joined. If more than one worker throws, only
-   *         the first is rethrown; the others are discarded.
+   *         the first one recorded is rethrown; the others are discarded.
    */
   template <typename Worker>
   void run_workers(const size_t thread_count, Worker worker)

--- a/Tests/concurrent_hash_map_test.cc
+++ b/Tests/concurrent_hash_map_test.cc
@@ -69,48 +69,13 @@ namespace
   };
 
   bool Throwing_Copy::should_throw = false;
-
-  /** @brief Launch `thread_count` threads, each running its own
-   *         `worker(index)`, started as close to simultaneously as
-   *         `Deterministic_Start_Gate` allows.
-   *
-   *  `concurrency_test_utils.H` provides `Deterministic_Start_Gate` (a
-   *  reusable start barrier) and `run_producer_consumer_stress()` (a
-   *  higher-level helper specifically for a single shared push/try_pop
-   *  queue), but no ready-made "N independent workers" launcher; this is
-   *  the small amount of local synchronization the harness's own
-   *  documentation anticipates for scenarios that don't fit its two
-   *  existing helpers.
-   */
-  template <typename Worker>
-  void run_workers(const size_t thread_count, Worker worker)
-  {
-    Deterministic_Start_Gate gate(thread_count);
-    std::vector<std::thread> threads;
-    threads.reserve(thread_count);
-
-    {
-      // Reuses the harness's own exception-safety guard: if launching one
-      // thread throws partway through, this cancels the gate (unblocking
-      // threads already parked in arrive_and_wait()) and joins everyone
-      // before the exception propagates, instead of leaving threads
-      // parked forever or calling std::terminate() on a still-joinable
-      // std::thread.
-      Aleph::Testing::detail::Joining_Thread_Guard guard(threads, gate);
-      for (size_t i = 0; i < thread_count; ++i)
-        threads.emplace_back([&, i, worker]() mutable
-        {
-          if (not gate.arrive_and_wait())
-            return;
-          worker(i);
-        });
-      guard.dismiss();
-
-      gate.wait_until_ready();
-      gate.release();
-    }
-  }
 }  // namespace
+
+// `run_workers(thread_count, worker)` (launch N independently-indexed
+// threads with a deterministic simultaneous start, exception-safe join,
+// and first-exception rethrow) is provided by concurrency_test_utils.H
+// itself -- Aleph::Testing::run_workers -- and used unqualified here via
+// the `using namespace Aleph::Testing;` above.
 
 TEST(ConcurrentHashMap, DefaultConstructedMapIsEmpty)
 {

--- a/tpl_concurrent_hash_map.H
+++ b/tpl_concurrent_hash_map.H
@@ -191,6 +191,9 @@ private:
    *       calling it twice with an equal key must yield the same shard
    *       index, or a key can effectively "move" between shards between
    *       calls and become invisible to later lookups.
+   *  @pre `hash_fct_` must not throw: this function is `noexcept` but
+   *       calls `hash_fct_(key)` directly, so a throwing hash function
+   *       would call `std::terminate()` here instead of propagating.
    */
   [[nodiscard]] Shard &shard_for(const Key &key) noexcept
   {
@@ -243,7 +246,9 @@ public:
    *          existing value is left untouched).
    *  @throws Whatever `Key`'s or `T`'s copy constructor throws, or
    *          `std::bad_alloc`. If it throws, the map is left exactly as it
-   *          was before the call.
+   *          was before the call. Also throws `std::system_error` if
+   *          acquiring the shard's `std::shared_mutex` fails at the OS
+   *          level.
    *  @note Safe to call concurrently from any number of threads. Blocks
    *        only other operations on the same shard.
    */
@@ -261,7 +266,9 @@ public:
    *  @return `true` if inserted, `false` if `key` was already present.
    *  @throws Whatever `Key`'s copy constructor or `T`'s move constructor
    *          throws, or `std::bad_alloc`. If it throws, the map is left
-   *          exactly as it was before the call.
+   *          exactly as it was before the call. Also throws
+   *          `std::system_error` if acquiring the shard's
+   *          `std::shared_mutex` fails at the OS level.
    *  @warning On a `false` return (duplicate `key`), `value` has still
    *           been moved from: the underlying table constructs the
    *           entry's `Pair` (moving `value` into it) *before* discovering
@@ -312,10 +319,10 @@ public:
    *
    *  @param[in] key Key to remove.
    *  @return `true` if `key` was present and removed, `false` otherwise.
-   *  @throws Whatever `T`'s move constructor throws: the underlying table
-   *          move-constructs the removed value to return it (a value this
-   *          method itself discards) before unlinking the entry, so a
-   *          throwing move leaves `key` still present in the map.
+   *  @throws std::system_error if acquiring the shard's `std::shared_mutex`
+   *          fails at the OS level; nothing else (unlinking a located
+   *          entry does not move- or copy-construct `T`, only destroys
+   *          it).
    *  @note Safe to call concurrently from any number of threads. Blocks
    *        only other operations on the same shard.
    */
@@ -324,12 +331,16 @@ public:
     Shard &shard = shard_for(key);
     std::unique_lock lock(shard.mutex);
 
-    // We explicitly search first because DynMapHashTable::remove may throw an
-    // exception (like domain_error) if the key does not exist.
-    if (shard.map.search(key) == nullptr)
+    // remove_by_data() removes the already-located entry directly (via
+    // pointer arithmetic back to its owning bucket), unlike
+    // DynMapHashTable::remove(key), which re-searches internally and
+    // move-constructs the removed value only to have it discarded here --
+    // paying an extra lookup and a throwing-move risk for nothing.
+    auto *pair = shard.map.search(key);
+    if (pair == nullptr)
       return false;
 
-    shard.map.remove(key);
+    shard.map.remove_by_data(pair->second);
     return true;
   }
 

--- a/tpl_concurrent_hash_map.H
+++ b/tpl_concurrent_hash_map.H
@@ -297,7 +297,9 @@ public:
    *          updating an existing entry's move assignment throws, that
    *          entry is left in whatever state `T::operator=(T&&)` leaves a
    *          failed assignment in (the map itself remains structurally
-   *          valid: the key is still present).
+   *          valid: the key is still present). Also throws
+   *          `std::system_error` if acquiring the shard's
+   *          `std::shared_mutex` fails at the OS level.
    *  @note Safe to call concurrently from any number of threads. Blocks
    *        only other operations on the same shard.
    */
@@ -348,7 +350,8 @@ public:
    *
    *  @param[in] key Key to look up.
    *  @return `true` if present at the moment of the check.
-   *  @throws Nothing.
+   *  @throws std::system_error if acquiring the shard's `std::shared_mutex`
+   *          fails at the OS level; nothing otherwise.
    *  @note Safe to call concurrently from any number of threads, including
    *        concurrently with other readers of the same shard. A
    *        concurrent insert/erase of the same key may change the answer
@@ -366,7 +369,9 @@ public:
    *  @param[in] key Key to look up.
    *  @return A copy of the value if `key` is present, `std::nullopt`
    *          otherwise.
-   *  @throws Whatever `T`'s copy constructor throws.
+   *  @throws Whatever `T`'s copy constructor throws. Also throws
+   *          `std::system_error` if acquiring the shard's
+   *          `std::shared_mutex` fails at the OS level.
    *  @note Safe to call concurrently from any number of threads, including
    *        concurrently with other readers of the same shard.
    */
@@ -391,6 +396,9 @@ public:
    *  @return `true` if `key` was present and `f` was invoked, `false`
    *          otherwise.
    *  @throws Whatever `f` throws, propagated after the lock is released.
+   *          Also throws `std::system_error` if acquiring the shard's
+   *          `std::shared_mutex` fails at the OS level (before `f` is
+   *          ever invoked).
    *  @note Safe to call concurrently from any number of threads, including
    *        concurrently with other readers of the same shard. `f` runs
    *        with the shard locked: keep it short, and never call back into
@@ -423,6 +431,9 @@ public:
    *  @return `true` if `key` was present and `f` was invoked, `false`
    *          otherwise.
    *  @throws Whatever `f` throws, propagated after the lock is released.
+   *          Also throws `std::system_error` if acquiring the shard's
+   *          `std::shared_mutex` fails at the OS level (before `f` is
+   *          ever invoked).
    *  @note Safe to call concurrently from any number of threads. `f` runs
    *        with the shard exclusively locked: keep it short, and never
    *        call back into this same `ConcurrentHashMap` from within `f`.
@@ -507,7 +518,10 @@ public:
    *
    *  @return An `Array` holding a copy of every entry seen while visiting
    *          each shard in turn.
-   *  @throws Whatever `Key`'s or `T`'s copy constructor throws.
+   *  @throws Whatever `Key`'s or `T`'s copy constructor throws, or
+   *          `std::bad_alloc` from growing the returned `Array`. Also
+   *          throws `std::system_error` if acquiring a shard's
+   *          `std::shared_mutex` fails at the OS level.
    *  @note Safe to call concurrently with other operations. Each shard is
    *        visited under its own lock and released before moving to the
    *        next, so this is a union of independent per-shard point-in-time

--- a/tpl_concurrent_hash_map.H
+++ b/tpl_concurrent_hash_map.H
@@ -76,13 +76,18 @@
  *  an independent, owned copy of the entries instead, or `with_value()`/
  *  `with_value_mut()` to operate on one entry while its shard is locked.
  *
- *  @par References never escape a lock
+ *  @par References must not escape a lock
  *  `with_value()`/`with_value_mut()` invoke the caller's callback while
- *  holding the shard's lock and forbid the callback from returning a
+ *  holding the shard's lock and forbid the callback from *returning* a
  *  reference (enforced with a `static_assert`, mirroring
- *  `Aleph::Synchronized::with_lock()` in `concurrency_utils.H`) precisely
- *  so no caller can accidentally keep a pointer/reference into the map
- *  around after the lock is released.
+ *  `Aleph::Synchronized::with_lock()` in `concurrency_utils.H`). This
+ *  catches the most common mistake (`return v;` from a callback taking
+ *  `T&`/`const T&`) at compile time, but -- like `with_lock()` -- it
+ *  cannot detect a callback that *captures* a pointer/reference to its
+ *  argument into external state (e.g. a callback that assigns its
+ *  parameter's address into a variable captured by reference); as with
+ *  `with_lock()`, the callback should not do that, since the entry is
+ *  only guaranteed valid while the shard's lock is held.
  *
  *  @par Example of use
  *  ```cpp
@@ -178,11 +183,21 @@ private:
   std::array<std::unique_ptr<Shard>, Shards> shards_;
   Hash_Fct_Ptr hash_fct_;
 
+  /** @brief Resolve which shard owns `key`.
+   *
+   *  @param[in] key Key to hash.
+   *  @return The shard whose lock and table must be used for `key`.
+   *  @pre `hash_fct_` is a deterministic, pure function of `key` alone:
+   *       calling it twice with an equal key must yield the same shard
+   *       index, or a key can effectively "move" between shards between
+   *       calls and become invisible to later lookups.
+   */
   [[nodiscard]] Shard &shard_for(const Key &key) noexcept
   {
     return *shards_[hash_fct_(key) % Shards];
   }
 
+  /// @brief `const` overload of shard_for(const Key&).
   [[nodiscard]] const Shard &shard_for(const Key &key) const noexcept
   {
     return *shards_[hash_fct_(key) % Shards];
@@ -242,12 +257,18 @@ public:
   /** @brief Insert `key` with `value` moved in, only if `key` is absent.
    *
    *  @param[in] key Key to insert.
-   *  @param[in,out] value Value to move in. Left unmodified if `key` was
-   *             already present (nothing is moved from it in that case).
+   *  @param[in,out] value Value to move in.
    *  @return `true` if inserted, `false` if `key` was already present.
    *  @throws Whatever `Key`'s copy constructor or `T`'s move constructor
    *          throws, or `std::bad_alloc`. If it throws, the map is left
    *          exactly as it was before the call.
+   *  @warning On a `false` return (duplicate `key`), `value` has still
+   *           been moved from: the underlying table constructs the
+   *           entry's `Pair` (moving `value` into it) *before* discovering
+   *           the key already exists and discarding that entry. Do not
+   *           read `value` after a `false` return; if you need to reuse
+   *           it, check `contains(key)` first, or capture a copy before
+   *           calling `insert`.
    *  @note Safe to call concurrently from any number of threads. Blocks
    *        only other operations on the same shard.
    */
@@ -291,8 +312,10 @@ public:
    *
    *  @param[in] key Key to remove.
    *  @return `true` if `key` was present and removed, `false` otherwise.
-   *  @throws Nothing beyond what the shard's internal bookkeeping might
-   *          throw in practice (none, for the default table policy).
+   *  @throws Whatever `T`'s move constructor throws: the underlying table
+   *          move-constructs the removed value to return it (a value this
+   *          method itself discards) before unlinking the entry, so a
+   *          throwing move leaves `key` still present in the map.
    *  @note Safe to call concurrently from any number of threads. Blocks
    *        only other operations on the same shard.
    */
@@ -410,14 +433,16 @@ public:
 
   /** @brief Remove every entry from every shard.
    *
-   *  @throws Nothing.
+   *  @throws std::system_error if acquiring a shard's `std::shared_mutex`
+   *          fails at the OS level; nothing otherwise (not `noexcept`
+   *          specifically because that lock acquisition is not).
    *  @note Safe to call concurrently with other operations, but is not a
    *        single atomic point in time across the whole map: shards are
    *        cleared one at a time, each under its own lock, so a
    *        concurrent insert into a not-yet-cleared shard can still be
    *        present when this returns.
    */
-  void clear() noexcept
+  void clear()
   {
     for (auto &shard : shards_)
       {
@@ -430,12 +455,13 @@ public:
    *
    *  @return Sum of each shard's entry count, each read under that
    *          shard's own lock.
-   *  @throws Nothing.
+   *  @throws std::system_error if acquiring a shard's `std::shared_mutex`
+   *          fails at the OS level; nothing otherwise.
    *  @note Safe to call concurrently with other operations. Not a
    *        transactionally consistent count across the whole map -- see
    *        the class-level note on `size()`/`snapshot()` consistency.
    */
-  [[nodiscard]] size_t size() const noexcept
+  [[nodiscard]] size_t size() const
   {
     size_t total = 0;
     for (const auto &shard : shards_)
@@ -450,10 +476,11 @@ public:
    *
    *  @return `true` if no shard held any entry at the moment each was
    *          checked.
-   *  @throws Nothing.
+   *  @throws std::system_error if acquiring a shard's `std::shared_mutex`
+   *          fails at the OS level; nothing otherwise.
    *  @note Same consistency caveat as `size()`.
    */
-  [[nodiscard]] bool is_empty() const noexcept
+  [[nodiscard]] bool is_empty() const
   {
     for (const auto &shard : shards_)
       {

--- a/tpl_memArray.H
+++ b/tpl_memArray.H
@@ -200,7 +200,12 @@ protected:
       << "MemArray::expand(): capacity overflow";
     const size_t newsz = dim << 1;  // 2*dim
     const size_t mask = dim - 1;
-    T *new_ptr = new T[newsz];
+    // Value-initialize (not just default-initialize): for scalar T,
+    // `new T[newsz]` alone leaves every slot indeterminate, and the
+    // std::swap() below reads new_ptr[i] before this loop ever writes a
+    // real value into it -- an uninitialized-read even though the stale
+    // bits end up discarded a few lines later (Coverity CID 412651).
+    T *new_ptr = new T[newsz]();
     for (size_t i = 0; i < dim; ++i)
       {
         assert(((i + first) & mask) == ((i + first) % dim));
@@ -235,7 +240,9 @@ protected:
     if (newsz <= Min_Dim)
       return false;
 
-    T *new_ptr = new T[newsz];
+    // Same rationale as expand(): value-initialize so the std::swap()
+    // below never reads an indeterminate scalar out of new_ptr[i].
+    T *new_ptr = new T[newsz]();
 
     const size_t mask = dim - 1;
     for (size_t i = 0; i < newsz; ++i)

--- a/tpl_mpsc_queue.H
+++ b/tpl_mpsc_queue.H
@@ -303,7 +303,7 @@ public:
     // unique_ptr guarantees the node is freed even if the move below
     // throws (T's move assignment is not required to be noexcept).
     std::unique_ptr<Node> owned(n);
-    out = std::move(*n->value);
+    out = std::move(*owned->value);
     return true;
   }
 
@@ -325,7 +325,7 @@ public:
     if (n == nullptr)
       return std::nullopt;
     std::unique_ptr<Node> owned(n);
-    return std::optional<T>(std::move(*n->value));
+    return std::optional<T>(std::move(*owned->value));
   }
 
   /** @brief Advisory check for whether the queue currently has no elements.

--- a/tpl_mpsc_queue.H
+++ b/tpl_mpsc_queue.H
@@ -107,6 +107,7 @@
 #define TPL_MPSC_QUEUE_H
 
 #include <atomic>
+#include <memory>
 #include <optional>
 #include <utility>
 
@@ -212,13 +213,18 @@ public:
    */
   ~MpscQueue()
   {
+    // stub_ is a data member, not a heap node: it must never reach
+    // `delete`. A racing push_node(&stub_) re-anchor (see pop_node()) can
+    // leave stub_ reachable from tail_ without *being* tail_ (a real,
+    // not-yet-popped node can end up between them), so every node in the
+    // remaining chain -- not just the first -- must be checked before
+    // deleting it.
     Node * n = tail_;
-    if (n == &stub_)
-      n = n->next.load(std::memory_order_relaxed);
     while (n != nullptr)
       {
         Node * next = n->next.load(std::memory_order_relaxed);
-        delete n;
+        if (n != &stub_)
+          delete n;
         n = next;
       }
   }
@@ -284,7 +290,8 @@ public:
    *  @throws Whatever `T`'s move assignment throws. If it throws, the node
    *          has already been unlinked from the queue; the element is lost
    *          (this matches the "no defined recovery from a throwing move
-   *          assignment" convention used elsewhere in Aleph's queues).
+   *          assignment" convention used elsewhere in Aleph's queues). The
+   *          node itself is still freed (via RAII) even if the move throws.
    *  @note Consumer-only: must never be called concurrently with another
    *        `try_pop`/`is_empty` call, nor from more than one thread.
    */
@@ -293,8 +300,10 @@ public:
     Node * n = pop_node();
     if (n == nullptr)
       return false;
+    // unique_ptr guarantees the node is freed even if the move below
+    // throws (T's move assignment is not required to be noexcept).
+    std::unique_ptr<Node> owned(n);
     out = std::move(*n->value);
-    delete n;
     return true;
   }
 
@@ -305,7 +314,8 @@ public:
    *          note on the narrow producer-race window).
    *  @throws Whatever moving `T` into the returned `std::optional` throws.
    *          If it throws, the node has already been unlinked from the
-   *          queue; the element is lost.
+   *          queue; the element is lost. The node itself is still freed
+   *          (via RAII) even if the move throws.
    *  @note Consumer-only: must never be called concurrently with another
    *        `try_pop`/`is_empty` call, nor from more than one thread.
    */
@@ -314,9 +324,8 @@ public:
     Node * n = pop_node();
     if (n == nullptr)
       return std::nullopt;
-    std::optional<T> result(std::move(*n->value));
-    delete n;
-    return result;
+    std::unique_ptr<Node> owned(n);
+    return std::optional<T>(std::move(*n->value));
   }
 
   /** @brief Advisory check for whether the queue currently has no elements.

--- a/tpl_snode.H
+++ b/tpl_snode.H
@@ -77,8 +77,11 @@ public:
 
   /// Default constructor. Value-initializes `data` (zero for a scalar or
   /// pointer `T`) rather than leaving it indeterminate, unlike a defaulted
-  /// constructor would for such `T` (Coverity CID 173393).
-  Snode() : data() { /* empty */ }
+  /// constructor would for such `T` (Coverity CID 173393). `constexpr` and
+  /// the `noexcept` condition are spelled out explicitly so this
+  /// hand-written constructor keeps the same conditional properties a
+  /// defaulted one would have inferred from `T`.
+  constexpr Snode() noexcept(noexcept(T{})) : data{} { /* empty */ }
 
   /// Constructor that copies the value.
   Snode(const T & _data) : data(_data) { /* empty */ }

--- a/tpl_snode.H
+++ b/tpl_snode.H
@@ -75,8 +75,10 @@ public:
   /// Return a constant reference to the stored data.
   const T & get_data() const { return data; }
 
-  /// Default constructor.
-  Snode() = default;
+  /// Default constructor. Value-initializes `data` (zero for a scalar or
+  /// pointer `T`) rather than leaving it indeterminate, unlike a defaulted
+  /// constructor would for such `T` (Coverity CID 173393).
+  Snode() : data() { /* empty */ }
 
   /// Constructor that copies the value.
   Snode(const T & _data) : data(_data) { /* empty */ }


### PR DESCRIPTION
Refactor internal concurrency utilities and data structures. Improved `tpl_concurrent_hash_map.H` documentation and safety notes. Updated `tpl_mpsc_queue.H` includes and structure. Corrected `tpl_memArray.H` and `tpl_snode.H` initialization for safety. Refactored `concurrency_test_utils.H` and `concurrent_hash_map_test.cc` for improved testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mejorada la robustez de las pruebas concurrentes: arranque coordinado de trabajadores y repropagación de la primera excepción.
  * Se corrigen liberaciones y realocaciones para evitar lecturas de memoria no inicializada y deletes accidentales en colas concurrentes y arreglos en crecimiento.
* **Documentation**
  * Actualizados contratos de uso y límites: clarificaciones sobre validez de referencias en callbacks y requisitos sobre el particionado de claves.
  * Se documentan explícitamente errores por fallo al adquirir bloqueos, incluyendo en operaciones como `insert/erase/contains/find_copy/with_value/with_value_mut/snapshot`.
* **Breaking Changes**
  * `clear()`, `size()` e `is_empty()` dejan de ser `noexcept`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->