### PR TITLE
feat(core): Add persistent treap and vector containers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,8 @@ set(HLIST
     tpl_radix_tree.H
     tpl_rope.H
     tpl_patricia_trie.H
+    tpl_persistent_treap.H
+    tpl_persistent_vector.H
     tpl_ca_parallel_engine.H
     tpl_ca_hex_lattice.H
     tpl_ca_triangular_lattice.H

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,7 @@ set(HLIST
     tpl_patricia_trie.H
     tpl_persistent_treap.H
     tpl_persistent_vector.H
+    tpl_persistent_hash_map.H
     tpl_ca_parallel_engine.H
     tpl_ca_hex_lattice.H
     tpl_ca_triangular_lattice.H

--- a/Examples/persistent_containers_example.cc
+++ b/Examples/persistent_containers_example.cc
@@ -1,0 +1,74 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file persistent_containers_example.cc
+ * @brief Small example for Aleph persistent in-memory containers.
+ *
+ * Build with the examples target and run:
+ *
+ * @code
+ * ./Examples/persistent_containers_example
+ * @endcode
+ */
+
+#include <iostream>
+#include <string>
+
+#include <tpl_persistent_treap.H>
+#include <tpl_persistent_vector.H>
+
+int main()
+{
+  Aleph::PersistentTreapSet<int> ids;
+  auto ids_v1 = ids.insert(10).insert(20);
+  auto ids_v2 = ids_v1.insert(15).erase(10);
+
+  std::cout << "ids_v1 contains 10: " << ids_v1.contains(10) << '\n';
+  std::cout << "ids_v2 contains 10: " << ids_v2.contains(10) << '\n';
+
+  Aleph::PersistentTreapMap<int, std::string> names;
+  auto names_v1 = names.insert(1, std::string("Ada"));
+  auto names_v2 = names_v1.insert_or_assign(1, std::string("Ada Lovelace"));
+
+  std::cout << "old name: " << *names_v1.find(1) << '\n';
+  std::cout << "new name: " << *names_v2.find(1) << '\n';
+
+  Aleph::PersistentVector<std::string> log;
+  auto log_v1 = log.push_back(std::string("created"));
+  auto log_v2 = log_v1.push_back(std::string("reviewed"));
+  auto log_v3 = log_v2.set(1, std::string("approved"));
+
+  std::cout << "log_v2[1]: " << log_v2.get(1) << '\n';
+  std::cout << "log_v3[1]: " << log_v3.get(1) << '\n';
+
+  return ids_v1.contains(10) and not ids_v2.contains(10) and
+    *names_v1.find(1) == "Ada" and *names_v2.find(1) == "Ada Lovelace" and
+    log_v2.get(1) == "reviewed" and log_v3.get(1) == "approved" ? 0 : 1;
+}

--- a/Examples/persistent_hash_map_example.cc
+++ b/Examples/persistent_hash_map_example.cc
@@ -1,0 +1,58 @@
+#include <cassert>
+#include <iostream>
+#include <string>
+
+#include <tpl_persistent_hash_map.H>
+
+using namespace Aleph;
+using namespace std;
+
+int main()
+{
+  cout << "Aleph-w PersistentHashMap Example" << endl;
+  cout << "=================================" << endl;
+
+  // Start with an empty immutable map.
+  PersistentHashMap<string, int> m0;
+
+  // Insert a few bindings.
+  auto m1 = m0.insert("apple", 10).insert("orange", 20).insert("banana", 30);
+
+  cout << "m1 has " << m1.size() << " bindings." << endl;
+
+  assert(m1.contains("apple"));
+  assert(*m1.find("orange") == 20);
+
+  // m0 remains intact.
+  assert(m0.is_empty());
+
+  // insert() leaves existing bindings unchanged.
+  auto duplicate = m1.insert("apple", 15);
+  assert(*duplicate.find("apple") == 10);
+
+  // insert_or_assign() updates a binding in the returned version.
+  auto m2 = m1.insert_or_assign("apple", 15).insert("grape", 40);
+
+  cout << "m2 has " << m2.size() << " bindings after update/insert." << endl;
+
+  assert(*m2.find("apple") == 15);
+
+  // m1 was not mutated.
+  assert(*m1.find("apple") == 10);
+  assert(!m1.contains("grape"));
+
+  auto m3 = m2.erase("orange").erase("banana");
+
+  cout << "m3 has " << m3.size() << " bindings after erasing." << endl;
+  assert(!m3.contains("orange"));
+  assert(m3.contains("apple"));
+
+  assert(m2.contains("orange"));
+  assert(m1.verify());
+  assert(m2.verify());
+  assert(m3.verify());
+
+  cout << "All persistent structural-sharing invariants are valid." << endl;
+
+  return 0;
+}

--- a/Examples/persistent_hash_map_example.cc
+++ b/Examples/persistent_hash_map_example.cc
@@ -1,3 +1,40 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file persistent_hash_map_example.cc
+ * @brief Basic operations and structural sharing for Aleph::PersistentHashMap.
+ *
+ * Usage:
+ *   ./persistent_hash_map_example
+ */
+
 #include <cassert>
 #include <iostream>
 #include <string>

--- a/README.es.md
+++ b/README.es.md
@@ -1680,6 +1680,8 @@ crit-bit/PATRICIA para claves enteras sin signo de ancho fijo.
 ### Contenedores persistentes en memoria
 
 ```cpp
+#include <string>
+
 #include <tpl_persistent_treap.H>
 #include <tpl_persistent_vector.H>
 #include <tpl_persistent_hash_map.H>

--- a/README.es.md
+++ b/README.es.md
@@ -40,6 +40,7 @@ Idioma: Español | [English](README.md)
   - [Heaps y colas de prioridad](#readme-es-heaps)
   - [Listas y estructuras secuenciales](#readme-es-estructuras-lineales)
   - [Rope (cadena inmutable con compartición estructural)](#readme-es-rope)
+  - [Contenedores persistentes en memoria](#readme-es-persistent-containers)
   - [Estructuras para consultas por rango](#readme-es-consultas-por-rango)
   - [Grafos](#readme-es-grafos)
   - [Geometría computacional](#readme-es-geometria)
@@ -1674,6 +1675,60 @@ palabras completas y soporta valores movibles. `RadixTree<T>` cubre el caso
 comprimido para claves string y reduce nodos fusionando cadenas de hijos
 unitarios. `PatriciaSet<UInt>` y `PatriciaMap<UInt, T>` son las variantes
 crit-bit/PATRICIA para claves enteras sin signo de ancho fijo.
+
+<a id="readme-es-persistent-containers"></a>
+### Contenedores persistentes en memoria
+
+```cpp
+#include <tpl_persistent_treap.H>
+#include <tpl_persistent_vector.H>
+#include <tpl_persistent_hash_map.H>
+
+int main() {
+    Aleph::PersistentTreapSet<int> ids;
+    auto v1 = ids.insert(10).insert(20);
+    auto v2 = v1.erase(10);              // v1 sigue intacto
+
+    Aleph::PersistentVector<int> log;
+    auto a = log.push_back(1);
+    auto b = a.set(0, 42);               // a[0] sigue siendo 1
+
+    Aleph::PersistentHashMap<std::string, int> env;
+    auto e1 = env.insert("path", 1);
+    auto e2 = e1.insert_or_assign("path", 2);   // e1["path"] sigue siendo 1
+
+    return v1.contains(10) and not v2.contains(10) and a.get(0) == 1 and b.get(0) == 42
+      and *e1.find("path") == 1 and *e2.find("path") == 2 ? 0 : 1;
+}
+```
+
+`PersistentTreapSet<Key, Compare>` y `PersistentTreapMap<Key, T, Compare>` son
+colecciones ordenadas inmutables respaldadas por treaps con path-copying.
+`insert`, `erase`, `insert_or_assign`, `split` y `join` devuelven versiones
+*nuevas* mientras las versiones viejas siguen compartiendo los subárboles no
+modificados vía `shared_ptr<const Node>`. El costo esperado de actualización y
+búsqueda es O(log n); copiar el valor de una colección es O(1).
+
+`PersistentVector<T>` es un bitmapped vector trie de factor 32. `push_back`,
+`set` y `pop_back` copian O(log_32 n) nodos del trie y comparten el resto. Los
+valores se guardan vía `shared_ptr<const T>`, así que las actualizaciones
+soportan valores move-only.
+
+`PersistentHashMap<Key, T, Cmp>` es un mapa no ordenado inmutable respaldado por
+un HAMT (Hash Array Mapped Trie). `insert`, `insert_or_assign` y `erase`
+devuelven versiones nuevas que solo copian (path-copy) los nodos del trie en la
+rama afectada y comparten el resto. La búsqueda, inserción y borrado son O(1)
+esperado para hashes bien distribuidos; las claves con el mismo hash completo se
+guardan en un nodo de colisión por hash. La función de hash se pasa como puntero
+`size_t (*)(const Key &)` (por defecto `dft_hash_ptr_fct` de Aleph), y un
+comparador de igualdad custom debe ser coherente con ella: `cmp(a, b)` implica
+`hash(a) == hash(b)`.
+
+Estos son snapshots volátiles en memoria, no la persistencia en archivo de los
+árboles B/B+ que proveen `File_B_Tree`, `File_BPlus_Tree`, `File_B_Map` y
+`File_BPlus_Map`. Las versiones publicadas pueden leerse concurrentemente desde
+distintos hilos; publicar una versión nueva en estado compartido sigue
+requiriendo sincronización del lado del usuario.
 
 <a id="readme-es-consultas-por-rango"></a>
 ### Estructuras para consultas por rango
@@ -3741,6 +3796,10 @@ int main() {
 | `tpl_small_vector.H` | `SmallVector<T, N>` | Vector con almacenamiento pequeño inline |
 | `tpl_ring_buffer.H` | `RingBuffer<T>` | FIFO circular de capacidad fija / ventana deslizante |
 | `tpl_rope.H` | `Rope<Char, LeafSize>` | Cadena inmutable con concat barato y substr/insert/erase compartidos |
+| `tpl_persistent_treap.H` | `PersistentTreapSet<K, Compare>` | Conjunto ordenado inmutable con path-copying |
+| `tpl_persistent_treap.H` | `PersistentTreapMap<K, T, Compare>` | Mapa ordenado inmutable con path-copying |
+| `tpl_persistent_vector.H` | `PersistentVector<T>` | Vector inmutable (bitmapped trie de factor 32) |
+| `tpl_persistent_hash_map.H` | `PersistentHashMap<K, T, Cmp>` | Mapa no ordenado inmutable con path-copying (HAMT) |
 | `tpl_dynSetTree.H` | `DynSetTree<T, Tree>` | Tree-based set |
 | `tpl_dynMapTree.H` | `DynMapTree<K, V, Tree>` | Tree-based map |
 | `tpl_flat_set.H` | `FlatSet<K, Compare>` | Conjunto ordenado sobre arreglo sorted |

--- a/README.md
+++ b/README.md
@@ -1867,6 +1867,7 @@ operations, structural sharing, and text-editing-style inserts/erases.
 ```cpp
 #include <tpl_persistent_treap.H>
 #include <tpl_persistent_vector.H>
+#include <tpl_persistent_hash_map.H>
 
 int main() {
     Aleph::PersistentTreapSet<int> ids;
@@ -1877,8 +1878,12 @@ int main() {
     auto a = log.push_back(1);
     auto b = a.set(0, 42);               // a[0] is still 1
 
+    Aleph::PersistentHashMap<std::string, int> env;
+    auto e1 = env.insert("path", 1);
+    auto e2 = e1.insert_or_assign("path", 2);   // e1["path"] is still 1
+
     return v1.contains(10) and not v2.contains(10) and a.get(0) == 1 and b.get(0) == 42
-      ? 0 : 1;
+      and *e1.find("path") == 1 and *e2.find("path") == 2 ? 0 : 1;
 }
 ```
 
@@ -1891,6 +1896,15 @@ Expected update and lookup cost is O(log n); copying a collection value is O(1).
 `PersistentVector<T>` is a 32-way bitmapped vector trie. `push_back`, `set` and
 `pop_back` copy O(log_32 n) trie nodes and share the rest. Values are stored via
 `shared_ptr<const T>`, so move-only values are supported for updates.
+
+`PersistentHashMap<Key, T, Cmp>` is an immutable unordered map backed by a Hash
+Array Mapped Trie (HAMT). `insert`, `insert_or_assign` and `erase` return new
+versions that path-copy only the trie nodes along the affected branch and share
+the rest. Lookup, insertion and erasure are expected O(1) for well-distributed
+hashes; keys sharing a full hash are kept in a per-hash collision node. The hash
+function is supplied as a `size_t (*)(const Key &)` pointer (defaulting to
+`Aleph`'s `dft_hash_ptr_fct`), and a custom equality comparator must agree with
+it: `cmp(a, b)` implies `hash(a) == hash(b)`.
 
 These are volatile in-memory snapshots, not the file-backed B/B+ tree
 persistence provided by `File_B_Tree`, `File_BPlus_Tree`, `File_B_Map` and
@@ -4211,6 +4225,7 @@ int main() {
 | `tpl_persistent_treap.H` | `PersistentTreapSet<K, Compare>` | Immutable path-copying ordered set |
 | `tpl_persistent_treap.H` | `PersistentTreapMap<K, T, Compare>` | Immutable path-copying ordered map |
 | `tpl_persistent_vector.H` | `PersistentVector<T>` | Immutable 32-way bitmapped vector trie |
+| `tpl_persistent_hash_map.H` | `PersistentHashMap<K, T, Cmp>` | Immutable path-copying unordered map backed by a HAMT |
 | `tpl_dynSetTree.H` | `DynSetTree<T, Tree>` | Tree-based set |
 | `tpl_dynMapTree.H` | `DynMapTree<K, V, Tree>` | Tree-based map |
 | `tpl_flat_set.H` | `FlatSet<K, Compare>` | Sorted-array ordered set |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Language: English | [Español](README.es.md)
   - [Heaps and Priority Queues](#readme-heaps-and-priority-queues)
   - [Lists and Sequential Structures](#readme-lists-and-sequential-structures)
   - [Rope (Immutable, Structurally-Shared String)](#readme-rope)
+  - [Persistent In-Memory Containers](#readme-persistent-containers)
   - [Range Query Structures](#readme-range-query-structures)
   - [Graphs](#readme-graphs)
   - [Computational Geometry](#readme-computational-geometry)
@@ -1859,6 +1860,43 @@ when `Char` has a `std::char_traits` specialization. See the file-level
 Doxygen in `tpl_rope.H` for the full complexity contract and
 `Examples/rope_example.cc` for a runnable walkthrough covering basic
 operations, structural sharing, and text-editing-style inserts/erases.
+
+<a id="readme-persistent-containers"></a>
+### Persistent In-Memory Containers
+
+```cpp
+#include <tpl_persistent_treap.H>
+#include <tpl_persistent_vector.H>
+
+int main() {
+    Aleph::PersistentTreapSet<int> ids;
+    auto v1 = ids.insert(10).insert(20);
+    auto v2 = v1.erase(10);              // v1 is still unchanged
+
+    Aleph::PersistentVector<int> log;
+    auto a = log.push_back(1);
+    auto b = a.set(0, 42);               // a[0] is still 1
+
+    return v1.contains(10) and not v2.contains(10) and a.get(0) == 1 and b.get(0) == 42
+      ? 0 : 1;
+}
+```
+
+`PersistentTreapSet<Key, Compare>` and `PersistentTreapMap<Key, T, Compare>`
+are immutable ordered collections backed by path-copying treaps. `insert`,
+`erase`, `insert_or_assign`, `split` and `join` return new versions while old
+versions keep sharing untouched subtrees through `shared_ptr<const Node>`.
+Expected update and lookup cost is O(log n); copying a collection value is O(1).
+
+`PersistentVector<T>` is a 32-way bitmapped vector trie. `push_back`, `set` and
+`pop_back` copy O(log_32 n) trie nodes and share the rest. Values are stored via
+`shared_ptr<const T>`, so move-only values are supported for updates.
+
+These are volatile in-memory snapshots, not the file-backed B/B+ tree
+persistence provided by `File_B_Tree`, `File_BPlus_Tree`, `File_B_Map` and
+`File_BPlus_Map`. Published versions may be read concurrently by different
+threads; publishing a new version into shared state still requires user-side
+synchronization.
 
 <a id="readme-range-query-structures"></a>
 ### Range Query Structures
@@ -4170,6 +4208,9 @@ int main() {
 | `tpl_small_vector.H` | `SmallVector<T, N>` | Vector with inline small-buffer storage |
 | `tpl_ring_buffer.H` | `RingBuffer<T>` | Fixed-capacity circular FIFO/sliding window |
 | `tpl_rope.H` | `Rope<Char, LeafSize>` | Immutable, structurally-shared string with cheap concat and shared substr/insert/erase |
+| `tpl_persistent_treap.H` | `PersistentTreapSet<K, Compare>` | Immutable path-copying ordered set |
+| `tpl_persistent_treap.H` | `PersistentTreapMap<K, T, Compare>` | Immutable path-copying ordered map |
+| `tpl_persistent_vector.H` | `PersistentVector<T>` | Immutable 32-way bitmapped vector trie |
 | `tpl_dynSetTree.H` | `DynSetTree<T, Tree>` | Tree-based set |
 | `tpl_dynMapTree.H` | `DynMapTree<K, V, Tree>` | Tree-based map |
 | `tpl_flat_set.H` | `FlatSet<K, Compare>` | Sorted-array ordered set |

--- a/README.md
+++ b/README.md
@@ -1865,6 +1865,8 @@ operations, structural sharing, and text-editing-style inserts/erases.
 ### Persistent In-Memory Containers
 
 ```cpp
+#include <string>
+
 #include <tpl_persistent_treap.H>
 #include <tpl_persistent_vector.H>
 #include <tpl_persistent_hash_map.H>

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -388,6 +388,8 @@ set(TEST_PROGRAMS
     radix_tree_test
     rope_test
     patricia_trie_test
+    persistent_treap_test
+    persistent_vector_test
     timeoutQueue_test
     graph_traverse_test
     test_ah_errors

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -385,6 +385,7 @@ set(TEST_PROGRAMS
     concurrency_test_utils_test
     mpsc_queue_test
     concurrent_hash_map_test
+    persistent_hash_map_test
     radix_tree_test
     rope_test
     patricia_trie_test

--- a/Tests/persistent_hash_map_test.cc
+++ b/Tests/persistent_hash_map_test.cc
@@ -1,3 +1,37 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file persistent_hash_map_test.cc
+ * @brief Tests for Aleph::PersistentHashMap.
+ */
+
 #include <gtest/gtest.h>
 
 #include <string>

--- a/Tests/persistent_hash_map_test.cc
+++ b/Tests/persistent_hash_map_test.cc
@@ -1,0 +1,330 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <random>
+
+#include <tpl_persistent_hash_map.H>
+
+using namespace Aleph;
+
+namespace
+{
+
+size_t bad_hash(const std::string &)
+{
+  return 0;
+}
+
+char lower_ascii(const char c)
+{
+  return c >= 'A' and c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c;
+}
+
+size_t case_hash(const std::string &s)
+{
+  size_t h = 1469598103934665603ULL;
+  for (const char c : s)
+    {
+      h ^= static_cast<unsigned char>(lower_ascii(c));
+      h *= 1099511628211ULL;
+    }
+  return h;
+}
+
+struct CaseEqual
+{
+  bool operator () (const std::string &a, const std::string &b) const noexcept
+  {
+    if (a.size() != b.size())
+      return false;
+    for (size_t i = 0; i < a.size(); ++i)
+      if (lower_ascii(a[i]) != lower_ascii(b[i]))
+        return false;
+    return true;
+  }
+};
+
+struct MoveTracked
+{
+  int value = 0;
+  bool moved_from = false;
+
+  explicit MoveTracked(const int v = 0) noexcept
+    : value(v)
+  {
+    // Empty.
+  }
+
+  MoveTracked(const MoveTracked &rhs) noexcept
+    : value(rhs.value)
+  {
+    // Empty.
+  }
+
+  MoveTracked(MoveTracked &&rhs) noexcept
+    : value(rhs.value)
+  {
+    rhs.moved_from = true;
+  }
+
+  MoveTracked &operator = (const MoveTracked &rhs) noexcept
+  {
+    value = rhs.value;
+    moved_from = false;
+    return *this;
+  }
+
+  MoveTracked &operator = (MoveTracked &&rhs) noexcept
+  {
+    value = rhs.value;
+    moved_from = false;
+    rhs.moved_from = true;
+    return *this;
+  }
+};
+
+} // namespace
+
+TEST(PersistentHashMap, Empty)
+{
+  PersistentHashMap<std::string, int> map;
+  EXPECT_TRUE(map.is_empty());
+  EXPECT_EQ(map.size(), 0);
+  EXPECT_EQ(map.keys().size(), 0);
+  EXPECT_EQ(map.items().size(), 0);
+  EXPECT_TRUE(map.verify());
+}
+
+TEST(PersistentHashMap, InsertBasic)
+{
+  PersistentHashMap<std::string, int> m1;
+  auto m2 = m1.insert("foo", 42);
+
+  EXPECT_EQ(m1.size(), 0);
+  EXPECT_FALSE(m1.contains("foo"));
+
+  EXPECT_EQ(m2.size(), 1);
+  EXPECT_TRUE(m2.contains("foo"));
+  ASSERT_NE(m2.find("foo"), nullptr);
+  EXPECT_EQ(*m2.find("foo"), 42);
+
+  auto m3 = m2.insert("bar", 99);
+  EXPECT_EQ(m2.size(), 1);
+  EXPECT_EQ(m3.size(), 2);
+  EXPECT_TRUE(m3.contains("foo"));
+  EXPECT_TRUE(m3.contains("bar"));
+  ASSERT_NE(m3.find("bar"), nullptr);
+  EXPECT_EQ(*m3.find("bar"), 99);
+
+  EXPECT_TRUE(m3.verify());
+}
+
+TEST(PersistentHashMap, InsertDoesNotOverwriteAndAssignDoes)
+{
+  PersistentHashMap<std::string, int> m1;
+  auto m2 = m1.insert("foo", 42);
+  auto duplicate = m2.insert("foo", 99);
+
+  EXPECT_EQ(duplicate.size(), 1);
+  ASSERT_NE(duplicate.find("foo"), nullptr);
+  EXPECT_EQ(*duplicate.find("foo"), 42);
+
+  auto updated = m2.insert_or_assign("foo", 99);
+  EXPECT_EQ(updated.size(), 1);
+  ASSERT_NE(updated.find("foo"), nullptr);
+  EXPECT_EQ(*updated.find("foo"), 99);
+
+  ASSERT_NE(m2.find("foo"), nullptr);
+  EXPECT_EQ(*m2.find("foo"), 42);
+  EXPECT_TRUE(updated.verify());
+}
+
+TEST(PersistentHashMap, DuplicateInsertDoesNotMoveRvalue)
+{
+  PersistentHashMap<std::string, MoveTracked> m1;
+  auto m2 = m1.insert("foo", MoveTracked{42});
+
+  MoveTracked replacement{99};
+  auto duplicate = m2.insert("foo", std::move(replacement));
+
+  EXPECT_FALSE(replacement.moved_from);
+  EXPECT_EQ(duplicate.size(), 1);
+  ASSERT_NE(duplicate.find("foo"), nullptr);
+  EXPECT_EQ(duplicate.find("foo")->value, 42);
+}
+
+TEST(PersistentHashMap, KeysAndItemsExposeEveryBinding)
+{
+  PersistentHashMap<std::string, int> map;
+  map = map.insert("a", 1).insert("b", 2).insert("c", 3);
+
+  auto keys = map.keys();
+  auto items = map.items();
+  EXPECT_EQ(keys.size(), 3);
+  EXPECT_EQ(items.size(), 3);
+
+  std::unordered_map<std::string, int> seen;
+  for (size_t i = 0; i < items.size(); ++i)
+    seen.emplace(items[i].first, items[i].second);
+
+  EXPECT_EQ(seen.size(), 3);
+  EXPECT_EQ(seen["a"], 1);
+  EXPECT_EQ(seen["b"], 2);
+  EXPECT_EQ(seen["c"], 3);
+}
+
+TEST(PersistentHashMap, EraseBasic)
+{
+  PersistentHashMap<std::string, int> m1;
+  auto m2 = m1.insert("a", 1).insert("b", 2).insert("c", 3);
+
+  EXPECT_EQ(m2.size(), 3);
+  auto missing = m2.erase("missing");
+  EXPECT_EQ(missing.size(), 3);
+  EXPECT_TRUE(missing.verify());
+
+  auto m3 = m2.erase("b");
+
+  EXPECT_EQ(m2.size(), 3);
+  EXPECT_TRUE(m2.contains("b"));
+
+  EXPECT_EQ(m3.size(), 2);
+  EXPECT_FALSE(m3.contains("b"));
+  EXPECT_TRUE(m3.contains("a"));
+  EXPECT_TRUE(m3.contains("c"));
+
+  auto m4 = m3.erase("a").erase("c");
+  EXPECT_TRUE(m4.is_empty());
+  EXPECT_TRUE(m4.verify());
+}
+
+TEST(PersistentHashMap, AdversarialCollisions)
+{
+  PersistentHashMap<std::string, int> map(bad_hash);
+  std::vector<PersistentHashMap<std::string, int>> versions;
+  versions.push_back(map);
+
+  for (int i = 0; i < 100; ++i)
+    {
+      map = map.insert(std::to_string(i), i * 10);
+      versions.push_back(map);
+      EXPECT_TRUE(map.verify());
+    }
+
+  EXPECT_EQ(map.size(), 100);
+  for (int i = 0; i < 100; ++i)
+    {
+      ASSERT_NE(map.find(std::to_string(i)), nullptr);
+      EXPECT_EQ(*map.find(std::to_string(i)), i * 10);
+    }
+
+  for (int i = 0; i <= 100; ++i)
+    EXPECT_EQ(versions[i].size(), i);
+
+  for (int i = 0; i < 100; ++i)
+    {
+      map = map.erase(std::to_string(i));
+      EXPECT_TRUE(map.verify());
+    }
+  EXPECT_TRUE(map.is_empty());
+}
+
+TEST(PersistentHashMap, CollisionInsertDoesNotOverwriteAndAssignDoes)
+{
+  PersistentHashMap<std::string, int> map(bad_hash);
+  auto base = map.insert("a", 1).insert("b", 2);
+
+  auto duplicate = base.insert("a", 99);
+  EXPECT_EQ(duplicate.size(), 2);
+  ASSERT_NE(duplicate.find("a"), nullptr);
+  EXPECT_EQ(*duplicate.find("a"), 1);
+
+  auto updated = base.insert_or_assign("a", 99);
+  EXPECT_EQ(updated.size(), 2);
+  ASSERT_NE(updated.find("a"), nullptr);
+  ASSERT_NE(updated.find("b"), nullptr);
+  EXPECT_EQ(*updated.find("a"), 99);
+  EXPECT_EQ(*updated.find("b"), 2);
+  EXPECT_TRUE(updated.verify());
+
+  ASSERT_NE(base.find("a"), nullptr);
+  EXPECT_EQ(*base.find("a"), 1);
+}
+
+TEST(PersistentHashMap, CustomComparatorAndCompatibleHash)
+{
+  PersistentHashMap<std::string, int, CaseEqual> map(case_hash, CaseEqual{});
+  auto m1 = map.insert("Aleph", 1);
+  auto duplicate = m1.insert("aleph", 2);
+  auto updated = m1.insert_or_assign("aleph", 2);
+
+  EXPECT_EQ(duplicate.size(), 1);
+  ASSERT_NE(duplicate.find("ALEPH"), nullptr);
+  EXPECT_EQ(*duplicate.find("ALEPH"), 1);
+
+  EXPECT_EQ(updated.size(), 1);
+  ASSERT_NE(updated.find("ALEPH"), nullptr);
+  EXPECT_EQ(*updated.find("ALEPH"), 2);
+  EXPECT_TRUE(updated.verify());
+}
+
+TEST(PersistentHashMap, RandomizedParity)
+{
+  std::mt19937 rng(42);
+  std::uniform_int_distribution<int> dist_op(0, 2);
+  std::uniform_int_distribution<int> dist_key(0, 500);
+
+  PersistentHashMap<int, std::string> pmap;
+  std::unordered_map<int, std::string> stdmap;
+  std::vector<PersistentHashMap<int, std::string>> versions;
+
+  versions.push_back(pmap);
+
+  for (int i = 0; i < 5000; ++i)
+    {
+      const int op = dist_op(rng);
+      const int key = dist_key(rng);
+
+      if (op == 0)
+        {
+          const std::string val = "insert" + std::to_string(key) + "_" + std::to_string(i);
+          pmap = pmap.insert(key, val);
+          stdmap.emplace(key, val);
+        }
+      else if (op == 1)
+        {
+          const std::string val = "assign" + std::to_string(key) + "_" + std::to_string(i);
+          pmap = pmap.insert_or_assign(key, val);
+          stdmap[key] = val;
+        }
+      else
+        {
+          pmap = pmap.erase(key);
+          stdmap.erase(key);
+        }
+
+      EXPECT_EQ(pmap.size(), stdmap.size());
+      EXPECT_TRUE(pmap.verify());
+
+      if (i % 100 == 0)
+        versions.push_back(pmap);
+    }
+
+  for (const auto &[k, v] : stdmap)
+    {
+      EXPECT_TRUE(pmap.contains(k));
+      ASSERT_NE(pmap.find(k), nullptr);
+      EXPECT_EQ(*pmap.find(k), v);
+    }
+
+  for (const auto &v_map : versions)
+    EXPECT_TRUE(v_map.verify());
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/Tests/persistent_hash_map_test.cc
+++ b/Tests/persistent_hash_map_test.cc
@@ -220,6 +220,30 @@ TEST(PersistentHashMap, AdversarialCollisions)
       EXPECT_EQ(*map.find(std::to_string(i)), i * 10);
     }
 
+  auto keys = map.keys();
+  auto items = map.items();
+  EXPECT_EQ(keys.size(), 100u);
+  EXPECT_EQ(items.size(), 100u);
+
+  std::unordered_map<std::string, bool> exported_keys;
+  for (size_t i = 0; i < keys.size(); ++i)
+    exported_keys.emplace(keys[i], true);
+
+  std::unordered_map<std::string, int> exported_items;
+  for (size_t i = 0; i < items.size(); ++i)
+    exported_items.emplace(items[i].first, items[i].second);
+
+  EXPECT_EQ(exported_keys.size(), 100u);
+  EXPECT_EQ(exported_items.size(), 100u);
+  for (int i = 0; i < 100; ++i)
+    {
+      const std::string key = std::to_string(i);
+      EXPECT_NE(exported_keys.find(key), exported_keys.end());
+      auto item = exported_items.find(key);
+      ASSERT_NE(item, exported_items.end());
+      EXPECT_EQ(item->second, i * 10);
+    }
+
   for (int i = 0; i <= 100; ++i)
     EXPECT_EQ(versions[i].size(), i);
 
@@ -321,10 +345,4 @@ TEST(PersistentHashMap, RandomizedParity)
 
   for (const auto &v_map : versions)
     EXPECT_TRUE(v_map.verify());
-}
-
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/Tests/persistent_treap_test.cc
+++ b/Tests/persistent_treap_test.cc
@@ -1,0 +1,319 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file persistent_treap_test.cc
+ * @brief Tests for Aleph::PersistentTreapSet and Aleph::PersistentTreapMap.
+ */
+
+#include <gtest/gtest.h>
+
+#include <tpl_persistent_treap.H>
+
+#include <map>
+#include <memory>
+#include <random>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace Aleph;
+
+namespace
+{
+  template <class ArrayType>
+  std::vector<typename ArrayType::Item_Type> to_vector(const ArrayType &array)
+  {
+    std::vector<typename ArrayType::Item_Type> out;
+    out.reserve(array.size());
+    for (size_t i = 0; i < array.size(); ++i)
+      out.push_back(array[i]);
+    return out;
+  }
+}
+
+TEST(PersistentTreapSet, InsertEraseAndVersionsAreIndependent)
+{
+  PersistentTreapSet<int> empty;
+  auto one = empty.insert(10);
+  auto two = one.insert(5).insert(20);
+  auto erased = two.erase(10);
+
+  EXPECT_TRUE(empty.is_empty());
+  EXPECT_FALSE(empty.contains(10));
+
+  EXPECT_EQ(one.size(), 1u);
+  EXPECT_TRUE(one.contains(10));
+  EXPECT_FALSE(one.contains(5));
+
+  EXPECT_EQ(two.size(), 3u);
+  EXPECT_TRUE(two.contains(5));
+  EXPECT_TRUE(two.contains(10));
+  EXPECT_TRUE(two.contains(20));
+
+  EXPECT_EQ(erased.size(), 2u);
+  EXPECT_FALSE(erased.contains(10));
+  EXPECT_TRUE(two.contains(10));  // old version unchanged
+
+  EXPECT_TRUE(empty.verify());
+  EXPECT_TRUE(one.verify());
+  EXPECT_TRUE(two.verify());
+  EXPECT_TRUE(erased.verify());
+}
+
+TEST(PersistentTreapSet, DuplicateInsertAndMissingEraseShareLogicalVersion)
+{
+  PersistentTreapSet<int> set;
+  auto one = set.insert(7);
+  auto duplicate = one.insert(7);
+  auto missing = duplicate.erase(99);
+
+  EXPECT_EQ(one.size(), 1u);
+  EXPECT_EQ(duplicate.size(), 1u);
+  EXPECT_EQ(missing.size(), 1u);
+  EXPECT_TRUE(missing.contains(7));
+  EXPECT_TRUE(missing.verify());
+}
+
+TEST(PersistentTreapSet, KeysAreSorted)
+{
+  PersistentTreapSet<int> set;
+  for (int x : {4, 1, 7, 3, 9, 2})
+    set = set.insert(x);
+
+  EXPECT_EQ(to_vector(set.keys()), (std::vector<int>{1, 2, 3, 4, 7, 9}));
+  EXPECT_TRUE(set.verify());
+}
+
+TEST(PersistentTreapSet, SplitAndJoin)
+{
+  PersistentTreapSet<int> set;
+  for (int i = 0; i < 10; ++i)
+    set = set.insert(i);
+
+  auto [left, right] = set.split(5);
+  EXPECT_EQ(to_vector(left.keys()), (std::vector<int>{0, 1, 2, 3, 4}));
+  EXPECT_EQ(to_vector(right.keys()), (std::vector<int>{5, 6, 7, 8, 9}));
+
+  auto joined = left.join(right);
+  EXPECT_EQ(to_vector(joined.keys()), (std::vector<int>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+  EXPECT_TRUE(left.verify());
+  EXPECT_TRUE(right.verify());
+  EXPECT_TRUE(joined.verify());
+}
+
+TEST(PersistentTreapSet, JoinRejectsOverlappingRanges)
+{
+  auto left = PersistentTreapSet<int>().insert(1).insert(3);
+  auto right = PersistentTreapSet<int>().insert(3).insert(5);
+
+  EXPECT_THROW((void)left.join(right), std::domain_error);
+}
+
+TEST(PersistentTreapSet, RandomizedTraceMatchesStdSetAndKeepsOldVersions)
+{
+  std::mt19937 rng(0x5EEDu);
+  std::uniform_int_distribution<int> key_dist(0, 80);
+  std::uniform_int_distribution<int> op_dist(0, 1);
+
+  PersistentTreapSet<int> subject;
+  std::set<int> reference;
+  std::vector<PersistentTreapSet<int>> old_subjects;
+  std::vector<std::set<int>> old_references;
+
+  for (int iter = 0; iter < 1200; ++iter)
+    {
+      if (iter % 37 == 0)
+        {
+          old_subjects.push_back(subject);
+          old_references.push_back(reference);
+        }
+
+      const int key = key_dist(rng);
+      if (op_dist(rng) == 0)
+        {
+          subject = subject.insert(key);
+          reference.insert(key);
+        }
+      else
+        {
+          subject = subject.erase(key);
+          reference.erase(key);
+        }
+
+      ASSERT_TRUE(subject.verify());
+      EXPECT_EQ(subject.size(), reference.size());
+      EXPECT_EQ(to_vector(subject.keys()),
+                std::vector<int>(reference.begin(), reference.end()));
+    }
+
+  for (size_t i = 0; i < old_subjects.size(); ++i)
+    EXPECT_EQ(to_vector(old_subjects[i].keys()),
+              std::vector<int>(old_references[i].begin(), old_references[i].end()));
+}
+
+TEST(PersistentTreapMap, InsertAssignEraseAndVersionsAreIndependent)
+{
+  PersistentTreapMap<int, std::string> empty;
+  auto one = empty.insert(1, std::string("one"));
+  auto two = one.insert(2, std::string("two"));
+  auto reassigned = two.insert_or_assign(1, std::string("uno"));
+  auto erased = reassigned.erase(2);
+
+  ASSERT_NE(one.find(1), nullptr);
+  EXPECT_EQ(*one.find(1), "one");
+  EXPECT_EQ(one.find(2), nullptr);
+
+  ASSERT_NE(two.find(2), nullptr);
+  EXPECT_EQ(*two.find(2), "two");
+  EXPECT_EQ(*two.find(1), "one");
+
+  EXPECT_EQ(*reassigned.find(1), "uno");
+  EXPECT_EQ(*two.find(1), "one");  // old version unchanged
+
+  EXPECT_FALSE(erased.contains(2));
+  EXPECT_TRUE(reassigned.contains(2));
+  EXPECT_TRUE(empty.verify());
+  EXPECT_TRUE(one.verify());
+  EXPECT_TRUE(two.verify());
+  EXPECT_TRUE(reassigned.verify());
+  EXPECT_TRUE(erased.verify());
+}
+
+TEST(PersistentTreapMap, DuplicateInsertDoesNotOverwrite)
+{
+  auto map = PersistentTreapMap<int, std::string>()
+               .insert(4, std::string("four"))
+               .insert(4, std::string("cuatro"));
+
+  ASSERT_NE(map.find(4), nullptr);
+  EXPECT_EQ(*map.find(4), "four");
+  EXPECT_EQ(map.size(), 1u);
+  EXPECT_TRUE(map.verify());
+}
+
+TEST(PersistentTreapMap, SplitJoinAndItems)
+{
+  PersistentTreapMap<int, std::string> map;
+  for (int i = 0; i < 6; ++i)
+    map = map.insert(i, std::to_string(i));
+
+  auto [left, right] = map.split(3);
+  EXPECT_EQ(to_vector(left.keys()), (std::vector<int>{0, 1, 2}));
+  EXPECT_EQ(to_vector(right.keys()), (std::vector<int>{3, 4, 5}));
+
+  auto joined = PersistentTreapMap<int, std::string>::join(left, right);
+  auto items = joined.items();
+  ASSERT_EQ(items.size(), 6u);
+  for (size_t i = 0; i < items.size(); ++i)
+    {
+      EXPECT_EQ(items[i].first, static_cast<int>(i));
+      EXPECT_EQ(items[i].second, std::to_string(i));
+    }
+  EXPECT_TRUE(joined.verify());
+}
+
+TEST(PersistentTreapMap, SupportsMoveOnlyMappedValues)
+{
+  PersistentTreapMap<int, std::unique_ptr<int>> map;
+  auto one = map.insert(1, std::make_unique<int>(10));
+  auto two = one.insert_or_assign(1, std::make_unique<int>(20));
+  auto three = two.insert(2, std::make_unique<int>(30));
+
+  ASSERT_NE(one.find(1), nullptr);
+  ASSERT_NE(two.find(1), nullptr);
+  ASSERT_NE(three.find(2), nullptr);
+  EXPECT_EQ(**one.find(1), 10);
+  EXPECT_EQ(**two.find(1), 20);
+  EXPECT_EQ(**three.find(2), 30);
+  EXPECT_TRUE(one.verify());
+  EXPECT_TRUE(two.verify());
+  EXPECT_TRUE(three.verify());
+}
+
+TEST(PersistentTreapMap, RandomizedTraceMatchesStdMapAndKeepsOldVersions)
+{
+  std::mt19937 rng(0xBADC0DEu);
+  std::uniform_int_distribution<int> key_dist(0, 60);
+  std::uniform_int_distribution<int> value_dist(-1000, 1000);
+  std::uniform_int_distribution<int> op_dist(0, 2);
+
+  PersistentTreapMap<int, int> subject;
+  std::map<int, int> reference;
+  std::vector<PersistentTreapMap<int, int>> old_subjects;
+  std::vector<std::map<int, int>> old_references;
+
+  for (int iter = 0; iter < 1500; ++iter)
+    {
+      if (iter % 41 == 0)
+        {
+          old_subjects.push_back(subject);
+          old_references.push_back(reference);
+        }
+
+      const int key = key_dist(rng);
+      const int op = op_dist(rng);
+      if (op == 0)
+        {
+          const int value = value_dist(rng);
+          subject = subject.insert(key, value);
+          reference.insert({key, value});
+        }
+      else if (op == 1)
+        {
+          const int value = value_dist(rng);
+          subject = subject.insert_or_assign(key, value);
+          reference[key] = value;
+        }
+      else
+        {
+          subject = subject.erase(key);
+          reference.erase(key);
+        }
+
+      ASSERT_TRUE(subject.verify());
+      EXPECT_EQ(subject.size(), reference.size());
+      for (const auto &[k, v] : reference)
+        {
+          ASSERT_NE(subject.find(k), nullptr);
+          EXPECT_EQ(*subject.find(k), v);
+        }
+    }
+
+  for (size_t i = 0; i < old_subjects.size(); ++i)
+    {
+      EXPECT_EQ(old_subjects[i].size(), old_references[i].size());
+      for (const auto &[k, v] : old_references[i])
+        {
+          ASSERT_NE(old_subjects[i].find(k), nullptr);
+          EXPECT_EQ(*old_subjects[i].find(k), v);
+        }
+    }
+}

--- a/Tests/persistent_treap_test.cc
+++ b/Tests/persistent_treap_test.cc
@@ -48,6 +48,16 @@ using namespace Aleph;
 
 namespace
 {
+  struct DirectionalIntCompare
+  {
+    bool reverse = false;
+
+    bool operator () (const int lhs, const int rhs) const noexcept
+    {
+      return reverse ? lhs > rhs : lhs < rhs;
+    }
+  };
+
   template <class ArrayType>
   std::vector<typename ArrayType::Item_Type> to_vector(const ArrayType &array)
   {
@@ -134,6 +144,19 @@ TEST(PersistentTreapSet, JoinRejectsOverlappingRanges)
   auto left = PersistentTreapSet<int>().insert(1).insert(3);
   auto right = PersistentTreapSet<int>().insert(3).insert(5);
 
+  EXPECT_THROW((void)left.join(right), std::domain_error);
+}
+
+TEST(PersistentTreapSet, JoinRejectsRightTreeOrderedByIncompatibleComparatorState)
+{
+  PersistentTreapSet<int, DirectionalIntCompare> left{DirectionalIntCompare{false}};
+  left = left.insert(1).insert(2);
+
+  PersistentTreapSet<int, DirectionalIntCompare> right{DirectionalIntCompare{true}};
+  right = right.insert(6).insert(5).insert(4);
+
+  ASSERT_TRUE(left.verify());
+  ASSERT_TRUE(right.verify());
   EXPECT_THROW((void)left.join(right), std::domain_error);
 }
 
@@ -238,6 +261,21 @@ TEST(PersistentTreapMap, SplitJoinAndItems)
       EXPECT_EQ(items[i].second, std::to_string(i));
     }
   EXPECT_TRUE(joined.verify());
+}
+
+TEST(PersistentTreapMap, JoinRejectsRightTreeOrderedByIncompatibleComparatorState)
+{
+  PersistentTreapMap<int, std::string, DirectionalIntCompare> left{DirectionalIntCompare{false}};
+  left = left.insert(1, std::string("one")).insert(2, std::string("two"));
+
+  PersistentTreapMap<int, std::string, DirectionalIntCompare> right{DirectionalIntCompare{true}};
+  right = right.insert(6, std::string("six"))
+           .insert(5, std::string("five"))
+           .insert(4, std::string("four"));
+
+  ASSERT_TRUE(left.verify());
+  ASSERT_TRUE(right.verify());
+  EXPECT_THROW((void)left.join(right), std::domain_error);
 }
 
 TEST(PersistentTreapMap, SupportsMoveOnlyMappedValues)

--- a/Tests/persistent_vector_test.cc
+++ b/Tests/persistent_vector_test.cc
@@ -45,6 +45,48 @@ using namespace Aleph;
 
 namespace
 {
+  struct CopyTrackedValue
+  {
+    static inline int copy_assignments = 0;
+    static inline int moves = 0;
+
+    int value = 0;
+
+    CopyTrackedValue() = default;
+    explicit CopyTrackedValue(const int v) noexcept : value(v) {}
+    CopyTrackedValue(const CopyTrackedValue &) = default;
+
+    CopyTrackedValue &operator = (const CopyTrackedValue &other) noexcept
+    {
+      value = other.value;
+      ++copy_assignments;
+      return *this;
+    }
+
+    CopyTrackedValue(CopyTrackedValue &&other) noexcept : value(other.value)
+    {
+      ++moves;
+    }
+
+    CopyTrackedValue &operator = (CopyTrackedValue &&other) noexcept
+    {
+      value = other.value;
+      ++moves;
+      return *this;
+    }
+
+    bool operator == (const CopyTrackedValue &other) const noexcept
+    {
+      return value == other.value;
+    }
+
+    static void reset_counters() noexcept
+    {
+      copy_assignments = 0;
+      moves = 0;
+    }
+  };
+
   template <typename T>
   std::vector<T> to_vector(const PersistentVector<T> &vector)
   {
@@ -152,6 +194,24 @@ TEST(PersistentVector, ToArrayCopiesValues)
   ASSERT_EQ(array.size(), 10u);
   for (size_t i = 0; i < array.size(); ++i)
     EXPECT_EQ(array[i], static_cast<int>(i));
+}
+
+TEST(PersistentVector, ToArrayCopiesWithoutMovingFromTemporaries)
+{
+  PersistentVector<CopyTrackedValue> vector;
+  const CopyTrackedValue one{1};
+  const CopyTrackedValue two{2};
+
+  vector = vector.push_back(one).push_back(two);
+
+  CopyTrackedValue::reset_counters();
+  auto array = vector.to_array();
+  ASSERT_EQ(array.size(), 2u);
+  EXPECT_EQ(array[0].value, 1);
+  EXPECT_EQ(array[1].value, 2);
+  EXPECT_EQ(CopyTrackedValue::copy_assignments, 2);
+  EXPECT_EQ(CopyTrackedValue::moves, 0);
+  EXPECT_TRUE(vector.verify());
 }
 
 TEST(PersistentVector, SupportsMoveOnlyValues)

--- a/Tests/persistent_vector_test.cc
+++ b/Tests/persistent_vector_test.cc
@@ -1,0 +1,222 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file persistent_vector_test.cc
+ * @brief Tests for Aleph::PersistentVector.
+ */
+
+#include <gtest/gtest.h>
+
+#include <tpl_persistent_vector.H>
+
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+using namespace Aleph;
+
+namespace
+{
+  template <typename T>
+  std::vector<T> to_vector(const PersistentVector<T> &vector)
+  {
+    std::vector<T> out;
+    out.reserve(vector.size());
+    for (size_t i = 0; i < vector.size(); ++i)
+      out.push_back(vector.get(i));
+    return out;
+  }
+}
+
+TEST(PersistentVector, EmptyVectorBasics)
+{
+  PersistentVector<int> vector;
+
+  EXPECT_TRUE(vector.is_empty());
+  EXPECT_EQ(vector.size(), 0u);
+  EXPECT_EQ(PersistentVector<int>::branching_factor(), 32u);
+  EXPECT_TRUE(vector.verify());
+  EXPECT_THROW(vector.get(0), std::out_of_range);
+  EXPECT_THROW(vector.pop_back(), std::underflow_error);
+}
+
+TEST(PersistentVector, PushBackAndOldVersionsAreIndependent)
+{
+  PersistentVector<int> empty;
+  auto one = empty.push_back(10);
+  auto two = one.push_back(20);
+  auto three = two.push_back(30);
+
+  EXPECT_TRUE(empty.is_empty());
+  EXPECT_EQ(one.size(), 1u);
+  EXPECT_EQ(two.size(), 2u);
+  EXPECT_EQ(three.size(), 3u);
+
+  EXPECT_EQ(one.get(0), 10);
+  EXPECT_EQ(two.get(0), 10);
+  EXPECT_EQ(two.get(1), 20);
+  EXPECT_EQ(three.get(2), 30);
+  EXPECT_TRUE(empty.verify());
+  EXPECT_TRUE(one.verify());
+  EXPECT_TRUE(two.verify());
+  EXPECT_TRUE(three.verify());
+}
+
+TEST(PersistentVector, SetReturnsNewVersion)
+{
+  auto base = PersistentVector<int>().push_back(1).push_back(2).push_back(3);
+  auto changed = base.set(1, 99);
+
+  EXPECT_EQ(to_vector(base), (std::vector<int>{1, 2, 3}));
+  EXPECT_EQ(to_vector(changed), (std::vector<int>{1, 99, 3}));
+  EXPECT_TRUE(base.verify());
+  EXPECT_TRUE(changed.verify());
+  EXPECT_THROW(base.set(3, 10), std::out_of_range);
+}
+
+TEST(PersistentVector, PopBackReturnsNewVersionAndShrinksLevels)
+{
+  PersistentVector<int> vector;
+  for (int i = 0; i < 40; ++i)
+    vector = vector.push_back(i);
+
+  auto popped = vector.pop_back();
+  for (int i = 0; i < 7; ++i)
+    popped = popped.pop_back();
+
+  EXPECT_EQ(vector.size(), 40u);
+  EXPECT_EQ(popped.size(), 32u);
+  EXPECT_EQ(vector.get(39), 39);
+  EXPECT_EQ(popped.get(31), 31);
+  EXPECT_THROW(popped.get(32), std::out_of_range);
+  EXPECT_TRUE(vector.verify());
+  EXPECT_TRUE(popped.verify());
+}
+
+TEST(PersistentVector, GrowsBeyondTwoTrieLevels)
+{
+  PersistentVector<int> vector;
+  for (int i = 0; i < 1100; ++i)
+    vector = vector.push_back(i * 3);
+
+  ASSERT_EQ(vector.size(), 1100u);
+  EXPECT_EQ(vector.get(0), 0);
+  EXPECT_EQ(vector.get(31), 93);
+  EXPECT_EQ(vector.get(32), 96);
+  EXPECT_EQ(vector.get(1023), 3069);
+  EXPECT_EQ(vector.get(1024), 3072);
+  EXPECT_EQ(vector.get(1099), 3297);
+
+  auto changed = vector.set(1024, -1);
+  EXPECT_EQ(vector.get(1024), 3072);
+  EXPECT_EQ(changed.get(1024), -1);
+  EXPECT_TRUE(vector.verify());
+  EXPECT_TRUE(changed.verify());
+}
+
+TEST(PersistentVector, ToArrayCopiesValues)
+{
+  PersistentVector<int> vector;
+  for (int i = 0; i < 10; ++i)
+    vector = vector.push_back(i);
+
+  auto array = vector.to_array();
+  ASSERT_EQ(array.size(), 10u);
+  for (size_t i = 0; i < array.size(); ++i)
+    EXPECT_EQ(array[i], static_cast<int>(i));
+}
+
+TEST(PersistentVector, SupportsMoveOnlyValues)
+{
+  PersistentVector<std::unique_ptr<int>> vector;
+  auto one = vector.push_back(std::make_unique<int>(10));
+  auto two = one.push_back(std::make_unique<int>(20));
+  auto changed = two.set(0, std::make_unique<int>(99));
+
+  EXPECT_EQ(*one.get(0), 10);
+  EXPECT_EQ(*two.get(0), 10);
+  EXPECT_EQ(*two.get(1), 20);
+  EXPECT_EQ(*changed.get(0), 99);
+  EXPECT_EQ(*changed.get(1), 20);
+  EXPECT_TRUE(one.verify());
+  EXPECT_TRUE(two.verify());
+  EXPECT_TRUE(changed.verify());
+}
+
+TEST(PersistentVector, RandomizedTraceMatchesStdVectorAndKeepsOldVersions)
+{
+  std::mt19937 rng(0xFACEB00Cu);
+  std::uniform_int_distribution<int> op_dist(0, 2);
+  std::uniform_int_distribution<int> value_dist(-5000, 5000);
+
+  PersistentVector<int> subject;
+  std::vector<int> reference;
+  std::vector<PersistentVector<int>> old_subjects;
+  std::vector<std::vector<int>> old_references;
+
+  for (int iter = 0; iter < 1800; ++iter)
+    {
+      if (iter % 53 == 0)
+        {
+          old_subjects.push_back(subject);
+          old_references.push_back(reference);
+        }
+
+      const int op = reference.empty() ? 0 : op_dist(rng);
+      if (op == 0)
+        {
+          const int value = value_dist(rng);
+          subject = subject.push_back(value);
+          reference.push_back(value);
+        }
+      else if (op == 1)
+        {
+          std::uniform_int_distribution<size_t> index_dist(0, reference.size() - 1);
+          const size_t index = index_dist(rng);
+          const int value = value_dist(rng);
+          subject = subject.set(index, value);
+          reference[index] = value;
+        }
+      else
+        {
+          subject = subject.pop_back();
+          reference.pop_back();
+        }
+
+      ASSERT_TRUE(subject.verify());
+      ASSERT_EQ(subject.size(), reference.size());
+      for (size_t i = 0; i < reference.size(); ++i)
+        ASSERT_EQ(subject.get(i), reference[i]) << "index " << i;
+    }
+
+  for (size_t i = 0; i < old_subjects.size(); ++i)
+    EXPECT_EQ(to_vector(old_subjects[i]), old_references[i]);
+}

--- a/tpl_persistent_hash_map.H
+++ b/tpl_persistent_hash_map.H
@@ -100,10 +100,10 @@ namespace Aleph
  *  stored in a special collision node (`CollisionNode`), which acts as 
  *  a small linear array.
  *
- *  @tparam Key Key type. It must be copy-constructible.
- *  @tparam T Mapped value type. It must be copy-constructible so path-copying
- *          updates can rebuild shared collision nodes without moving from old
- *          versions.
+ *  @tparam Key Key type. It must be copy-constructible and copy-assignable.
+ *  @tparam T Mapped value type. It must be copy-constructible and copy-assignable
+ *          so path-copying updates can rebuild shared collision nodes without
+ *          moving from old versions.
  *  @tparam Cmp Equality predicate. If `cmp(a, b)` is true, the hash function
  *          supplied to the constructor must return the same hash for `a` and
  *          `b`.
@@ -113,8 +113,12 @@ class PersistentHashMap
 {
   static_assert(std::is_copy_constructible_v<Key>,
                 "PersistentHashMap requires copy-constructible keys");
+  static_assert(std::is_copy_assignable_v<Key>,
+                "PersistentHashMap requires copy-assignable keys");
   static_assert(std::is_copy_constructible_v<T>,
                 "PersistentHashMap requires copy-constructible mapped values");
+  static_assert(std::is_copy_assignable_v<T>,
+                "PersistentHashMap requires copy-assignable mapped values");
   static_assert(std::is_copy_constructible_v<Cmp>,
                 "PersistentHashMap requires a copy-constructible comparator");
 

--- a/tpl_persistent_hash_map.H
+++ b/tpl_persistent_hash_map.H
@@ -1,0 +1,868 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/** @file tpl_persistent_hash_map.H
+ *  @brief Immutable path-copying hash map backed by a HAMT.
+ *
+ *  `PersistentHashMap` is an in-memory persistent collection: operations that
+ *  look like updates return a new collection version and never mutate the old
+ *  one. Unchanged trie nodes are shared through `std::shared_ptr<const Node>`.
+ *
+ *  This is unrelated to Aleph's file-backed persistence. Values are volatile
+ *  in-memory objects and are not durable storage.
+ *
+ *  @par Complexity
+ *  Lookup, insertion and erasure are expected O(1) for well-distributed hashes
+ *  because the trie depth is bounded by the width of `size_t`. Keys with the
+ *  same full hash are stored in a collision node and cost O(k) inside that
+ *  collision group.
+ *
+ *  @par Thread safety
+ *  Published versions are immutable. Different threads may read distinct
+ *  collection objects that share the same trie without synchronization. The
+ *  publication of a new version into a shared variable is still the user's
+ *  responsibility and must be synchronized externally.
+ *
+ *  @ingroup Hash
+ */
+
+#ifndef TPL_PERSISTENT_HASH_MAP_H
+#define TPL_PERSISTENT_HASH_MAP_H
+
+#include <bit>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <ah-errors.H>
+#include <ahFunction.H>
+#include <hash-fct.H>
+#include <tpl_array.H>
+
+namespace Aleph
+{
+
+/** @brief Immutable unordered map backed by a Hash Array Mapped Trie (HAMT).
+ *
+ *  @details 
+ *  ### What is a Persistent HAMT?
+ *  A HAMT (Hash Array Mapped Trie) is a search trie where keys are not used 
+ *  directly for the search path; instead, they are routed using fragments of 
+ *  their hash value. At each level of the tree, 5 bits of the hash are consumed 
+ *  (allowing 32 possible branches per level).
+ *
+ *  "Persistence" in this context means **immutability with history** 
+ *  (structural sharing / path-copying), not disk storage. When an element is 
+ *  inserted or erased, the original container does not mutate; instead, a 
+ *  **new** map containing the modification is returned. Nodes that were not 
+ *  affected by the operation are recycled and shared between the old and new 
+ *  versions using smart pointers (`std::shared_ptr`).
+ *  This makes copying the container an immediate O(1) operation and allows 
+ *  multiple threads to read different versions without using locks.
+ *
+ *  ### How does compression work (BitmapNode)?
+ *  To avoid wasting memory with arrays of 32 pointers filled with nulls, 
+ *  a 32-bit bitmap is used. If an internal node has only 3 children, its 
+ *  `bitmap` will have exactly 3 bits set, and it will store an array of 
+ *  exactly 3 pointers. The real position of the pointer is calculated 
+ *  super-efficiently using the hardware instruction `std::popcount`.
+ * 
+ *  ### Collisions
+ *  If two distinct keys produce exactly the same 64-bit hash, they are 
+ *  stored in a special collision node (`CollisionNode`), which acts as 
+ *  a small linear array.
+ *
+ *  @tparam Key Key type. It must be copy-constructible.
+ *  @tparam T Mapped value type. It must be copy-constructible so path-copying
+ *          updates can rebuild shared collision nodes without moving from old
+ *          versions.
+ *  @tparam Cmp Equality predicate. If `cmp(a, b)` is true, the hash function
+ *          supplied to the constructor must return the same hash for `a` and
+ *          `b`.
+ */
+template <typename Key, typename T, class Cmp = Aleph::equal_to<Key>>
+class PersistentHashMap
+{
+  static_assert(std::is_copy_constructible_v<Key>,
+                "PersistentHashMap requires copy-constructible keys");
+  static_assert(std::is_copy_constructible_v<T>,
+                "PersistentHashMap requires copy-constructible mapped values");
+  static_assert(std::is_copy_constructible_v<Cmp>,
+                "PersistentHashMap requires a copy-constructible comparator");
+
+public:
+  /// @brief Hash function pointer type used by this map.
+  using Hash_Fct_Ptr = size_t (*)(const Key &);
+
+private:
+  static constexpr size_t BITS_PER_LEVEL = 5;
+  static constexpr size_t BRANCHING_FACTOR = 1ULL << BITS_PER_LEVEL;
+  static constexpr size_t LEVEL_MASK = BRANCHING_FACTOR - 1;
+
+  /// @brief Types of polymorphic nodes in the HAMT.
+  enum class NodeType
+  {
+    LEAF,      ///< Terminal leaf node that stores exactly one (key, value) pair.
+    BITMAP,    ///< Compressed internal node that uses a 32-bit bitmap for routing.
+    COLLISION  ///< Terminal node that stores multiple (key, value) pairs with the exact same hash.
+  };
+
+  /// @brief Polymorphic base node managed by std::shared_ptr for structural sharing.
+  struct Node
+  {
+    NodeType type;
+
+    explicit Node(const NodeType t) noexcept
+      : type(t)
+    {
+      // Empty.
+    }
+
+    virtual ~Node() = default;
+  };
+
+  using NodePtr = std::shared_ptr<const Node>;
+
+  struct LeafNode : public Node
+  {
+    Key key;
+    T value;
+    size_t hash;
+
+    LeafNode(Key k, T v, const size_t h)
+      : Node(NodeType::LEAF), key(std::move(k)), value(std::move(v)), hash(h)
+    {
+      // Empty.
+    }
+  };
+
+  struct BitmapNode : public Node
+  {
+    std::uint32_t bitmap = 0;
+    Array<NodePtr> children;
+
+    BitmapNode(const std::uint32_t b, Array<NodePtr> c)
+      : Node(NodeType::BITMAP), bitmap(b), children(std::move(c))
+    {
+      // Empty.
+    }
+  };
+
+  struct CollisionNode : public Node
+  {
+    size_t hash = 0;
+    Array<std::pair<Key, T>> entries;
+
+    CollisionNode(const size_t h, Array<std::pair<Key, T>> e)
+      : Node(NodeType::COLLISION), hash(h), entries(std::move(e))
+    {
+      // Empty.
+    }
+  };
+
+  NodePtr root_;
+  Hash_Fct_Ptr hash_fct_;
+  Cmp cmp_;
+  size_t size_ = 0;
+
+  explicit PersistentHashMap(NodePtr root,
+                             const Hash_Fct_Ptr hash_fct,
+                             Cmp cmp,
+                             const size_t size)
+    : root_(std::move(root)), hash_fct_(hash_fct), cmp_(std::move(cmp)), size_(size)
+  {
+    // Empty.
+  }
+
+  [[nodiscard]] static size_t bitpos(const size_t hash, const size_t shift) noexcept
+  {
+    return (hash >> shift) & LEVEL_MASK;
+  }
+
+  [[nodiscard]] static std::uint32_t bit(const size_t pos) noexcept
+  {
+    return std::uint32_t{1} << pos;
+  }
+
+  [[nodiscard]] static size_t index(const std::uint32_t bitmap,
+                                    const std::uint32_t bit_value) noexcept
+  {
+    return std::popcount(bitmap & (bit_value - 1));
+  }
+
+  [[nodiscard]] static NodePtr make_leaf(const Key &key, const T &value, const size_t hash)
+  {
+    return std::make_shared<LeafNode>(key, value, hash);
+  }
+
+  [[nodiscard]] static NodePtr make_leaf(const Key &key, T &&value, const size_t hash)
+  {
+    return std::make_shared<LeafNode>(key, std::move(value), hash);
+  }
+
+  [[nodiscard]] static NodePtr make_leaf_from_value(const Key &key,
+                                                    const T *value,
+                                                    T *movable_value,
+                                                    const size_t hash)
+  {
+    return movable_value != nullptr
+      ? make_leaf(key, std::move(*movable_value), hash)
+      : make_leaf(key, *value, hash);
+  }
+
+  static void append_entry(Array<std::pair<Key, T>> &entries,
+                           const Key &key,
+                           const T *value,
+                           T *movable_value)
+  {
+    if (movable_value != nullptr)
+      entries.append(std::pair<Key, T>{key, std::move(*movable_value)});
+    else
+      entries.append(std::pair<Key, T>{key, *value});
+  }
+
+  [[nodiscard]] NodePtr merge_leaves(const NodePtr &n1,
+                                     const NodePtr &n2,
+                                     const size_t shift) const
+  {
+    const size_t h1 = n1->type == NodeType::LEAF
+      ? static_cast<const LeafNode *>(n1.get())->hash
+      : static_cast<const CollisionNode *>(n1.get())->hash;
+    const size_t h2 = n2->type == NodeType::LEAF
+      ? static_cast<const LeafNode *>(n2.get())->hash
+      : static_cast<const CollisionNode *>(n2.get())->hash;
+
+    const size_t p1 = bitpos(h1, shift);
+    const size_t p2 = bitpos(h2, shift);
+
+    if (p1 != p2)
+      {
+        Array<NodePtr> children;
+        children.reserve(2);
+        if (p1 < p2)
+          {
+            children.append(n1);
+            children.append(n2);
+          }
+        else
+          {
+            children.append(n2);
+            children.append(n1);
+          }
+        return std::make_shared<BitmapNode>(bit(p1) | bit(p2), std::move(children));
+      }
+
+    Array<NodePtr> children;
+    children.append(merge_leaves(n1, n2, shift + BITS_PER_LEVEL));
+    return std::make_shared<BitmapNode>(bit(p1), std::move(children));
+  }
+
+  [[nodiscard]] NodePtr insert_impl(const NodePtr &node,
+                                    const Key &key,
+                                    const T *value,
+                                    T *movable_value,
+                                    const size_t hash,
+                                    const size_t shift,
+                                    const bool replace,
+                                    bool &added,
+                                    bool &changed) const
+  {
+    if (node == nullptr)
+      {
+        added = true;
+        changed = true;
+        return make_leaf_from_value(key, value, movable_value, hash);
+      }
+
+    if (node->type == NodeType::LEAF)
+      {
+        const auto leaf = static_cast<const LeafNode *>(node.get());
+        if (cmp_(key, leaf->key))
+          {
+            added = false;
+            if (not replace)
+              {
+                changed = false;
+                return node;
+              }
+
+            changed = true;
+            return make_leaf_from_value(leaf->key, value, movable_value, leaf->hash);
+          }
+
+        if (leaf->hash == hash)
+          {
+            Array<std::pair<Key, T>> entries;
+            entries.reserve(2);
+            entries.append(std::pair<Key, T>{leaf->key, leaf->value});
+            append_entry(entries, key, value, movable_value);
+            added = true;
+            changed = true;
+            return std::make_shared<CollisionNode>(hash, std::move(entries));
+          }
+
+        NodePtr new_leaf = make_leaf_from_value(key, value, movable_value, hash);
+        added = true;
+        changed = true;
+        return merge_leaves(node, new_leaf, shift);
+      }
+
+    if (node->type == NodeType::BITMAP)
+      {
+        const auto bnode = static_cast<const BitmapNode *>(node.get());
+        const size_t pos = bitpos(hash, shift);
+        const std::uint32_t b = bit(pos);
+        const size_t idx = index(bnode->bitmap, b);
+
+        if ((bnode->bitmap & b) == 0)
+          {
+            Array<NodePtr> new_children;
+            new_children.reserve(bnode->children.size() + 1);
+            for (size_t i = 0; i < idx; ++i)
+              new_children.append(bnode->children[i]);
+            new_children.append(make_leaf_from_value(key, value, movable_value, hash));
+            for (size_t i = idx; i < bnode->children.size(); ++i)
+              new_children.append(bnode->children[i]);
+
+            added = true;
+            changed = true;
+            return std::make_shared<BitmapNode>(bnode->bitmap | b, std::move(new_children));
+          }
+
+        const NodePtr child = bnode->children[idx];
+        NodePtr new_child = insert_impl(child, key, value, movable_value, hash,
+                                        shift + BITS_PER_LEVEL, replace, added, changed);
+        if (not changed)
+          return node;
+
+        Array<NodePtr> new_children = bnode->children;
+        new_children[idx] = std::move(new_child);
+        return std::make_shared<BitmapNode>(bnode->bitmap, std::move(new_children));
+      }
+
+    if (node->type == NodeType::COLLISION)
+      {
+        const auto cnode = static_cast<const CollisionNode *>(node.get());
+        if (hash != cnode->hash)
+          {
+            NodePtr new_leaf = make_leaf_from_value(key, value, movable_value, hash);
+            added = true;
+            changed = true;
+            return merge_leaves(node, new_leaf, shift);
+          }
+
+        if (not replace)
+          for (const auto &entry : cnode->entries)
+            if (cmp_(key, entry.first))
+              {
+                added = false;
+                changed = false;
+                return node;
+              }
+
+        Array<std::pair<Key, T>> new_entries;
+        new_entries.reserve(cnode->entries.size() + 1);
+        bool found = false;
+        for (const auto &entry : cnode->entries)
+          if (cmp_(key, entry.first) and not found)
+            {
+              append_entry(new_entries, entry.first, value, movable_value);
+              found = true;
+            }
+          else
+            new_entries.append(entry);
+
+        if (not found)
+          {
+            append_entry(new_entries, key, value, movable_value);
+            added = true;
+          }
+        else
+          added = false;
+
+        changed = true;
+        return std::make_shared<CollisionNode>(hash, std::move(new_entries));
+      }
+
+    changed = false;
+    return node;
+  }
+
+  [[nodiscard]] NodePtr erase_impl(const NodePtr &node,
+                                   const Key &key,
+                                   const size_t hash,
+                                   const size_t shift,
+                                   bool &removed) const
+  {
+    if (node == nullptr)
+      return nullptr;
+
+    if (node->type == NodeType::LEAF)
+      {
+        const auto leaf = static_cast<const LeafNode *>(node.get());
+        if (cmp_(key, leaf->key))
+          {
+            removed = true;
+            return nullptr;
+          }
+        return node;
+      }
+
+    if (node->type == NodeType::BITMAP)
+      {
+        const auto bnode = static_cast<const BitmapNode *>(node.get());
+        const size_t pos = bitpos(hash, shift);
+        const std::uint32_t b = bit(pos);
+        if ((bnode->bitmap & b) == 0)
+          return node;
+
+        const size_t idx = index(bnode->bitmap, b);
+        const NodePtr child = bnode->children[idx];
+        NodePtr new_child = erase_impl(child, key, hash, shift + BITS_PER_LEVEL, removed);
+        if (new_child == child)
+          return node;
+
+        if (new_child == nullptr)
+          {
+            if (bnode->bitmap == b)
+              return nullptr;
+
+            if (std::popcount(bnode->bitmap) == 2)
+              {
+                const size_t other_idx = idx == 0 ? 1 : 0;
+                NodePtr other_child = bnode->children[other_idx];
+                if (other_child->type == NodeType::LEAF or
+                    other_child->type == NodeType::COLLISION)
+                  return other_child;
+              }
+
+            Array<NodePtr> new_children;
+            new_children.reserve(bnode->children.size() - 1);
+            for (size_t i = 0; i < bnode->children.size(); ++i)
+              if (i != idx)
+                new_children.append(bnode->children[i]);
+            return std::make_shared<BitmapNode>(bnode->bitmap & ~b, std::move(new_children));
+          }
+
+        Array<NodePtr> new_children = bnode->children;
+        new_children[idx] = std::move(new_child);
+        if (new_children.size() == 1 and
+            (new_children[0]->type == NodeType::LEAF or
+             new_children[0]->type == NodeType::COLLISION))
+          return new_children[0];
+        return std::make_shared<BitmapNode>(bnode->bitmap, std::move(new_children));
+      }
+
+    if (node->type == NodeType::COLLISION)
+      {
+        const auto cnode = static_cast<const CollisionNode *>(node.get());
+        if (hash != cnode->hash)
+          return node;
+
+        Array<std::pair<Key, T>> new_entries;
+        new_entries.reserve(cnode->entries.size());
+        for (const auto &entry : cnode->entries)
+          if (cmp_(key, entry.first))
+            removed = true;
+          else
+            new_entries.append(entry);
+
+        if (not removed)
+          return node;
+        if (new_entries.size() == 1)
+          return std::make_shared<LeafNode>(new_entries[0].first,
+                                            new_entries[0].second,
+                                            hash);
+        return std::make_shared<CollisionNode>(hash, std::move(new_entries));
+      }
+
+    return node;
+  }
+
+  [[nodiscard]] const T *find_impl(const NodePtr &node,
+                                   const Key &key,
+                                   const size_t hash,
+                                   const size_t shift) const
+  {
+    if (node == nullptr)
+      return nullptr;
+
+    if (node->type == NodeType::LEAF)
+      {
+        const auto leaf = static_cast<const LeafNode *>(node.get());
+        return cmp_(key, leaf->key) ? &leaf->value : nullptr;
+      }
+
+    if (node->type == NodeType::BITMAP)
+      {
+        const auto bnode = static_cast<const BitmapNode *>(node.get());
+        const size_t pos = bitpos(hash, shift);
+        const std::uint32_t b = bit(pos);
+        if ((bnode->bitmap & b) == 0)
+          return nullptr;
+        return find_impl(bnode->children[index(bnode->bitmap, b)],
+                         key, hash, shift + BITS_PER_LEVEL);
+      }
+
+    if (node->type == NodeType::COLLISION)
+      {
+        const auto cnode = static_cast<const CollisionNode *>(node.get());
+        if (hash != cnode->hash)
+          return nullptr;
+        for (const auto &entry : cnode->entries)
+          if (cmp_(key, entry.first))
+            return &entry.second;
+      }
+
+    return nullptr;
+  }
+
+  [[nodiscard]] bool hashes_match_slot(const NodePtr &node,
+                                       const size_t shift,
+                                       const size_t pos) const
+  {
+    if (node == nullptr)
+      return false;
+    if (node->type == NodeType::LEAF)
+      return bitpos(static_cast<const LeafNode *>(node.get())->hash, shift) == pos;
+    if (node->type == NodeType::COLLISION)
+      return bitpos(static_cast<const CollisionNode *>(node.get())->hash, shift) == pos;
+
+    const auto bnode = static_cast<const BitmapNode *>(node.get());
+    for (size_t i = 0; i < bnode->children.size(); ++i)
+      if (not hashes_match_slot(bnode->children[i], shift, pos))
+        return false;
+    return true;
+  }
+
+  [[nodiscard]] bool collision_keys_are_unique(const CollisionNode &node) const
+  {
+    for (size_t i = 0; i < node.entries.size(); ++i)
+      for (size_t j = i + 1; j < node.entries.size(); ++j)
+        if (cmp_(node.entries[i].first, node.entries[j].first))
+          return false;
+    return true;
+  }
+
+  [[nodiscard]] bool verify_rec(const NodePtr &node, const size_t shift, size_t &count) const
+  {
+    count = 0;
+    if (node == nullptr)
+      return true;
+
+    if (node->type == NodeType::LEAF)
+      {
+        const auto leaf = static_cast<const LeafNode *>(node.get());
+        if (hash_fct_(leaf->key) != leaf->hash)
+          return false;
+        count = 1;
+        return true;
+      }
+
+    if (node->type == NodeType::COLLISION)
+      {
+        const auto cnode = static_cast<const CollisionNode *>(node.get());
+        if (cnode->entries.size() < 2 or not collision_keys_are_unique(*cnode))
+          return false;
+        for (const auto &entry : cnode->entries)
+          if (hash_fct_(entry.first) != cnode->hash)
+            return false;
+        count = cnode->entries.size();
+        return true;
+      }
+
+    if (node->type == NodeType::BITMAP)
+      {
+        const auto bnode = static_cast<const BitmapNode *>(node.get());
+        const size_t child_count = std::popcount(bnode->bitmap);
+        if (child_count == 0 or child_count != bnode->children.size())
+          return false;
+        if (bnode->children.size() == 1 and
+            (bnode->children[0]->type == NodeType::LEAF or
+             bnode->children[0]->type == NodeType::COLLISION))
+          return false;
+
+        size_t idx = 0;
+        size_t total = 0;
+        for (size_t pos = 0; pos < BRANCHING_FACTOR; ++pos)
+          {
+            const std::uint32_t b = bit(pos);
+            if ((bnode->bitmap & b) == 0)
+              continue;
+
+            if (idx >= bnode->children.size())
+              return false;
+            const NodePtr &child = bnode->children[idx++];
+            if (child == nullptr or not hashes_match_slot(child, shift, pos))
+              return false;
+
+            size_t subtree_count = 0;
+            if (not verify_rec(child, shift + BITS_PER_LEVEL, subtree_count))
+              return false;
+            ah_overflow_error_if(total > std::numeric_limits<size_t>::max() - subtree_count)
+              << "PersistentHashMap::verify(): node count would overflow";
+            total += subtree_count;
+          }
+
+        if (idx != bnode->children.size())
+          return false;
+        count = total;
+        return true;
+      }
+
+    return false;
+  }
+
+  static void collect_keys(const NodePtr &node, Array<Key> &out)
+  {
+    if (node == nullptr)
+      return;
+    if (node->type == NodeType::LEAF)
+      {
+        out.append(static_cast<const LeafNode *>(node.get())->key);
+        return;
+      }
+    if (node->type == NodeType::COLLISION)
+      {
+        const auto cnode = static_cast<const CollisionNode *>(node.get());
+        for (const auto &entry : cnode->entries)
+          out.append(entry.first);
+        return;
+      }
+
+    const auto bnode = static_cast<const BitmapNode *>(node.get());
+    for (size_t i = 0; i < bnode->children.size(); ++i)
+      collect_keys(bnode->children[i], out);
+  }
+
+  static void collect_items(const NodePtr &node, Array<std::pair<Key, T>> &out)
+  {
+    if (node == nullptr)
+      return;
+    if (node->type == NodeType::LEAF)
+      {
+        const auto leaf = static_cast<const LeafNode *>(node.get());
+        out.append(std::pair<Key, T>{leaf->key, leaf->value});
+        return;
+      }
+    if (node->type == NodeType::COLLISION)
+      {
+        const auto cnode = static_cast<const CollisionNode *>(node.get());
+        for (const auto &entry : cnode->entries)
+          out.append(entry);
+        return;
+      }
+
+    const auto bnode = static_cast<const BitmapNode *>(node.get());
+    for (size_t i = 0; i < bnode->children.size(); ++i)
+      collect_items(bnode->children[i], out);
+  }
+
+  [[nodiscard]] size_t size_after_insert(const bool added) const
+  {
+    if (not added)
+      return size_;
+    ah_overflow_error_if(size_ == std::numeric_limits<size_t>::max())
+      << "PersistentHashMap: size would overflow";
+    return size_ + 1;
+  }
+
+public:
+  /** @brief Construct an empty persistent hash map.
+   *  @param hash_fct Hash function used to route keys through the HAMT.
+   *  @param cmp Equality predicate used to compare keys.
+   *  @throws std::domain_error if `hash_fct` is null.
+   *  @throws Whatever copying `cmp` throws.
+   *  @pre If `cmp(a, b)` is true, `hash_fct(a) == hash_fct(b)` must also be true.
+   */
+  explicit PersistentHashMap(const Hash_Fct_Ptr hash_fct = dft_hash_ptr_fct<Key>,
+                             const Cmp &cmp = Cmp())
+    : hash_fct_(hash_fct), cmp_(cmp)
+  {
+    ah_domain_error_unless(hash_fct_ != nullptr)
+      << "PersistentHashMap: hash function must not be null";
+  }
+
+  /** @brief Return the number of bindings stored in this version.
+   *  @return Number of bindings.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] size_t size() const noexcept { return size_; }
+
+  /** @brief Return true when this version has no bindings.
+   *  @return `true` iff `size() == 0`.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] bool is_empty() const noexcept { return size_ == 0; }
+
+  /** @brief Return a new version with `key` inserted if absent.
+   *  @param key Key to insert.
+   *  @param value Mapped value to copy into the new version when `key` is absent.
+   *  @return New map version. If an equivalent key already exists, returns an
+   *          unchanged version sharing the same root.
+   *  @throws std::bad_alloc or whatever copying/comparison/hashing throws.
+   */
+  [[nodiscard]] PersistentHashMap insert(const Key &key, const T &value) const
+  {
+    bool added = false;
+    bool changed = false;
+    NodePtr new_root = insert_impl(root_, key, &value, nullptr, hash_fct_(key), 0,
+                                   false, added, changed);
+    if (not changed)
+      return *this;
+    return PersistentHashMap(std::move(new_root), hash_fct_, cmp_, size_after_insert(added));
+  }
+
+  /** @brief Return a new version with `key` inserted if absent, moving `value`.
+   *  @param key Key to insert.
+   *  @param value Mapped value to move into the new version when `key` is absent.
+   *  @return New map version. If an equivalent key already exists, returns an
+   *          unchanged version and does not move from `value`.
+   *  @throws std::bad_alloc or whatever copying/moving/comparison/hashing throws.
+   */
+  [[nodiscard]] PersistentHashMap insert(const Key &key, T &&value) const
+  {
+    bool added = false;
+    bool changed = false;
+    NodePtr new_root = insert_impl(root_, key, nullptr, &value, hash_fct_(key), 0,
+                                   false, added, changed);
+    if (not changed)
+      return *this;
+    return PersistentHashMap(std::move(new_root), hash_fct_, cmp_, size_after_insert(added));
+  }
+
+  /** @brief Return a new version with `key` bound to `value`.
+   *  @param key Key to insert or update.
+   *  @param value Mapped value to copy into the returned version.
+   *  @return New map version with an equivalent key present.
+   *  @throws std::bad_alloc or whatever copying/comparison/hashing throws.
+   */
+  [[nodiscard]] PersistentHashMap insert_or_assign(const Key &key, const T &value) const
+  {
+    bool added = false;
+    bool changed = false;
+    NodePtr new_root = insert_impl(root_, key, &value, nullptr, hash_fct_(key), 0,
+                                   true, added, changed);
+    return PersistentHashMap(std::move(new_root), hash_fct_, cmp_, size_after_insert(added));
+  }
+
+  /** @brief Return a new version with `key` bound to moved `value`.
+   *  @param key Key to insert or update.
+   *  @param value Mapped value to move into the returned version.
+   *  @return New map version with an equivalent key present.
+   *  @throws std::bad_alloc or whatever copying/moving/comparison/hashing throws.
+   */
+  [[nodiscard]] PersistentHashMap insert_or_assign(const Key &key, T &&value) const
+  {
+    bool added = false;
+    bool changed = false;
+    NodePtr new_root = insert_impl(root_, key, nullptr, &value, hash_fct_(key), 0,
+                                   true, added, changed);
+    return PersistentHashMap(std::move(new_root), hash_fct_, cmp_, size_after_insert(added));
+  }
+
+  /** @brief Return a new version without `key`.
+   *  @param key Key to erase.
+   *  @return New map version. If the key is absent, returns an unchanged
+   *          version sharing the same root.
+   *  @throws std::bad_alloc or whatever comparison/hashing throws.
+   */
+  [[nodiscard]] PersistentHashMap erase(const Key &key) const
+  {
+    bool removed = false;
+    NodePtr new_root = erase_impl(root_, key, hash_fct_(key), 0, removed);
+    if (not removed)
+      return *this;
+    return PersistentHashMap(std::move(new_root), hash_fct_, cmp_, size_ - 1);
+  }
+
+  /** @brief Test whether `key` is present.
+   *  @param key Key to search.
+   *  @return `true` if an equivalent key is stored.
+   *  @throws Whatever comparison or hashing throws.
+   */
+  [[nodiscard]] bool contains(const Key &key) const
+  {
+    return find(key) != nullptr;
+  }
+
+  /** @brief Find a mapped value.
+   *  @param key Key to search.
+   *  @return Pointer to the stored mapped value, or `nullptr` when absent. The
+   *          pointer remains valid while this map version is alive.
+   *  @throws Whatever comparison or hashing throws.
+   */
+  [[nodiscard]] const T *find(const Key &key) const
+  {
+    return find_impl(root_, key, hash_fct_(key), 0);
+  }
+
+  /** @brief Return all keys in unspecified order.
+   *  @return Aleph array with a copy of every key.
+   *  @throws std::bad_alloc or whatever copying `Key` throws.
+   */
+  [[nodiscard]] Array<Key> keys() const
+  {
+    Array<Key> out;
+    out.reserve(size());
+    collect_keys(root_, out);
+    return out;
+  }
+
+  /** @brief Return all key/value bindings in unspecified order.
+   *  @return Aleph array with a copy of every binding.
+   *  @throws std::bad_alloc or whatever copying `Key` or `T` throws.
+   */
+  [[nodiscard]] Array<std::pair<Key, T>> items() const
+  {
+    Array<std::pair<Key, T>> out;
+    out.reserve(size());
+    collect_items(root_, out);
+    return out;
+  }
+
+  /** @brief Verify HAMT routing, collision, uniqueness and size invariants.
+   *  @return `true` if the internal structure is consistent.
+   *  @throws std::overflow_error if a diagnostic node count overflows.
+   *  @throws Whatever `hash_fct_` or `Cmp` throws.
+   *  @note Intended for tests and diagnostics; it is O(n) plus O(k^2) inside
+   *        each full-hash collision node.
+   */
+  [[nodiscard]] bool verify() const
+  {
+    size_t count = 0;
+    return verify_rec(root_, 0, count) and count == size_;
+  }
+};
+
+} // namespace Aleph
+
+#endif // TPL_PERSISTENT_HASH_MAP_H

--- a/tpl_persistent_hash_map.H
+++ b/tpl_persistent_hash_map.H
@@ -503,7 +503,7 @@ private:
           return node;
         if (new_entries.size() == 1)
           return std::make_shared<LeafNode>(new_entries[0].first,
-                                            new_entries[0].second,
+                                            std::move(new_entries[0].second),
                                             hash);
         return std::make_shared<CollisionNode>(hash, std::move(new_entries));
       }
@@ -706,6 +706,8 @@ public:
    *  @throws std::domain_error if `hash_fct` is null.
    *  @throws Whatever copying `cmp` throws.
    *  @pre If `cmp(a, b)` is true, `hash_fct(a) == hash_fct(b)` must also be true.
+   *  @note Exception safety: strong guarantee; if an exception is thrown, no
+   *        map is constructed.
    */
   explicit PersistentHashMap(const Hash_Fct_Ptr hash_fct = dft_hash_ptr_fct<Key>,
                              const Cmp &cmp = Cmp())
@@ -718,12 +720,14 @@ public:
   /** @brief Return the number of bindings stored in this version.
    *  @return Number of bindings.
    *  @throws Nothing.
+   *  @note Exception safety: no-throw.
    */
   [[nodiscard]] size_t size() const noexcept { return size_; }
 
   /** @brief Return true when this version has no bindings.
    *  @return `true` iff `size() == 0`.
    *  @throws Nothing.
+   *  @note Exception safety: no-throw.
    */
   [[nodiscard]] bool is_empty() const noexcept { return size_ == 0; }
 
@@ -733,6 +737,8 @@ public:
    *  @return New map version. If an equivalent key already exists, returns an
    *          unchanged version sharing the same root.
    *  @throws std::bad_alloc or whatever copying/comparison/hashing throws.
+   *  @note Exception safety: strong guarantee; this map version remains
+   *        unchanged if an exception is thrown.
    */
   [[nodiscard]] PersistentHashMap insert(const Key &key, const T &value) const
   {
@@ -751,6 +757,8 @@ public:
    *  @return New map version. If an equivalent key already exists, returns an
    *          unchanged version and does not move from `value`.
    *  @throws std::bad_alloc or whatever copying/moving/comparison/hashing throws.
+   *  @note Exception safety: strong guarantee; this map version remains
+   *        unchanged if an exception is thrown.
    */
   [[nodiscard]] PersistentHashMap insert(const Key &key, T &&value) const
   {
@@ -768,6 +776,8 @@ public:
    *  @param value Mapped value to copy into the returned version.
    *  @return New map version with an equivalent key present.
    *  @throws std::bad_alloc or whatever copying/comparison/hashing throws.
+   *  @note Exception safety: strong guarantee; this map version remains
+   *        unchanged if an exception is thrown.
    */
   [[nodiscard]] PersistentHashMap insert_or_assign(const Key &key, const T &value) const
   {
@@ -783,6 +793,8 @@ public:
    *  @param value Mapped value to move into the returned version.
    *  @return New map version with an equivalent key present.
    *  @throws std::bad_alloc or whatever copying/moving/comparison/hashing throws.
+   *  @note Exception safety: strong guarantee; this map version remains
+   *        unchanged if an exception is thrown.
    */
   [[nodiscard]] PersistentHashMap insert_or_assign(const Key &key, T &&value) const
   {
@@ -798,6 +810,8 @@ public:
    *  @return New map version. If the key is absent, returns an unchanged
    *          version sharing the same root.
    *  @throws std::bad_alloc or whatever comparison/hashing throws.
+   *  @note Exception safety: strong guarantee; this map version remains
+   *        unchanged if an exception is thrown.
    */
   [[nodiscard]] PersistentHashMap erase(const Key &key) const
   {
@@ -812,6 +826,8 @@ public:
    *  @param key Key to search.
    *  @return `true` if an equivalent key is stored.
    *  @throws Whatever comparison or hashing throws.
+   *  @note Exception safety: strong guarantee; this map version remains
+   *        unchanged if an exception is thrown.
    */
   [[nodiscard]] bool contains(const Key &key) const
   {
@@ -823,6 +839,8 @@ public:
    *  @return Pointer to the stored mapped value, or `nullptr` when absent. The
    *          pointer remains valid while this map version is alive.
    *  @throws Whatever comparison or hashing throws.
+   *  @note Exception safety: strong guarantee; this map version remains
+   *        unchanged if an exception is thrown.
    */
   [[nodiscard]] const T *find(const Key &key) const
   {
@@ -832,6 +850,9 @@ public:
   /** @brief Return all keys in unspecified order.
    *  @return Aleph array with a copy of every key.
    *  @throws std::bad_alloc or whatever copying `Key` throws.
+   *  @note Complexity: O(n) time for a full-trie collection operation.
+   *  @note Exception safety: strong guarantee; this map version remains
+   *        unchanged if an exception is thrown.
    */
   [[nodiscard]] Array<Key> keys() const
   {
@@ -844,6 +865,9 @@ public:
   /** @brief Return all key/value bindings in unspecified order.
    *  @return Aleph array with a copy of every binding.
    *  @throws std::bad_alloc or whatever copying `Key` or `T` throws.
+   *  @note Complexity: O(n) time for a full-trie collection operation.
+   *  @note Exception safety: strong guarantee; this map version remains
+   *        unchanged if an exception is thrown.
    */
   [[nodiscard]] Array<std::pair<Key, T>> items() const
   {
@@ -859,6 +883,8 @@ public:
    *  @throws Whatever `hash_fct_` or `Cmp` throws.
    *  @note Intended for tests and diagnostics; it is O(n) plus O(k^2) inside
    *        each full-hash collision node.
+   *  @note Exception safety: strong guarantee; this map version remains
+   *        unchanged if an exception is thrown.
    */
   [[nodiscard]] bool verify() const
   {

--- a/tpl_persistent_treap.H
+++ b/tpl_persistent_treap.H
@@ -30,12 +30,27 @@
 /** @file tpl_persistent_treap.H
  *  @brief Immutable path-copying treap set and map.
  *
- *  `PersistentTreapSet` and `PersistentTreapMap` are in-memory persistent
- *  collections: operations that look like updates return a new collection
- *  version and never mutate the old one. Unchanged subtrees are shared through
- *  `std::shared_ptr<const Node>`, so copying a collection is O(1), snapshots
- *  are cheap, and an update copies only the nodes on the affected search path
- *  plus the nodes needed by treap rotations.
+ *  @details
+ *  ### What is a Persistent Treap?
+ *  A Treap is a randomized binary search tree that maintains both a BST property 
+ *  (for the keys) and a Max-Heap property (using randomly generated priorities). 
+ *  This guarantees balanced O(log n) tree depth with high probability.
+ *
+ *  "Persistence" in this context refers to **immutability with history** 
+ *  (structural sharing or path-copying). It does NOT mean disk storage.
+ *  When a node is inserted, erased, or when the tree is split/joined, the 
+ *  existing tree is never mutated. Instead, a new root is returned.
+ *  Only the nodes along the search path (and those affected by rotations) 
+ *  are copied. The rest of the subtrees remain completely untouched and are 
+ *  shared between the old and new versions using smart pointers 
+ *  (`std::shared_ptr<const Node>`).
+ *
+ *  ### Advantages
+ *  - **Fast Snapshots:** Copying the entire collection is an O(1) operation 
+ *    (just copying the root pointer).
+ *  - **Lock-free Concurrency:** Because existing nodes are never mutated, 
+ *    multiple threads can read from past and present versions simultaneously 
+ *    without requiring locks or synchronization.
  *
  *  This is unrelated to Aleph's file-backed B/B+ tree persistence: these
  *  containers are volatile in-memory values, not durable storage.
@@ -81,6 +96,180 @@ namespace detail
     x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
     return x ^ (x >> 31);
   }
+
+  template <typename Node, typename Key, class Compare>
+  struct PersistentTreapNodeOps
+  {
+    using NodePtr = std::shared_ptr<const Node>;
+
+    [[nodiscard]] static size_t node_size(const NodePtr &p) noexcept
+    {
+      return p == nullptr ? 0 : p->count;
+    }
+
+    [[nodiscard]] static const Key *min_key(const NodePtr &node) noexcept
+    {
+      const Node *curr = node.get();
+      while (curr->left != nullptr)
+        curr = curr->left.get();
+      return curr->key.get();
+    }
+
+    [[nodiscard]] static const Key *max_key(const NodePtr &node) noexcept
+    {
+      const Node *curr = node.get();
+      while (curr->right != nullptr)
+        curr = curr->right.get();
+      return curr->key.get();
+    }
+
+    [[nodiscard]] static bool can_join(const NodePtr &left,
+                                       const NodePtr &right,
+                                       const Compare &cmp)
+    {
+      return left == nullptr or right == nullptr or cmp(*max_key(left), *min_key(right));
+    }
+
+    template <class Rebuild>
+    [[nodiscard]] static NodePtr rotate_right(const NodePtr &node, const Rebuild &rebuild)
+    {
+      const NodePtr child = node->left;
+      NodePtr new_right = rebuild(node, child->right, node->right);
+      return rebuild(child, child->left, std::move(new_right));
+    }
+
+    template <class Rebuild>
+    [[nodiscard]] static NodePtr rotate_left(const NodePtr &node, const Rebuild &rebuild)
+    {
+      const NodePtr child = node->right;
+      NodePtr new_left = rebuild(node, node->left, child->left);
+      return rebuild(child, std::move(new_left), child->right);
+    }
+
+    template <class Rebuild>
+    [[nodiscard]] static NodePtr join_nodes(const NodePtr &left,
+                                            const NodePtr &right,
+                                            const Rebuild &rebuild)
+    {
+      if (left == nullptr)
+        return right;
+      if (right == nullptr)
+        return left;
+
+      if (left->priority <= right->priority)
+        {
+          NodePtr new_right = join_nodes(left->right, right, rebuild);
+          return rebuild(left, left->left, std::move(new_right));
+        }
+
+      NodePtr new_left = join_nodes(left, right->left, rebuild);
+      return rebuild(right, std::move(new_left), right->right);
+    }
+
+    template <class Rebuild>
+    [[nodiscard]] static NodePtr erase_rec(const NodePtr &node,
+                                           const Key &key,
+                                           const Compare &cmp,
+                                           bool &erased,
+                                           const Rebuild &rebuild)
+    {
+      if (node == nullptr)
+        {
+          erased = false;
+          return nullptr;
+        }
+
+      if (cmp(key, *node->key))
+        {
+          NodePtr new_left = erase_rec(node->left, key, cmp, erased, rebuild);
+          if (not erased)
+            return node;
+          return rebuild(node, std::move(new_left), node->right);
+        }
+
+      if (cmp(*node->key, key))
+        {
+          NodePtr new_right = erase_rec(node->right, key, cmp, erased, rebuild);
+          if (not erased)
+            return node;
+          return rebuild(node, node->left, std::move(new_right));
+        }
+
+      erased = true;
+      return join_nodes(node->left, node->right, rebuild);
+    }
+
+    template <class Rebuild>
+    [[nodiscard]] static std::pair<NodePtr, NodePtr> split_rec(const NodePtr &node,
+                                                               const Key &pivot,
+                                                               const Compare &cmp,
+                                                               const Rebuild &rebuild)
+    {
+      if (node == nullptr)
+        return {nullptr, nullptr};
+
+      if (cmp(*node->key, pivot))
+        {
+          auto [right_left, right_right] = split_rec(node->right, pivot, cmp, rebuild);
+          NodePtr left = rebuild(node, node->left, std::move(right_left));
+          return {std::move(left), std::move(right_right)};
+        }
+
+      auto [left_left, left_right] = split_rec(node->left, pivot, cmp, rebuild);
+      NodePtr right = rebuild(node, std::move(left_right), node->right);
+      return {std::move(left_left), std::move(right)};
+    }
+
+    static void collect_keys(const NodePtr &node, Array<Key> &out)
+      requires std::copy_constructible<Key>
+    {
+      if (node == nullptr)
+        return;
+      collect_keys(node->left, out);
+      out.append(Key(*node->key));
+      collect_keys(node->right, out);
+    }
+
+    [[nodiscard]] static bool verify_rec(const NodePtr &node,
+                                         const Key *lo,
+                                         const Key *hi,
+                                         const Compare &cmp,
+                                         size_t &count)
+    {
+      if (node == nullptr)
+        return true;
+      if (node->key == nullptr)
+        return false;
+      if constexpr (requires (const Node &n) { n.value; })
+        if (node->value == nullptr)
+          return false;
+      if (lo != nullptr and not cmp(*lo, *node->key))
+        return false;
+      if (hi != nullptr and not cmp(*node->key, *hi))
+        return false;
+      if (node->left != nullptr and node->left->priority < node->priority)
+        return false;
+      if (node->right != nullptr and node->right->priority < node->priority)
+        return false;
+
+      size_t left_count = 0;
+      size_t right_count = 0;
+      if (not verify_rec(node->left, lo, node->key.get(), cmp, left_count))
+        return false;
+      if (not verify_rec(node->right, node->key.get(), hi, cmp, right_count))
+        return false;
+      if (node->count != left_count + right_count + 1)
+        return false;
+      count = node->count;
+      return true;
+    }
+
+    [[nodiscard]] static bool is_valid_under(const NodePtr &node, const Compare &cmp)
+    {
+      size_t count = 0;
+      return verify_rec(node, nullptr, nullptr, cmp, count) and count == node_size(node);
+    }
+  };
 }
 
 /** @brief Immutable ordered set backed by a path-copying treap.
@@ -102,23 +291,19 @@ class PersistentTreapSet
   };
 
   using NodePtr = std::shared_ptr<const Node>;
+  using NodeOps = detail::PersistentTreapNodeOps<Node, Key, Compare>;
 
   NodePtr root_;
   Compare cmp_;
   std::uint64_t next_priority_ = 0;
-
-  [[nodiscard]] static size_t node_size(const NodePtr &p) noexcept
-  {
-    return p == nullptr ? 0 : p->count;
-  }
 
   [[nodiscard]] static NodePtr make_node(std::shared_ptr<const Key> key,
                                          const std::uint64_t priority,
                                          NodePtr left,
                                          NodePtr right)
   {
-    const size_t left_size = node_size(left);
-    const size_t right_size = node_size(right);
+    const size_t left_size = NodeOps::node_size(left);
+    const size_t right_size = NodeOps::node_size(right);
     ah_overflow_error_if(left_size > std::numeric_limits<size_t>::max() - right_size)
       << "PersistentTreapSet: node size would overflow";
     const size_t children_size = left_size + right_size;
@@ -134,23 +319,9 @@ class PersistentTreapSet
     return node;
   }
 
-  [[nodiscard]] static NodePtr rotate_right(const NodePtr &node)
+  [[nodiscard]] static NodePtr rebuild_node(const NodePtr &node, NodePtr left, NodePtr right)
   {
-    const NodePtr child = node->left;
-    NodePtr new_right = make_node(node->key, node->priority, child->right, node->right);
-    return make_node(child->key, child->priority, child->left, std::move(new_right));
-  }
-
-  [[nodiscard]] static NodePtr rotate_left(const NodePtr &node)
-  {
-    const NodePtr child = node->right;
-    NodePtr new_left = make_node(node->key, node->priority, node->left, child->left);
-    return make_node(child->key, child->priority, std::move(new_left), child->right);
-  }
-
-  [[nodiscard]] static bool equal_keys(const Key &a, const Key &b, const Compare &cmp)
-  {
-    return not cmp(a, b) and not cmp(b, a);
+    return make_node(node->key, node->priority, std::move(left), std::move(right));
   }
 
   [[nodiscard]] static NodePtr insert_rec(const NodePtr &node,
@@ -171,7 +342,8 @@ class PersistentTreapSet
         if (not inserted)
           return node;
         NodePtr rebuilt = make_node(node->key, node->priority, std::move(new_left), node->right);
-        return rebuilt->left->priority < rebuilt->priority ? rotate_right(rebuilt) : rebuilt;
+        return rebuilt->left->priority < rebuilt->priority
+          ? NodeOps::rotate_right(rebuilt, rebuild_node) : rebuilt;
       }
 
     if (cmp(*node->key, *key))
@@ -180,144 +352,12 @@ class PersistentTreapSet
         if (not inserted)
           return node;
         NodePtr rebuilt = make_node(node->key, node->priority, node->left, std::move(new_right));
-        return rebuilt->right->priority < rebuilt->priority ? rotate_left(rebuilt) : rebuilt;
+        return rebuilt->right->priority < rebuilt->priority
+          ? NodeOps::rotate_left(rebuilt, rebuild_node) : rebuilt;
       }
 
     inserted = false;
     return node;
-  }
-
-  [[nodiscard]] static NodePtr join_nodes(const NodePtr &left, const NodePtr &right)
-  {
-    if (left == nullptr)
-      return right;
-    if (right == nullptr)
-      return left;
-
-    if (left->priority <= right->priority)
-      {
-        NodePtr new_right = join_nodes(left->right, right);
-        return make_node(left->key, left->priority, left->left, std::move(new_right));
-      }
-
-    NodePtr new_left = join_nodes(left, right->left);
-    return make_node(right->key, right->priority, std::move(new_left), right->right);
-  }
-
-  [[nodiscard]] static NodePtr erase_rec(const NodePtr &node,
-                                         const Key &key,
-                                         const Compare &cmp,
-                                         bool &erased)
-  {
-    if (node == nullptr)
-      {
-        erased = false;
-        return nullptr;
-      }
-
-    if (cmp(key, *node->key))
-      {
-        NodePtr new_left = erase_rec(node->left, key, cmp, erased);
-        if (not erased)
-          return node;
-        return make_node(node->key, node->priority, std::move(new_left), node->right);
-      }
-
-    if (cmp(*node->key, key))
-      {
-        NodePtr new_right = erase_rec(node->right, key, cmp, erased);
-        if (not erased)
-          return node;
-        return make_node(node->key, node->priority, node->left, std::move(new_right));
-      }
-
-    erased = true;
-    return join_nodes(node->left, node->right);
-  }
-
-  [[nodiscard]] static std::pair<NodePtr, NodePtr> split_rec(const NodePtr &node,
-                                                             const Key &pivot,
-                                                             const Compare &cmp)
-  {
-    if (node == nullptr)
-      return {nullptr, nullptr};
-
-    if (cmp(*node->key, pivot))
-      {
-        auto [right_left, right_right] = split_rec(node->right, pivot, cmp);
-        NodePtr left = make_node(node->key, node->priority, node->left,
-                                 std::move(right_left));
-        return {std::move(left), std::move(right_right)};
-      }
-
-    auto [left_left, left_right] = split_rec(node->left, pivot, cmp);
-    NodePtr right = make_node(node->key, node->priority, std::move(left_right),
-                              node->right);
-    return {std::move(left_left), std::move(right)};
-  }
-
-  [[nodiscard]] static const Key *min_key(const NodePtr &node) noexcept
-  {
-    const Node *curr = node.get();
-    while (curr->left != nullptr)
-      curr = curr->left.get();
-    return curr->key.get();
-  }
-
-  [[nodiscard]] static const Key *max_key(const NodePtr &node) noexcept
-  {
-    const Node *curr = node.get();
-    while (curr->right != nullptr)
-      curr = curr->right.get();
-    return curr->key.get();
-  }
-
-  [[nodiscard]] static bool can_join(const NodePtr &left,
-                                     const NodePtr &right,
-                                     const Compare &cmp)
-  {
-    return left == nullptr or right == nullptr or cmp(*max_key(left), *min_key(right));
-  }
-
-  static void collect_keys(const NodePtr &node, Array<Key> &out)
-    requires std::copy_constructible<Key>
-  {
-    if (node == nullptr)
-      return;
-    collect_keys(node->left, out);
-    out.append(Key(*node->key));
-    collect_keys(node->right, out);
-  }
-
-  [[nodiscard]] static bool verify_rec(const NodePtr &node,
-                                       const Key *lo,
-                                       const Key *hi,
-                                       const Compare &cmp,
-                                       size_t &count)
-  {
-    if (node == nullptr)
-      return true;
-    if (node->key == nullptr)
-      return false;
-    if (lo != nullptr and not cmp(*lo, *node->key))
-      return false;
-    if (hi != nullptr and not cmp(*node->key, *hi))
-      return false;
-    if (node->left != nullptr and node->left->priority < node->priority)
-      return false;
-    if (node->right != nullptr and node->right->priority < node->priority)
-      return false;
-
-    size_t left_count = 0;
-    size_t right_count = 0;
-    if (not verify_rec(node->left, lo, node->key.get(), cmp, left_count))
-      return false;
-    if (not verify_rec(node->right, node->key.get(), hi, cmp, right_count))
-      return false;
-    if (node->count != left_count + right_count + 1)
-      return false;
-    count = node->count;
-    return true;
   }
 
   PersistentTreapSet(NodePtr root, Compare cmp, const std::uint64_t next_priority)
@@ -347,7 +387,7 @@ public:
    *  @return Number of keys.
    *  @throws Nothing.
    */
-  [[nodiscard]] size_t size() const noexcept { return node_size(root_); }
+  [[nodiscard]] size_t size() const noexcept { return NodeOps::node_size(root_); }
 
   /** @brief Find a key equivalent to `key`.
    *  @param key Key to search.
@@ -419,7 +459,7 @@ public:
   [[nodiscard]] PersistentTreapSet erase(const Key &key) const
   {
     bool erased = false;
-    NodePtr root = erase_rec(root_, key, cmp_, erased);
+    NodePtr root = NodeOps::erase_rec(root_, key, cmp_, erased, rebuild_node);
     return erased ? PersistentTreapSet(std::move(root), cmp_, next_priority_) : *this;
   }
 
@@ -432,7 +472,7 @@ public:
   [[nodiscard]] std::pair<PersistentTreapSet, PersistentTreapSet>
   split(const Key &pivot) const
   {
-    auto [left, right] = split_rec(root_, pivot, cmp_);
+    auto [left, right] = NodeOps::split_rec(root_, pivot, cmp_, rebuild_node);
     return {PersistentTreapSet(std::move(left), cmp_, next_priority_),
             PersistentTreapSet(std::move(right), cmp_, next_priority_)};
   }
@@ -441,23 +481,29 @@ public:
    *  @param left Set whose keys must all be less than every key in `right`.
    *  @param right Set whose keys must all be greater than every key in `left`.
    *  @return Joined set version.
-   *  @throws std::domain_error if the key ranges overlap or touch.
+   *  @throws std::domain_error if `right` is not ordered under `left`'s
+   *          comparator, or if the key ranges overlap or touch.
    *  @throws std::bad_alloc if node allocation fails.
+   *  @throws Whatever `Compare` throws.
    */
   [[nodiscard]] static PersistentTreapSet join(const PersistentTreapSet &left,
                                                const PersistentTreapSet &right)
   {
-    ah_domain_error_unless(can_join(left.root_, right.root_, left.cmp_))
+    ah_domain_error_unless(NodeOps::is_valid_under(right.root_, left.cmp_))
+      << "PersistentTreapSet::join(): right tree must be ordered by left comparator";
+    ah_domain_error_unless(NodeOps::can_join(left.root_, right.root_, left.cmp_))
       << "PersistentTreapSet::join(): left keys must be strictly less than right keys";
-    return PersistentTreapSet(join_nodes(left.root_, right.root_), left.cmp_,
+    return PersistentTreapSet(NodeOps::join_nodes(left.root_, right.root_, rebuild_node), left.cmp_,
                               std::max(left.next_priority_, right.next_priority_));
   }
 
   /** @brief Join this version with `right`.
    *  @param right Set whose keys must all be greater than every key in this set.
    *  @return Joined set version.
-   *  @throws std::domain_error if the key ranges overlap or touch.
+   *  @throws std::domain_error if `right` is not ordered under this set's
+   *          comparator, or if the key ranges overlap or touch.
    *  @throws std::bad_alloc if node allocation fails.
+   *  @throws Whatever `Compare` throws.
    */
   [[nodiscard]] PersistentTreapSet join(const PersistentTreapSet &right) const
   {
@@ -473,7 +519,7 @@ public:
   {
     Array<Key> out;
     out.reserve(size());
-    collect_keys(root_, out);
+    NodeOps::collect_keys(root_, out);
     return out;
   }
 
@@ -485,7 +531,7 @@ public:
   [[nodiscard]] bool verify() const
   {
     size_t count = 0;
-    return verify_rec(root_, nullptr, nullptr, cmp_, count) and count == size();
+    return NodeOps::verify_rec(root_, nullptr, nullptr, cmp_, count) and count == size();
   }
 };
 
@@ -510,15 +556,11 @@ class PersistentTreapMap
   };
 
   using NodePtr = std::shared_ptr<const Node>;
+  using NodeOps = detail::PersistentTreapNodeOps<Node, Key, Compare>;
 
   NodePtr root_;
   Compare cmp_;
   std::uint64_t next_priority_ = 0;
-
-  [[nodiscard]] static size_t node_size(const NodePtr &p) noexcept
-  {
-    return p == nullptr ? 0 : p->count;
-  }
 
   [[nodiscard]] static NodePtr make_node(std::shared_ptr<const Key> key,
                                          std::shared_ptr<const T> value,
@@ -526,8 +568,8 @@ class PersistentTreapMap
                                          NodePtr left,
                                          NodePtr right)
   {
-    const size_t left_size = node_size(left);
-    const size_t right_size = node_size(right);
+    const size_t left_size = NodeOps::node_size(left);
+    const size_t right_size = NodeOps::node_size(right);
     ah_overflow_error_if(left_size > std::numeric_limits<size_t>::max() - right_size)
       << "PersistentTreapMap: node size would overflow";
     const size_t children_size = left_size + right_size;
@@ -544,22 +586,10 @@ class PersistentTreapMap
     return node;
   }
 
-  [[nodiscard]] static NodePtr rotate_right(const NodePtr &node)
+  [[nodiscard]] static NodePtr rebuild_node(const NodePtr &node, NodePtr left, NodePtr right)
   {
-    const NodePtr child = node->left;
-    NodePtr new_right = make_node(node->key, node->value, node->priority,
-                                  child->right, node->right);
-    return make_node(child->key, child->value, child->priority, child->left,
-                     std::move(new_right));
-  }
-
-  [[nodiscard]] static NodePtr rotate_left(const NodePtr &node)
-  {
-    const NodePtr child = node->right;
-    NodePtr new_left = make_node(node->key, node->value, node->priority,
-                                 node->left, child->left);
-    return make_node(child->key, child->value, child->priority,
-                     std::move(new_left), child->right);
+    return make_node(node->key, node->value, node->priority,
+                     std::move(left), std::move(right));
   }
 
   [[nodiscard]] static NodePtr insert_rec(const NodePtr &node,
@@ -583,7 +613,8 @@ class PersistentTreapMap
           return node;
         NodePtr rebuilt = make_node(node->key, node->value, node->priority,
                                     std::move(new_left), node->right);
-        return rebuilt->left->priority < rebuilt->priority ? rotate_right(rebuilt) : rebuilt;
+        return rebuilt->left->priority < rebuilt->priority
+          ? NodeOps::rotate_right(rebuilt, rebuild_node) : rebuilt;
       }
 
     if (cmp(*node->key, *key))
@@ -594,7 +625,8 @@ class PersistentTreapMap
           return node;
         NodePtr rebuilt = make_node(node->key, node->value, node->priority,
                                     node->left, std::move(new_right));
-        return rebuilt->right->priority < rebuilt->priority ? rotate_left(rebuilt) : rebuilt;
+        return rebuilt->right->priority < rebuilt->priority
+          ? NodeOps::rotate_left(rebuilt, rebuild_node) : rebuilt;
       }
 
     inserted = false;
@@ -622,7 +654,7 @@ class PersistentTreapMap
         NodePtr rebuilt = make_node(node->key, node->value, node->priority,
                                     std::move(new_left), node->right);
         return inserted and rebuilt->left->priority < rebuilt->priority
-          ? rotate_right(rebuilt) : rebuilt;
+          ? NodeOps::rotate_right(rebuilt, rebuild_node) : rebuilt;
       }
 
     if (cmp(*node->key, *key))
@@ -633,117 +665,11 @@ class PersistentTreapMap
         NodePtr rebuilt = make_node(node->key, node->value, node->priority,
                                     node->left, std::move(new_right));
         return inserted and rebuilt->right->priority < rebuilt->priority
-          ? rotate_left(rebuilt) : rebuilt;
+          ? NodeOps::rotate_left(rebuilt, rebuild_node) : rebuilt;
       }
 
     inserted = false;
     return make_node(node->key, std::move(value), node->priority, node->left, node->right);
-  }
-
-  [[nodiscard]] static NodePtr join_nodes(const NodePtr &left, const NodePtr &right)
-  {
-    if (left == nullptr)
-      return right;
-    if (right == nullptr)
-      return left;
-
-    if (left->priority <= right->priority)
-      {
-        NodePtr new_right = join_nodes(left->right, right);
-        return make_node(left->key, left->value, left->priority, left->left,
-                         std::move(new_right));
-      }
-
-    NodePtr new_left = join_nodes(left, right->left);
-    return make_node(right->key, right->value, right->priority, std::move(new_left),
-                     right->right);
-  }
-
-  [[nodiscard]] static NodePtr erase_rec(const NodePtr &node,
-                                         const Key &key,
-                                         const Compare &cmp,
-                                         bool &erased)
-  {
-    if (node == nullptr)
-      {
-        erased = false;
-        return nullptr;
-      }
-
-    if (cmp(key, *node->key))
-      {
-        NodePtr new_left = erase_rec(node->left, key, cmp, erased);
-        if (not erased)
-          return node;
-        return make_node(node->key, node->value, node->priority,
-                         std::move(new_left), node->right);
-      }
-
-    if (cmp(*node->key, key))
-      {
-        NodePtr new_right = erase_rec(node->right, key, cmp, erased);
-        if (not erased)
-          return node;
-        return make_node(node->key, node->value, node->priority,
-                         node->left, std::move(new_right));
-      }
-
-    erased = true;
-    return join_nodes(node->left, node->right);
-  }
-
-  [[nodiscard]] static std::pair<NodePtr, NodePtr> split_rec(const NodePtr &node,
-                                                             const Key &pivot,
-                                                             const Compare &cmp)
-  {
-    if (node == nullptr)
-      return {nullptr, nullptr};
-
-    if (cmp(*node->key, pivot))
-      {
-        auto [right_left, right_right] = split_rec(node->right, pivot, cmp);
-        NodePtr left = make_node(node->key, node->value, node->priority,
-                                 node->left, std::move(right_left));
-        return {std::move(left), std::move(right_right)};
-      }
-
-    auto [left_left, left_right] = split_rec(node->left, pivot, cmp);
-    NodePtr right = make_node(node->key, node->value, node->priority,
-                              std::move(left_right), node->right);
-    return {std::move(left_left), std::move(right)};
-  }
-
-  [[nodiscard]] static const Key *min_key(const NodePtr &node) noexcept
-  {
-    const Node *curr = node.get();
-    while (curr->left != nullptr)
-      curr = curr->left.get();
-    return curr->key.get();
-  }
-
-  [[nodiscard]] static const Key *max_key(const NodePtr &node) noexcept
-  {
-    const Node *curr = node.get();
-    while (curr->right != nullptr)
-      curr = curr->right.get();
-    return curr->key.get();
-  }
-
-  [[nodiscard]] static bool can_join(const NodePtr &left,
-                                     const NodePtr &right,
-                                     const Compare &cmp)
-  {
-    return left == nullptr or right == nullptr or cmp(*max_key(left), *min_key(right));
-  }
-
-  static void collect_keys(const NodePtr &node, Array<Key> &out)
-    requires std::copy_constructible<Key>
-  {
-    if (node == nullptr)
-      return;
-    collect_keys(node->left, out);
-    out.append(Key(*node->key));
-    collect_keys(node->right, out);
   }
 
   static void collect_items(const NodePtr &node, Array<std::pair<Key, T>> &out)
@@ -754,37 +680,6 @@ class PersistentTreapMap
     collect_items(node->left, out);
     out.append(std::pair<Key, T>{*node->key, *node->value});
     collect_items(node->right, out);
-  }
-
-  [[nodiscard]] static bool verify_rec(const NodePtr &node,
-                                       const Key *lo,
-                                       const Key *hi,
-                                       const Compare &cmp,
-                                       size_t &count)
-  {
-    if (node == nullptr)
-      return true;
-    if (node->key == nullptr or node->value == nullptr)
-      return false;
-    if (lo != nullptr and not cmp(*lo, *node->key))
-      return false;
-    if (hi != nullptr and not cmp(*node->key, *hi))
-      return false;
-    if (node->left != nullptr and node->left->priority < node->priority)
-      return false;
-    if (node->right != nullptr and node->right->priority < node->priority)
-      return false;
-
-    size_t left_count = 0;
-    size_t right_count = 0;
-    if (not verify_rec(node->left, lo, node->key.get(), cmp, left_count))
-      return false;
-    if (not verify_rec(node->right, node->key.get(), hi, cmp, right_count))
-      return false;
-    if (node->count != left_count + right_count + 1)
-      return false;
-    count = node->count;
-    return true;
   }
 
   PersistentTreapMap(NodePtr root, Compare cmp, const std::uint64_t next_priority)
@@ -814,7 +709,7 @@ public:
    *  @return Number of bindings.
    *  @throws Nothing.
    */
-  [[nodiscard]] size_t size() const noexcept { return node_size(root_); }
+  [[nodiscard]] size_t size() const noexcept { return NodeOps::node_size(root_); }
 
   /** @brief Find a mapped value.
    *  @param key Key to search.
@@ -899,7 +794,7 @@ public:
   [[nodiscard]] PersistentTreapMap erase(const Key &key) const
   {
     bool erased = false;
-    NodePtr root = erase_rec(root_, key, cmp_, erased);
+    NodePtr root = NodeOps::erase_rec(root_, key, cmp_, erased, rebuild_node);
     return erased ? PersistentTreapMap(std::move(root), cmp_, next_priority_) : *this;
   }
 
@@ -912,7 +807,7 @@ public:
   [[nodiscard]] std::pair<PersistentTreapMap, PersistentTreapMap>
   split(const Key &pivot) const
   {
-    auto [left, right] = split_rec(root_, pivot, cmp_);
+    auto [left, right] = NodeOps::split_rec(root_, pivot, cmp_, rebuild_node);
     return {PersistentTreapMap(std::move(left), cmp_, next_priority_),
             PersistentTreapMap(std::move(right), cmp_, next_priority_)};
   }
@@ -921,23 +816,29 @@ public:
    *  @param left Map whose keys must all be less than every key in `right`.
    *  @param right Map whose keys must all be greater than every key in `left`.
    *  @return Joined map version.
-   *  @throws std::domain_error if the key ranges overlap or touch.
+   *  @throws std::domain_error if `right` is not ordered under `left`'s
+   *          comparator, or if the key ranges overlap or touch.
    *  @throws std::bad_alloc if node allocation fails.
+   *  @throws Whatever `Compare` throws.
    */
   [[nodiscard]] static PersistentTreapMap join(const PersistentTreapMap &left,
                                                const PersistentTreapMap &right)
   {
-    ah_domain_error_unless(can_join(left.root_, right.root_, left.cmp_))
+    ah_domain_error_unless(NodeOps::is_valid_under(right.root_, left.cmp_))
+      << "PersistentTreapMap::join(): right tree must be ordered by left comparator";
+    ah_domain_error_unless(NodeOps::can_join(left.root_, right.root_, left.cmp_))
       << "PersistentTreapMap::join(): left keys must be strictly less than right keys";
-    return PersistentTreapMap(join_nodes(left.root_, right.root_), left.cmp_,
+    return PersistentTreapMap(NodeOps::join_nodes(left.root_, right.root_, rebuild_node), left.cmp_,
                               std::max(left.next_priority_, right.next_priority_));
   }
 
   /** @brief Join this version with `right`.
    *  @param right Map whose keys must all be greater than every key in this map.
    *  @return Joined map version.
-   *  @throws std::domain_error if the key ranges overlap or touch.
+   *  @throws std::domain_error if `right` is not ordered under this map's
+   *          comparator, or if the key ranges overlap or touch.
    *  @throws std::bad_alloc if node allocation fails.
+   *  @throws Whatever `Compare` throws.
    */
   [[nodiscard]] PersistentTreapMap join(const PersistentTreapMap &right) const
   {
@@ -953,7 +854,7 @@ public:
   {
     Array<Key> out;
     out.reserve(size());
-    collect_keys(root_, out);
+    NodeOps::collect_keys(root_, out);
     return out;
   }
 
@@ -978,7 +879,7 @@ public:
   [[nodiscard]] bool verify() const
   {
     size_t count = 0;
-    return verify_rec(root_, nullptr, nullptr, cmp_, count) and count == size();
+    return NodeOps::verify_rec(root_, nullptr, nullptr, cmp_, count) and count == size();
   }
 };
 

--- a/tpl_persistent_treap.H
+++ b/tpl_persistent_treap.H
@@ -1,0 +1,987 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/** @file tpl_persistent_treap.H
+ *  @brief Immutable path-copying treap set and map.
+ *
+ *  `PersistentTreapSet` and `PersistentTreapMap` are in-memory persistent
+ *  collections: operations that look like updates return a new collection
+ *  version and never mutate the old one. Unchanged subtrees are shared through
+ *  `std::shared_ptr<const Node>`, so copying a collection is O(1), snapshots
+ *  are cheap, and an update copies only the nodes on the affected search path
+ *  plus the nodes needed by treap rotations.
+ *
+ *  This is unrelated to Aleph's file-backed B/B+ tree persistence: these
+ *  containers are volatile in-memory values, not durable storage.
+ *
+ *  @par Complexity
+ *  Search, insert, erase, split and join are expected O(log n) with O(log n)
+ *  new nodes allocated per update. Copying a collection value is O(1).
+ *  `keys()` and `items()` flatten a version in sorted order and cost O(n).
+ *
+ *  @par Thread safety
+ *  Published versions are immutable. Different threads may read distinct
+ *  collection objects that share the same tree without synchronization. The
+ *  publication of a new version into a shared variable is still the user's
+ *  responsibility and must be synchronized externally.
+ *
+ *  @ingroup Trees
+ */
+
+#ifndef TPL_PERSISTENT_TREAP_H
+#define TPL_PERSISTENT_TREAP_H
+
+#include <algorithm>
+#include <concepts>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <ah-errors.H>
+#include <ahFunction.H>
+#include <tpl_array.H>
+
+namespace Aleph
+{
+
+namespace detail
+{
+  [[nodiscard]] inline std::uint64_t persistent_treap_priority(const std::uint64_t n) noexcept
+  {
+    std::uint64_t x = n + 0x9e3779b97f4a7c15ULL;
+    x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+    return x ^ (x >> 31);
+  }
+}
+
+/** @brief Immutable ordered set backed by a path-copying treap.
+ *
+ *  @tparam Key Key type stored by the set.
+ *  @tparam Compare Strict weak ordering used for keys. Defaults to
+ *          `Aleph::less<Key>`.
+ */
+template <typename Key, class Compare = Aleph::less<Key>>
+class PersistentTreapSet
+{
+  struct Node
+  {
+    std::shared_ptr<const Key> key;
+    std::uint64_t priority = 0;
+    size_t count = 1;
+    std::shared_ptr<const Node> left;
+    std::shared_ptr<const Node> right;
+  };
+
+  using NodePtr = std::shared_ptr<const Node>;
+
+  NodePtr root_;
+  Compare cmp_;
+  std::uint64_t next_priority_ = 0;
+
+  [[nodiscard]] static size_t node_size(const NodePtr &p) noexcept
+  {
+    return p == nullptr ? 0 : p->count;
+  }
+
+  [[nodiscard]] static NodePtr make_node(std::shared_ptr<const Key> key,
+                                         const std::uint64_t priority,
+                                         NodePtr left,
+                                         NodePtr right)
+  {
+    const size_t left_size = node_size(left);
+    const size_t right_size = node_size(right);
+    ah_overflow_error_if(left_size > std::numeric_limits<size_t>::max() - right_size)
+      << "PersistentTreapSet: node size would overflow";
+    const size_t children_size = left_size + right_size;
+    ah_overflow_error_if(children_size == std::numeric_limits<size_t>::max())
+      << "PersistentTreapSet: node size would overflow";
+
+    auto node = std::make_shared<Node>();
+    node->key = std::move(key);
+    node->priority = priority;
+    node->left = std::move(left);
+    node->right = std::move(right);
+    node->count = children_size + 1;
+    return node;
+  }
+
+  [[nodiscard]] static NodePtr rotate_right(const NodePtr &node)
+  {
+    const NodePtr child = node->left;
+    NodePtr new_right = make_node(node->key, node->priority, child->right, node->right);
+    return make_node(child->key, child->priority, child->left, std::move(new_right));
+  }
+
+  [[nodiscard]] static NodePtr rotate_left(const NodePtr &node)
+  {
+    const NodePtr child = node->right;
+    NodePtr new_left = make_node(node->key, node->priority, node->left, child->left);
+    return make_node(child->key, child->priority, std::move(new_left), child->right);
+  }
+
+  [[nodiscard]] static bool equal_keys(const Key &a, const Key &b, const Compare &cmp)
+  {
+    return not cmp(a, b) and not cmp(b, a);
+  }
+
+  [[nodiscard]] static NodePtr insert_rec(const NodePtr &node,
+                                          std::shared_ptr<const Key> key,
+                                          const std::uint64_t priority,
+                                          const Compare &cmp,
+                                          bool &inserted)
+  {
+    if (node == nullptr)
+      {
+        inserted = true;
+        return make_node(std::move(key), priority, nullptr, nullptr);
+      }
+
+    if (cmp(*key, *node->key))
+      {
+        NodePtr new_left = insert_rec(node->left, std::move(key), priority, cmp, inserted);
+        if (not inserted)
+          return node;
+        NodePtr rebuilt = make_node(node->key, node->priority, std::move(new_left), node->right);
+        return rebuilt->left->priority < rebuilt->priority ? rotate_right(rebuilt) : rebuilt;
+      }
+
+    if (cmp(*node->key, *key))
+      {
+        NodePtr new_right = insert_rec(node->right, std::move(key), priority, cmp, inserted);
+        if (not inserted)
+          return node;
+        NodePtr rebuilt = make_node(node->key, node->priority, node->left, std::move(new_right));
+        return rebuilt->right->priority < rebuilt->priority ? rotate_left(rebuilt) : rebuilt;
+      }
+
+    inserted = false;
+    return node;
+  }
+
+  [[nodiscard]] static NodePtr join_nodes(const NodePtr &left, const NodePtr &right)
+  {
+    if (left == nullptr)
+      return right;
+    if (right == nullptr)
+      return left;
+
+    if (left->priority <= right->priority)
+      {
+        NodePtr new_right = join_nodes(left->right, right);
+        return make_node(left->key, left->priority, left->left, std::move(new_right));
+      }
+
+    NodePtr new_left = join_nodes(left, right->left);
+    return make_node(right->key, right->priority, std::move(new_left), right->right);
+  }
+
+  [[nodiscard]] static NodePtr erase_rec(const NodePtr &node,
+                                         const Key &key,
+                                         const Compare &cmp,
+                                         bool &erased)
+  {
+    if (node == nullptr)
+      {
+        erased = false;
+        return nullptr;
+      }
+
+    if (cmp(key, *node->key))
+      {
+        NodePtr new_left = erase_rec(node->left, key, cmp, erased);
+        if (not erased)
+          return node;
+        return make_node(node->key, node->priority, std::move(new_left), node->right);
+      }
+
+    if (cmp(*node->key, key))
+      {
+        NodePtr new_right = erase_rec(node->right, key, cmp, erased);
+        if (not erased)
+          return node;
+        return make_node(node->key, node->priority, node->left, std::move(new_right));
+      }
+
+    erased = true;
+    return join_nodes(node->left, node->right);
+  }
+
+  [[nodiscard]] static std::pair<NodePtr, NodePtr> split_rec(const NodePtr &node,
+                                                             const Key &pivot,
+                                                             const Compare &cmp)
+  {
+    if (node == nullptr)
+      return {nullptr, nullptr};
+
+    if (cmp(*node->key, pivot))
+      {
+        auto [right_left, right_right] = split_rec(node->right, pivot, cmp);
+        NodePtr left = make_node(node->key, node->priority, node->left,
+                                 std::move(right_left));
+        return {std::move(left), std::move(right_right)};
+      }
+
+    auto [left_left, left_right] = split_rec(node->left, pivot, cmp);
+    NodePtr right = make_node(node->key, node->priority, std::move(left_right),
+                              node->right);
+    return {std::move(left_left), std::move(right)};
+  }
+
+  [[nodiscard]] static const Key *min_key(const NodePtr &node) noexcept
+  {
+    const Node *curr = node.get();
+    while (curr->left != nullptr)
+      curr = curr->left.get();
+    return curr->key.get();
+  }
+
+  [[nodiscard]] static const Key *max_key(const NodePtr &node) noexcept
+  {
+    const Node *curr = node.get();
+    while (curr->right != nullptr)
+      curr = curr->right.get();
+    return curr->key.get();
+  }
+
+  [[nodiscard]] static bool can_join(const NodePtr &left,
+                                     const NodePtr &right,
+                                     const Compare &cmp)
+  {
+    return left == nullptr or right == nullptr or cmp(*max_key(left), *min_key(right));
+  }
+
+  static void collect_keys(const NodePtr &node, Array<Key> &out)
+    requires std::copy_constructible<Key>
+  {
+    if (node == nullptr)
+      return;
+    collect_keys(node->left, out);
+    out.append(Key(*node->key));
+    collect_keys(node->right, out);
+  }
+
+  [[nodiscard]] static bool verify_rec(const NodePtr &node,
+                                       const Key *lo,
+                                       const Key *hi,
+                                       const Compare &cmp,
+                                       size_t &count)
+  {
+    if (node == nullptr)
+      return true;
+    if (node->key == nullptr)
+      return false;
+    if (lo != nullptr and not cmp(*lo, *node->key))
+      return false;
+    if (hi != nullptr and not cmp(*node->key, *hi))
+      return false;
+    if (node->left != nullptr and node->left->priority < node->priority)
+      return false;
+    if (node->right != nullptr and node->right->priority < node->priority)
+      return false;
+
+    size_t left_count = 0;
+    size_t right_count = 0;
+    if (not verify_rec(node->left, lo, node->key.get(), cmp, left_count))
+      return false;
+    if (not verify_rec(node->right, node->key.get(), hi, cmp, right_count))
+      return false;
+    if (node->count != left_count + right_count + 1)
+      return false;
+    count = node->count;
+    return true;
+  }
+
+  PersistentTreapSet(NodePtr root, Compare cmp, const std::uint64_t next_priority)
+    : root_(std::move(root)), cmp_(std::move(cmp)), next_priority_(next_priority)
+  {
+    // Empty.
+  }
+
+public:
+  /** @brief Construct an empty persistent set.
+   *  @param cmp Comparator used for key ordering.
+   *  @throws Nothing unless copying `cmp` throws.
+   */
+  explicit PersistentTreapSet(Compare cmp = Compare())
+    : cmp_(std::move(cmp))
+  {
+    // Empty.
+  }
+
+  /** @brief Return true when the set has no keys.
+   *  @return `true` iff `size() == 0`.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] bool is_empty() const noexcept { return root_ == nullptr; }
+
+  /** @brief Return the number of keys stored in this version.
+   *  @return Number of keys.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] size_t size() const noexcept { return node_size(root_); }
+
+  /** @brief Find a key equivalent to `key`.
+   *  @param key Key to search.
+   *  @return Pointer to the stored key, or `nullptr` when absent. The pointer
+   *          remains valid while this set version is alive.
+   *  @throws Whatever `Compare` throws.
+   */
+  [[nodiscard]] const Key *find(const Key &key) const
+  {
+    const Node *curr = root_.get();
+    while (curr != nullptr)
+      if (cmp_(key, *curr->key))
+        curr = curr->left.get();
+      else if (cmp_(*curr->key, key))
+        curr = curr->right.get();
+      else
+        return curr->key.get();
+    return nullptr;
+  }
+
+  /** @brief Test whether `key` is present.
+   *  @param key Key to search.
+   *  @return `true` if an equivalent key is stored.
+   *  @throws Whatever `Compare` throws.
+   */
+  [[nodiscard]] bool contains(const Key &key) const
+  {
+    return find(key) != nullptr;
+  }
+
+  /** @brief Return a new version with `key` inserted by copy.
+   *  @param key Key to insert.
+   *  @return New set version. If an equivalent key already exists, returns an
+   *          unchanged version sharing the same root.
+   *  @throws std::bad_alloc or whatever `Compare`/`Key` copy construction throws.
+   */
+  [[nodiscard]] PersistentTreapSet insert(const Key &key) const
+  {
+    auto stored_key = std::make_shared<const Key>(key);
+    bool inserted = false;
+    NodePtr root = insert_rec(root_, std::move(stored_key),
+                              detail::persistent_treap_priority(next_priority_),
+                              cmp_, inserted);
+    return inserted ? PersistentTreapSet(std::move(root), cmp_, next_priority_ + 1) : *this;
+  }
+
+  /** @brief Return a new version with `key` inserted by move.
+   *  @param key Key to move into the new version.
+   *  @return New set version. If an equivalent key already exists, returns an
+   *          unchanged version sharing the same root.
+   *  @throws std::bad_alloc or whatever `Compare`/`Key` move construction throws.
+   */
+  [[nodiscard]] PersistentTreapSet insert(Key &&key) const
+  {
+    auto stored_key = std::make_shared<const Key>(std::move(key));
+    bool inserted = false;
+    NodePtr root = insert_rec(root_, std::move(stored_key),
+                              detail::persistent_treap_priority(next_priority_),
+                              cmp_, inserted);
+    return inserted ? PersistentTreapSet(std::move(root), cmp_, next_priority_ + 1) : *this;
+  }
+
+  /** @brief Return a new version without `key`.
+   *  @param key Key to erase.
+   *  @return New set version. If the key is absent, returns an unchanged
+   *          version sharing the same root.
+   *  @throws std::bad_alloc or whatever `Compare` throws.
+   */
+  [[nodiscard]] PersistentTreapSet erase(const Key &key) const
+  {
+    bool erased = false;
+    NodePtr root = erase_rec(root_, key, cmp_, erased);
+    return erased ? PersistentTreapSet(std::move(root), cmp_, next_priority_) : *this;
+  }
+
+  /** @brief Split this version around `pivot`.
+   *  @param pivot Split key.
+   *  @return Pair `{less, greater_equal}` where the first set contains keys
+   *          strictly less than `pivot` and the second contains the rest.
+   *  @throws std::bad_alloc or whatever `Compare` throws.
+   */
+  [[nodiscard]] std::pair<PersistentTreapSet, PersistentTreapSet>
+  split(const Key &pivot) const
+  {
+    auto [left, right] = split_rec(root_, pivot, cmp_);
+    return {PersistentTreapSet(std::move(left), cmp_, next_priority_),
+            PersistentTreapSet(std::move(right), cmp_, next_priority_)};
+  }
+
+  /** @brief Join two ordered, non-overlapping set versions.
+   *  @param left Set whose keys must all be less than every key in `right`.
+   *  @param right Set whose keys must all be greater than every key in `left`.
+   *  @return Joined set version.
+   *  @throws std::domain_error if the key ranges overlap or touch.
+   *  @throws std::bad_alloc if node allocation fails.
+   */
+  [[nodiscard]] static PersistentTreapSet join(const PersistentTreapSet &left,
+                                               const PersistentTreapSet &right)
+  {
+    ah_domain_error_unless(can_join(left.root_, right.root_, left.cmp_))
+      << "PersistentTreapSet::join(): left keys must be strictly less than right keys";
+    return PersistentTreapSet(join_nodes(left.root_, right.root_), left.cmp_,
+                              std::max(left.next_priority_, right.next_priority_));
+  }
+
+  /** @brief Join this version with `right`.
+   *  @param right Set whose keys must all be greater than every key in this set.
+   *  @return Joined set version.
+   *  @throws std::domain_error if the key ranges overlap or touch.
+   *  @throws std::bad_alloc if node allocation fails.
+   */
+  [[nodiscard]] PersistentTreapSet join(const PersistentTreapSet &right) const
+  {
+    return join(*this, right);
+  }
+
+  /** @brief Return all keys in sorted order.
+   *  @return Aleph array with a copy of every key.
+   *  @throws std::bad_alloc or whatever copying `Key` throws.
+   */
+  [[nodiscard]] Array<Key> keys() const
+    requires std::copy_constructible<Key>
+  {
+    Array<Key> out;
+    out.reserve(size());
+    collect_keys(root_, out);
+    return out;
+  }
+
+  /** @brief Verify treap, BST and cached-size invariants.
+   *  @return `true` if the internal structure is consistent.
+   *  @throws Nothing unless `Compare` throws.
+   *  @note Intended for tests and diagnostics; it is O(n).
+   */
+  [[nodiscard]] bool verify() const
+  {
+    size_t count = 0;
+    return verify_rec(root_, nullptr, nullptr, cmp_, count) and count == size();
+  }
+};
+
+/** @brief Immutable ordered map backed by a path-copying treap.
+ *
+ *  @tparam Key Key type.
+ *  @tparam T Mapped value type.
+ *  @tparam Compare Strict weak ordering used for keys. Defaults to
+ *          `Aleph::less<Key>`.
+ */
+template <typename Key, typename T, class Compare = Aleph::less<Key>>
+class PersistentTreapMap
+{
+  struct Node
+  {
+    std::shared_ptr<const Key> key;
+    std::shared_ptr<const T> value;
+    std::uint64_t priority = 0;
+    size_t count = 1;
+    std::shared_ptr<const Node> left;
+    std::shared_ptr<const Node> right;
+  };
+
+  using NodePtr = std::shared_ptr<const Node>;
+
+  NodePtr root_;
+  Compare cmp_;
+  std::uint64_t next_priority_ = 0;
+
+  [[nodiscard]] static size_t node_size(const NodePtr &p) noexcept
+  {
+    return p == nullptr ? 0 : p->count;
+  }
+
+  [[nodiscard]] static NodePtr make_node(std::shared_ptr<const Key> key,
+                                         std::shared_ptr<const T> value,
+                                         const std::uint64_t priority,
+                                         NodePtr left,
+                                         NodePtr right)
+  {
+    const size_t left_size = node_size(left);
+    const size_t right_size = node_size(right);
+    ah_overflow_error_if(left_size > std::numeric_limits<size_t>::max() - right_size)
+      << "PersistentTreapMap: node size would overflow";
+    const size_t children_size = left_size + right_size;
+    ah_overflow_error_if(children_size == std::numeric_limits<size_t>::max())
+      << "PersistentTreapMap: node size would overflow";
+
+    auto node = std::make_shared<Node>();
+    node->key = std::move(key);
+    node->value = std::move(value);
+    node->priority = priority;
+    node->left = std::move(left);
+    node->right = std::move(right);
+    node->count = children_size + 1;
+    return node;
+  }
+
+  [[nodiscard]] static NodePtr rotate_right(const NodePtr &node)
+  {
+    const NodePtr child = node->left;
+    NodePtr new_right = make_node(node->key, node->value, node->priority,
+                                  child->right, node->right);
+    return make_node(child->key, child->value, child->priority, child->left,
+                     std::move(new_right));
+  }
+
+  [[nodiscard]] static NodePtr rotate_left(const NodePtr &node)
+  {
+    const NodePtr child = node->right;
+    NodePtr new_left = make_node(node->key, node->value, node->priority,
+                                 node->left, child->left);
+    return make_node(child->key, child->value, child->priority,
+                     std::move(new_left), child->right);
+  }
+
+  [[nodiscard]] static NodePtr insert_rec(const NodePtr &node,
+                                          std::shared_ptr<const Key> key,
+                                          std::shared_ptr<const T> value,
+                                          const std::uint64_t priority,
+                                          const Compare &cmp,
+                                          bool &inserted)
+  {
+    if (node == nullptr)
+      {
+        inserted = true;
+        return make_node(std::move(key), std::move(value), priority, nullptr, nullptr);
+      }
+
+    if (cmp(*key, *node->key))
+      {
+        NodePtr new_left = insert_rec(node->left, std::move(key), std::move(value),
+                                      priority, cmp, inserted);
+        if (not inserted)
+          return node;
+        NodePtr rebuilt = make_node(node->key, node->value, node->priority,
+                                    std::move(new_left), node->right);
+        return rebuilt->left->priority < rebuilt->priority ? rotate_right(rebuilt) : rebuilt;
+      }
+
+    if (cmp(*node->key, *key))
+      {
+        NodePtr new_right = insert_rec(node->right, std::move(key), std::move(value),
+                                       priority, cmp, inserted);
+        if (not inserted)
+          return node;
+        NodePtr rebuilt = make_node(node->key, node->value, node->priority,
+                                    node->left, std::move(new_right));
+        return rebuilt->right->priority < rebuilt->priority ? rotate_left(rebuilt) : rebuilt;
+      }
+
+    inserted = false;
+    return node;
+  }
+
+  [[nodiscard]] static NodePtr insert_or_assign_rec(const NodePtr &node,
+                                                    std::shared_ptr<const Key> key,
+                                                    std::shared_ptr<const T> value,
+                                                    const std::uint64_t priority,
+                                                    const Compare &cmp,
+                                                    bool &inserted)
+  {
+    if (node == nullptr)
+      {
+        inserted = true;
+        return make_node(std::move(key), std::move(value), priority, nullptr, nullptr);
+      }
+
+    if (cmp(*key, *node->key))
+      {
+        NodePtr new_left = insert_or_assign_rec(node->left, std::move(key),
+                                                std::move(value), priority, cmp,
+                                                inserted);
+        NodePtr rebuilt = make_node(node->key, node->value, node->priority,
+                                    std::move(new_left), node->right);
+        return inserted and rebuilt->left->priority < rebuilt->priority
+          ? rotate_right(rebuilt) : rebuilt;
+      }
+
+    if (cmp(*node->key, *key))
+      {
+        NodePtr new_right = insert_or_assign_rec(node->right, std::move(key),
+                                                 std::move(value), priority, cmp,
+                                                 inserted);
+        NodePtr rebuilt = make_node(node->key, node->value, node->priority,
+                                    node->left, std::move(new_right));
+        return inserted and rebuilt->right->priority < rebuilt->priority
+          ? rotate_left(rebuilt) : rebuilt;
+      }
+
+    inserted = false;
+    return make_node(node->key, std::move(value), node->priority, node->left, node->right);
+  }
+
+  [[nodiscard]] static NodePtr join_nodes(const NodePtr &left, const NodePtr &right)
+  {
+    if (left == nullptr)
+      return right;
+    if (right == nullptr)
+      return left;
+
+    if (left->priority <= right->priority)
+      {
+        NodePtr new_right = join_nodes(left->right, right);
+        return make_node(left->key, left->value, left->priority, left->left,
+                         std::move(new_right));
+      }
+
+    NodePtr new_left = join_nodes(left, right->left);
+    return make_node(right->key, right->value, right->priority, std::move(new_left),
+                     right->right);
+  }
+
+  [[nodiscard]] static NodePtr erase_rec(const NodePtr &node,
+                                         const Key &key,
+                                         const Compare &cmp,
+                                         bool &erased)
+  {
+    if (node == nullptr)
+      {
+        erased = false;
+        return nullptr;
+      }
+
+    if (cmp(key, *node->key))
+      {
+        NodePtr new_left = erase_rec(node->left, key, cmp, erased);
+        if (not erased)
+          return node;
+        return make_node(node->key, node->value, node->priority,
+                         std::move(new_left), node->right);
+      }
+
+    if (cmp(*node->key, key))
+      {
+        NodePtr new_right = erase_rec(node->right, key, cmp, erased);
+        if (not erased)
+          return node;
+        return make_node(node->key, node->value, node->priority,
+                         node->left, std::move(new_right));
+      }
+
+    erased = true;
+    return join_nodes(node->left, node->right);
+  }
+
+  [[nodiscard]] static std::pair<NodePtr, NodePtr> split_rec(const NodePtr &node,
+                                                             const Key &pivot,
+                                                             const Compare &cmp)
+  {
+    if (node == nullptr)
+      return {nullptr, nullptr};
+
+    if (cmp(*node->key, pivot))
+      {
+        auto [right_left, right_right] = split_rec(node->right, pivot, cmp);
+        NodePtr left = make_node(node->key, node->value, node->priority,
+                                 node->left, std::move(right_left));
+        return {std::move(left), std::move(right_right)};
+      }
+
+    auto [left_left, left_right] = split_rec(node->left, pivot, cmp);
+    NodePtr right = make_node(node->key, node->value, node->priority,
+                              std::move(left_right), node->right);
+    return {std::move(left_left), std::move(right)};
+  }
+
+  [[nodiscard]] static const Key *min_key(const NodePtr &node) noexcept
+  {
+    const Node *curr = node.get();
+    while (curr->left != nullptr)
+      curr = curr->left.get();
+    return curr->key.get();
+  }
+
+  [[nodiscard]] static const Key *max_key(const NodePtr &node) noexcept
+  {
+    const Node *curr = node.get();
+    while (curr->right != nullptr)
+      curr = curr->right.get();
+    return curr->key.get();
+  }
+
+  [[nodiscard]] static bool can_join(const NodePtr &left,
+                                     const NodePtr &right,
+                                     const Compare &cmp)
+  {
+    return left == nullptr or right == nullptr or cmp(*max_key(left), *min_key(right));
+  }
+
+  static void collect_keys(const NodePtr &node, Array<Key> &out)
+    requires std::copy_constructible<Key>
+  {
+    if (node == nullptr)
+      return;
+    collect_keys(node->left, out);
+    out.append(Key(*node->key));
+    collect_keys(node->right, out);
+  }
+
+  static void collect_items(const NodePtr &node, Array<std::pair<Key, T>> &out)
+    requires (std::copy_constructible<Key> and std::copy_constructible<T>)
+  {
+    if (node == nullptr)
+      return;
+    collect_items(node->left, out);
+    out.append(std::pair<Key, T>{*node->key, *node->value});
+    collect_items(node->right, out);
+  }
+
+  [[nodiscard]] static bool verify_rec(const NodePtr &node,
+                                       const Key *lo,
+                                       const Key *hi,
+                                       const Compare &cmp,
+                                       size_t &count)
+  {
+    if (node == nullptr)
+      return true;
+    if (node->key == nullptr or node->value == nullptr)
+      return false;
+    if (lo != nullptr and not cmp(*lo, *node->key))
+      return false;
+    if (hi != nullptr and not cmp(*node->key, *hi))
+      return false;
+    if (node->left != nullptr and node->left->priority < node->priority)
+      return false;
+    if (node->right != nullptr and node->right->priority < node->priority)
+      return false;
+
+    size_t left_count = 0;
+    size_t right_count = 0;
+    if (not verify_rec(node->left, lo, node->key.get(), cmp, left_count))
+      return false;
+    if (not verify_rec(node->right, node->key.get(), hi, cmp, right_count))
+      return false;
+    if (node->count != left_count + right_count + 1)
+      return false;
+    count = node->count;
+    return true;
+  }
+
+  PersistentTreapMap(NodePtr root, Compare cmp, const std::uint64_t next_priority)
+    : root_(std::move(root)), cmp_(std::move(cmp)), next_priority_(next_priority)
+  {
+    // Empty.
+  }
+
+public:
+  /** @brief Construct an empty persistent map.
+   *  @param cmp Comparator used for key ordering.
+   *  @throws Nothing unless copying `cmp` throws.
+   */
+  explicit PersistentTreapMap(Compare cmp = Compare())
+    : cmp_(std::move(cmp))
+  {
+    // Empty.
+  }
+
+  /** @brief Return true when the map has no bindings.
+   *  @return `true` iff `size() == 0`.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] bool is_empty() const noexcept { return root_ == nullptr; }
+
+  /** @brief Return the number of key/value bindings in this version.
+   *  @return Number of bindings.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] size_t size() const noexcept { return node_size(root_); }
+
+  /** @brief Find a mapped value.
+   *  @param key Key to search.
+   *  @return Pointer to the stored mapped value, or `nullptr` when absent. The
+   *          pointer remains valid while this map version is alive.
+   *  @throws Whatever `Compare` throws.
+   */
+  [[nodiscard]] const T *find(const Key &key) const
+  {
+    const Node *curr = root_.get();
+    while (curr != nullptr)
+      if (cmp_(key, *curr->key))
+        curr = curr->left.get();
+      else if (cmp_(*curr->key, key))
+        curr = curr->right.get();
+      else
+        return curr->value.get();
+    return nullptr;
+  }
+
+  /** @brief Test whether `key` is present.
+   *  @param key Key to search.
+   *  @return `true` if an equivalent key is stored.
+   *  @throws Whatever `Compare` throws.
+   */
+  [[nodiscard]] bool contains(const Key &key) const
+  {
+    return find(key) != nullptr;
+  }
+
+  /** @brief Return a new version with a binding inserted if absent.
+   *  @tparam KArg Type used to construct `Key`.
+   *  @tparam VArg Type used to construct `T`.
+   *  @param key Key to insert.
+   *  @param value Mapped value to insert.
+   *  @return New map version. If an equivalent key already exists, returns an
+   *          unchanged version sharing the same root.
+   *  @throws std::bad_alloc or whatever construction/comparison throws.
+   */
+  template <typename KArg, typename VArg>
+    requires std::constructible_from<Key, KArg &&> and std::constructible_from<T, VArg &&>
+  [[nodiscard]] PersistentTreapMap insert(KArg &&key, VArg &&value) const
+  {
+    auto stored_key = std::make_shared<const Key>(std::forward<KArg>(key));
+    auto stored_value = std::make_shared<const T>(std::forward<VArg>(value));
+    bool inserted = false;
+    NodePtr root = insert_rec(root_, std::move(stored_key), std::move(stored_value),
+                              detail::persistent_treap_priority(next_priority_),
+                              cmp_, inserted);
+    return inserted ? PersistentTreapMap(std::move(root), cmp_, next_priority_ + 1) : *this;
+  }
+
+  /** @brief Return a new version with `key` assigned to `value`.
+   *  @tparam KArg Type used to construct `Key` when the key is absent.
+   *  @tparam VArg Type used to construct `T`.
+   *  @param key Key to insert or update.
+   *  @param value Mapped value for the returned version.
+   *  @return New map version with the binding present.
+   *  @throws std::bad_alloc or whatever construction/comparison throws.
+   */
+  template <typename KArg, typename VArg>
+    requires std::constructible_from<Key, KArg &&> and std::constructible_from<T, VArg &&>
+  [[nodiscard]] PersistentTreapMap insert_or_assign(KArg &&key, VArg &&value) const
+  {
+    auto stored_key = std::make_shared<const Key>(std::forward<KArg>(key));
+    auto stored_value = std::make_shared<const T>(std::forward<VArg>(value));
+    bool inserted = false;
+    NodePtr root = insert_or_assign_rec(root_, std::move(stored_key),
+                                        std::move(stored_value),
+                                        detail::persistent_treap_priority(next_priority_),
+                                        cmp_, inserted);
+    return PersistentTreapMap(std::move(root), cmp_, inserted ? next_priority_ + 1
+                                                              : next_priority_);
+  }
+
+  /** @brief Return a new version without `key`.
+   *  @param key Key to erase.
+   *  @return New map version. If the key is absent, returns an unchanged
+   *          version sharing the same root.
+   *  @throws std::bad_alloc or whatever `Compare` throws.
+   */
+  [[nodiscard]] PersistentTreapMap erase(const Key &key) const
+  {
+    bool erased = false;
+    NodePtr root = erase_rec(root_, key, cmp_, erased);
+    return erased ? PersistentTreapMap(std::move(root), cmp_, next_priority_) : *this;
+  }
+
+  /** @brief Split this version around `pivot`.
+   *  @param pivot Split key.
+   *  @return Pair `{less, greater_equal}` where the first map contains keys
+   *          strictly less than `pivot` and the second contains the rest.
+   *  @throws std::bad_alloc or whatever `Compare` throws.
+   */
+  [[nodiscard]] std::pair<PersistentTreapMap, PersistentTreapMap>
+  split(const Key &pivot) const
+  {
+    auto [left, right] = split_rec(root_, pivot, cmp_);
+    return {PersistentTreapMap(std::move(left), cmp_, next_priority_),
+            PersistentTreapMap(std::move(right), cmp_, next_priority_)};
+  }
+
+  /** @brief Join two ordered, non-overlapping map versions.
+   *  @param left Map whose keys must all be less than every key in `right`.
+   *  @param right Map whose keys must all be greater than every key in `left`.
+   *  @return Joined map version.
+   *  @throws std::domain_error if the key ranges overlap or touch.
+   *  @throws std::bad_alloc if node allocation fails.
+   */
+  [[nodiscard]] static PersistentTreapMap join(const PersistentTreapMap &left,
+                                               const PersistentTreapMap &right)
+  {
+    ah_domain_error_unless(can_join(left.root_, right.root_, left.cmp_))
+      << "PersistentTreapMap::join(): left keys must be strictly less than right keys";
+    return PersistentTreapMap(join_nodes(left.root_, right.root_), left.cmp_,
+                              std::max(left.next_priority_, right.next_priority_));
+  }
+
+  /** @brief Join this version with `right`.
+   *  @param right Map whose keys must all be greater than every key in this map.
+   *  @return Joined map version.
+   *  @throws std::domain_error if the key ranges overlap or touch.
+   *  @throws std::bad_alloc if node allocation fails.
+   */
+  [[nodiscard]] PersistentTreapMap join(const PersistentTreapMap &right) const
+  {
+    return join(*this, right);
+  }
+
+  /** @brief Return all keys in sorted order.
+   *  @return Aleph array with a copy of every key.
+   *  @throws std::bad_alloc or whatever copying `Key` throws.
+   */
+  [[nodiscard]] Array<Key> keys() const
+    requires std::copy_constructible<Key>
+  {
+    Array<Key> out;
+    out.reserve(size());
+    collect_keys(root_, out);
+    return out;
+  }
+
+  /** @brief Return all key/value bindings in sorted-key order.
+   *  @return Aleph array with a copy of every binding.
+   *  @throws std::bad_alloc or whatever copying `Key` or `T` throws.
+   */
+  [[nodiscard]] Array<std::pair<Key, T>> items() const
+    requires (std::copy_constructible<Key> and std::copy_constructible<T>)
+  {
+    Array<std::pair<Key, T>> out;
+    out.reserve(size());
+    collect_items(root_, out);
+    return out;
+  }
+
+  /** @brief Verify treap, BST and cached-size invariants.
+   *  @return `true` if the internal structure is consistent.
+   *  @throws Nothing unless `Compare` throws.
+   *  @note Intended for tests and diagnostics; it is O(n).
+   */
+  [[nodiscard]] bool verify() const
+  {
+    size_t count = 0;
+    return verify_rec(root_, nullptr, nullptr, cmp_, count) and count == size();
+  }
+};
+
+} // namespace Aleph
+
+#endif // TPL_PERSISTENT_TREAP_H

--- a/tpl_persistent_treap.H
+++ b/tpl_persistent_treap.H
@@ -33,7 +33,7 @@
  *  @details
  *  ### What is a Persistent Treap?
  *  A Treap is a randomized binary search tree that maintains both a BST property 
- *  (for the keys) and a Max-Heap property (using randomly generated priorities). 
+ *  (for the keys) and a Min-Heap property (using randomly generated priorities).
  *  This guarantees balanced O(log n) tree depth with high probability.
  *
  *  "Persistence" in this context refers to **immutability with history** 

--- a/tpl_persistent_vector.H
+++ b/tpl_persistent_vector.H
@@ -1,0 +1,421 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/** @file tpl_persistent_vector.H
+ *  @brief Immutable bitmapped-vector trie with structural sharing.
+ *
+ *  `PersistentVector<T>` is an in-memory persistent sequence. `push_back`,
+ *  `set` and `pop_back` return new vector versions and never mutate existing
+ *  versions. The implementation is a bitmapped vector trie with branching
+ *  factor 32, so updates copy O(log_32 n) trie nodes and share the rest.
+ *
+ *  This container is volatile in-memory persistence, not file-backed durable
+ *  storage. Published versions may be read concurrently by different threads;
+ *  publishing a new version into shared state still requires external
+ *  synchronization.
+ *
+ *  @ingroup Sequences
+ */
+
+#ifndef TPL_PERSISTENT_VECTOR_H
+#define TPL_PERSISTENT_VECTOR_H
+
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <ah-errors.H>
+#include <tpl_array.H>
+
+namespace Aleph
+{
+
+/** @brief Immutable vector backed by a 32-way bitmapped trie.
+ *
+ *  @tparam T Value type stored by the vector. Values are held through
+ *          `std::shared_ptr<const T>`, so updating one index does not copy
+ *          untouched values and move-only `T` is supported for `push_back`
+ *          and `set`.
+ */
+template <typename T>
+class PersistentVector
+{
+  static constexpr size_t branch_bits = 5;
+  static constexpr size_t branch_factor = size_t{1} << branch_bits;
+  static constexpr size_t branch_mask = branch_factor - 1;
+
+  using ValuePtr = std::shared_ptr<const T>;
+
+  struct Node
+  {
+    explicit Node(const bool leaf = true) noexcept : is_leaf(leaf) {}
+
+    bool is_leaf = true;
+    std::array<std::shared_ptr<const Node>, branch_factor> children{};
+    std::array<ValuePtr, branch_factor> values{};
+  };
+
+  using NodePtr = std::shared_ptr<const Node>;
+
+  NodePtr root_;
+  size_t size_ = 0;
+  size_t shift_ = 0;  // 0 means root is a leaf; otherwise high child shift.
+
+  [[nodiscard]] static size_t child_index(const size_t index, const size_t shift) noexcept
+  {
+    return (index >> shift) & branch_mask;
+  }
+
+  [[nodiscard]] static size_t capacity_for_shift(const size_t shift) noexcept
+  {
+    constexpr size_t digits = std::numeric_limits<size_t>::digits;
+    if (shift >= digits - branch_bits)
+      return std::numeric_limits<size_t>::max();
+    return size_t{1} << (shift + branch_bits);
+  }
+
+  [[nodiscard]] static NodePtr set_rec(const NodePtr &node,
+                                       const size_t shift,
+                                       const size_t index,
+                                       ValuePtr value)
+  {
+    auto copy = node == nullptr ? std::make_shared<Node>(shift == 0)
+                                : std::make_shared<Node>(*node);
+    copy->is_leaf = shift == 0;
+
+    if (shift == 0)
+      {
+        copy->values[child_index(index, 0)] = std::move(value);
+        return copy;
+      }
+
+    const size_t slot = child_index(index, shift);
+    copy->children[slot] = set_rec(copy->children[slot], shift - branch_bits,
+                                   index, std::move(value));
+    return copy;
+  }
+
+  [[nodiscard]] static bool leaf_has_values(const std::shared_ptr<Node> &node) noexcept
+  {
+    for (const auto &value : node->values)
+      if (value != nullptr)
+        return true;
+    return false;
+  }
+
+  [[nodiscard]] static bool internal_has_children(const std::shared_ptr<Node> &node) noexcept
+  {
+    for (const auto &child : node->children)
+      if (child != nullptr)
+        return true;
+    return false;
+  }
+
+  [[nodiscard]] static NodePtr clear_rec(const NodePtr &node,
+                                         const size_t shift,
+                                         const size_t index)
+  {
+    if (node == nullptr)
+      return nullptr;
+
+    auto copy = std::make_shared<Node>(*node);
+    copy->is_leaf = shift == 0;
+
+    if (shift == 0)
+      {
+        copy->values[child_index(index, 0)] = nullptr;
+        return leaf_has_values(copy) ? NodePtr(copy) : nullptr;
+      }
+
+    const size_t slot = child_index(index, shift);
+    copy->children[slot] = clear_rec(copy->children[slot], shift - branch_bits, index);
+    return internal_has_children(copy) ? NodePtr(copy) : nullptr;
+  }
+
+  [[nodiscard]] static const T *get_ptr(const NodePtr &root,
+                                        size_t shift,
+                                        const size_t index) noexcept
+  {
+    const Node *curr = root.get();
+    while (curr != nullptr and shift > 0)
+      {
+        curr = curr->children[child_index(index, shift)].get();
+        shift -= branch_bits;
+      }
+    if (curr == nullptr)
+      return nullptr;
+    const ValuePtr &value = curr->values[child_index(index, 0)];
+    return value == nullptr ? nullptr : value.get();
+  }
+
+  [[nodiscard]] static size_t count_values_rec(const NodePtr &node,
+                                               const size_t shift,
+                                               bool &ok) noexcept
+  {
+    if (node == nullptr)
+      return 0;
+    if (node->is_leaf != (shift == 0))
+      {
+        ok = false;
+        return 0;
+      }
+
+    size_t count = 0;
+    if (shift == 0)
+      {
+        for (const auto &child : node->children)
+          if (child != nullptr)
+            ok = false;
+        for (const auto &value : node->values)
+          if (value != nullptr)
+            ++count;
+        return count;
+      }
+
+    for (const auto &value : node->values)
+      if (value != nullptr)
+        ok = false;
+    for (const auto &child : node->children)
+      count += count_values_rec(child, shift - branch_bits, ok);
+    return count;
+  }
+
+  explicit PersistentVector(NodePtr root, const size_t n, const size_t shift) noexcept
+    : root_(std::move(root)), size_(n), shift_(shift)
+  {
+    // Empty.
+  }
+
+public:
+  /** @brief Construct an empty persistent vector.
+   *  @throws Nothing.
+   */
+  PersistentVector() noexcept = default;
+
+  /** @brief Return the trie branching factor.
+   *  @return Always 32.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] static constexpr size_t branching_factor() noexcept
+  {
+    return branch_factor;
+  }
+
+  /** @brief Return true when the vector has no values.
+   *  @return `true` iff `size() == 0`.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] bool is_empty() const noexcept { return size_ == 0; }
+
+  /** @brief Return the number of values in this version.
+   *  @return Logical vector length.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] size_t size() const noexcept { return size_; }
+
+  /** @brief Read a value by index.
+   *  @param index Zero-based index.
+   *  @return Constant reference to the stored value.
+   *  @throws std::out_of_range if `index >= size()`.
+   */
+  [[nodiscard]] const T &get(const size_t index) const
+  {
+    ah_out_of_range_error_if(index >= size_)
+      << "PersistentVector::get(): index out of range";
+    const T *value = get_ptr(root_, shift_, index);
+    ah_logic_error_if(value == nullptr)
+      << "PersistentVector::get(): missing value inside vector trie";
+    return *value;
+  }
+
+  /** @brief Read a value by index.
+   *  @param index Zero-based index.
+   *  @return Constant reference to the stored value.
+   *  @throws std::out_of_range if `index >= size()`.
+   */
+  [[nodiscard]] const T &operator [] (const size_t index) const
+  {
+    return get(index);
+  }
+
+  /** @brief Return a new version with `value` appended by copy.
+   *  @param value Value to append.
+   *  @return New vector version with size increased by one.
+   *  @throws std::length_error if the vector cannot grow further.
+   *  @throws std::bad_alloc or whatever copying `T` throws.
+   */
+  [[nodiscard]] PersistentVector push_back(const T &value) const
+  {
+    return push_back(ValuePtr(std::make_shared<const T>(value)));
+  }
+
+  /** @brief Return a new version with `value` appended by move.
+   *  @param value Value to move into the returned version.
+   *  @return New vector version with size increased by one.
+   *  @throws std::length_error if the vector cannot grow further.
+   *  @throws std::bad_alloc or whatever moving `T` throws.
+   */
+  [[nodiscard]] PersistentVector push_back(T &&value) const
+  {
+    return push_back(ValuePtr(std::make_shared<const T>(std::move(value))));
+  }
+
+  /** @brief Return a new version with one index replaced by copy.
+   *  @param index Index to replace.
+   *  @param value New value.
+   *  @return New vector version with the same size.
+   *  @throws std::out_of_range if `index >= size()`.
+   *  @throws std::bad_alloc or whatever copying `T` throws.
+   */
+  [[nodiscard]] PersistentVector set(const size_t index, const T &value) const
+  {
+    ah_out_of_range_error_if(index >= size_)
+      << "PersistentVector::set(): index out of range";
+    return set(index, ValuePtr(std::make_shared<const T>(value)));
+  }
+
+  /** @brief Return a new version with one index replaced by move.
+   *  @param index Index to replace.
+   *  @param value New value.
+   *  @return New vector version with the same size.
+   *  @throws std::out_of_range if `index >= size()`.
+   *  @throws std::bad_alloc or whatever moving `T` throws.
+   */
+  [[nodiscard]] PersistentVector set(const size_t index, T &&value) const
+  {
+    ah_out_of_range_error_if(index >= size_)
+      << "PersistentVector::set(): index out of range";
+    return set(index, ValuePtr(std::make_shared<const T>(std::move(value))));
+  }
+
+  /** @brief Return a new version without the last value.
+   *  @return New vector version with size decreased by one.
+   *  @throws std::underflow_error if the vector is empty.
+   *  @throws std::bad_alloc if a path-copy node allocation fails.
+   */
+  [[nodiscard]] PersistentVector pop_back() const
+  {
+    ah_underflow_error_if(is_empty())
+      << "PersistentVector::pop_back(): empty vector";
+
+    if (size_ == 1)
+      return PersistentVector();
+
+    const size_t new_size = size_ - 1;
+    NodePtr root = clear_rec(root_, shift_, new_size);
+    size_t shift = shift_;
+
+    while (shift > 0 and new_size <= capacity_for_shift(shift - branch_bits))
+      {
+        root = root == nullptr ? nullptr : root->children[0];
+        shift -= branch_bits;
+      }
+
+    return PersistentVector(std::move(root), new_size, shift);
+  }
+
+  /** @brief Return all values in an Aleph array.
+   *  @return Array containing a copy of every value in index order.
+   *  @throws std::bad_alloc or whatever copying `T` throws.
+   */
+  [[nodiscard]] Array<T> to_array() const
+    requires std::copy_constructible<T>
+  {
+    Array<T> out;
+    out.reserve(size_);
+    for (size_t i = 0; i < size_; ++i)
+      out.append(T(get(i)));
+    return out;
+  }
+
+  /** @brief Verify trie shape and logical prefix invariants.
+   *  @return `true` if the internal structure is consistent.
+   *  @throws Nothing.
+   *  @note Intended for tests and diagnostics; it is O(n log_32 n).
+   */
+  [[nodiscard]] bool verify() const noexcept
+  {
+    if (size_ == 0)
+      return root_ == nullptr and shift_ == 0;
+    if (root_ == nullptr)
+      return false;
+    if (size_ > capacity_for_shift(shift_))
+      return false;
+
+    bool ok = true;
+    const size_t count = count_values_rec(root_, shift_, ok);
+    if (not ok or count != size_)
+      return false;
+    for (size_t i = 0; i < size_; ++i)
+      if (get_ptr(root_, shift_, i) == nullptr)
+        return false;
+    return true;
+  }
+
+private:
+  [[nodiscard]] PersistentVector push_back(ValuePtr value) const
+  {
+    ah_length_error_if(size_ == std::numeric_limits<size_t>::max())
+      << "PersistentVector::push_back(): size_t capacity exhausted";
+
+    if (root_ == nullptr)
+      return PersistentVector(set_rec(nullptr, 0, 0, std::move(value)), 1, 0);
+
+    NodePtr root = root_;
+    size_t shift = shift_;
+    if (size_ == capacity_for_shift(shift_))
+      {
+        ah_length_error_if(shift_ >= std::numeric_limits<size_t>::digits - branch_bits)
+          << "PersistentVector::push_back(): trie depth exhausted";
+        auto grown = std::make_shared<Node>(false);
+        grown->children[0] = root_;
+        root = grown;
+        shift += branch_bits;
+      }
+
+    root = set_rec(root, shift, size_, std::move(value));
+    return PersistentVector(std::move(root), size_ + 1, shift);
+  }
+
+  [[nodiscard]] PersistentVector set(const size_t index, ValuePtr value) const
+  {
+    ah_out_of_range_error_if(index >= size_)
+      << "PersistentVector::set(): index out of range";
+    return PersistentVector(set_rec(root_, shift_, index, std::move(value)),
+                            size_, shift_);
+  }
+};
+
+} // namespace Aleph
+
+#endif // TPL_PERSISTENT_VECTOR_H

--- a/tpl_persistent_vector.H
+++ b/tpl_persistent_vector.H
@@ -74,7 +74,7 @@ namespace Aleph
  *  "Persistence" in this context refers to **immutability with history** 
  *  (structural sharing or path-copying), not disk storage. When you call 
  *  `push_back` or `set`, the original vector is not mutated. Instead, the 
- *  container copies only the $O(\log_{32} N)$ nodes from the root down to the 
+ *  container copies only the O(log_32 N) nodes from the root down to the 
  *  modified leaf. The other 31 branches at each level remain untouched and are 
  *  shared between the old and new vectors via smart pointers (`std::shared_ptr`).
  *

--- a/tpl_persistent_vector.H
+++ b/tpl_persistent_vector.H
@@ -62,6 +62,29 @@ namespace Aleph
 
 /** @brief Immutable vector backed by a 32-way bitmapped trie.
  *
+ *  @details
+ *  ### What is a Persistent Vector?
+ *  Unlike a standard `std::vector` which stores elements in a contiguous memory 
+ *  block and requires an O(N) copy to duplicate, a `PersistentVector` is structured 
+ *  as a shallow, wide tree (a Trie) where each node has up to 32 children.
+ *  Because $32^6 > 10^9$, the tree depth never exceeds 6 levels for any realistic 
+ *  number of elements. Thus, index lookups and updates require at most 6 pointer 
+ *  dereferences, providing "effectively O(1)" performance.
+ *
+ *  "Persistence" in this context refers to **immutability with history** 
+ *  (structural sharing or path-copying), not disk storage. When you call 
+ *  `push_back` or `set`, the original vector is not mutated. Instead, the 
+ *  container copies only the $O(\log_{32} N)$ nodes from the root down to the 
+ *  modified leaf. The other 31 branches at each level remain untouched and are 
+ *  shared between the old and new vectors via smart pointers (`std::shared_ptr`).
+ *
+ *  ### Benefits
+ *  - **Lock-free Concurrency:** Because older versions are never overwritten, 
+ *    multiple threads can read safely without locks.
+ *  - **Move-only Types:** Values are held inside `std::shared_ptr<const T>`. 
+ *    This allows the vector to store move-only types, and ensures that updating 
+ *    one index does not force the copy constructor of unchanged heavy elements.
+ *
  *  @tparam T Value type stored by the vector. Values are held through
  *          `std::shared_ptr<const T>`, so updating one index does not copy
  *          untouched values and move-only `T` is supported for `push_back`
@@ -347,14 +370,19 @@ public:
   /** @brief Return all values in an Aleph array.
    *  @return Array containing a copy of every value in index order.
    *  @throws std::bad_alloc or whatever copying `T` throws.
+   *  @note `T` must also satisfy `Array<T>`'s movable-value requirements.
    */
   [[nodiscard]] Array<T> to_array() const
-    requires std::copy_constructible<T>
+    requires (std::is_copy_constructible_v<T> and std::is_copy_assignable_v<T> and
+              std::is_move_constructible_v<T> and std::is_move_assignable_v<T>)
   {
     Array<T> out;
     out.reserve(size_);
     for (size_t i = 0; i < size_; ++i)
-      out.append(T(get(i)));
+      {
+        const T &value = get(i);
+        out.append(value);
+      }
     return out;
   }
 
@@ -373,8 +401,7 @@ public:
       return false;
 
     bool ok = true;
-    const size_t count = count_values_rec(root_, shift_, ok);
-    if (not ok or count != size_)
+    if (const size_t count = count_values_rec(root_, shift_, ok); not ok or count != size_)
       return false;
     for (size_t i = 0; i < size_; ++i)
       if (get_ptr(root_, shift_, i) == nullptr)


### PR DESCRIPTION
Implement persistent treap and vector data structures. Includes example usage, comprehensive tests, and README updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas funcionalidades**
  * Contenedores persistentes en memoria: `PersistentTreapSet`, `PersistentTreapMap`, `PersistentVector` y `PersistentHashMap`, con snapshots inmutables por versiones y compartición estructural.
* **Documentación**
  * Nueva sección en el README (EN y ES) con ejemplos, contratos de inmutabilidad y notas de concurrencia.
* **Ejemplos**
  * Programas de ejemplo para `PersistentTreap*` y `PersistentHashMap`.
* **Pruebas**
  * Nuevos tests de GoogleTest para treaps, vector y `PersistentHashMap`, incluyendo casos con tipos move-only y pruebas aleatorizadas.
* **Chores**
  * Ajustada la instalación de cabeceras y la selección/registro de tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->