### PR TITLE
feat(core): Implement R-tree and R*-tree data structures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,8 @@ set(HLIST
     tpl_persistent_treap.H
     tpl_persistent_vector.H
     tpl_persistent_hash_map.H
+    tpl_r_tree.H
+    tpl_r_star_tree.H
     tpl_ca_parallel_engine.H
     tpl_ca_hex_lattice.H
     tpl_ca_triangular_lattice.H

--- a/Examples/r_tree_example.cc
+++ b/Examples/r_tree_example.cc
@@ -1,0 +1,110 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file r_tree_example.cc
+ * @brief Dynamic spatial indexing with Aleph::RTree.
+ *
+ * Usage:
+ *   ./r_tree_example
+ */
+
+#include <cassert>
+#include <iostream>
+#include <string>
+
+#include <tpl_r_tree.H>
+#include <tpl_r_star_tree.H>
+
+using namespace Aleph;
+using namespace std;
+
+static Rectangle box(const int x1, const int y1, const int x2, const int y2)
+{
+  return Rectangle(Geom_Number(x1), Geom_Number(y1),
+                   Geom_Number(x2), Geom_Number(y2));
+}
+
+int main()
+{
+  cout << "Aleph-w RTree Example" << endl;
+  cout << "=====================" << endl;
+
+  // A dynamic spatial index mapping bounding boxes to named regions.
+  RTree<string> map;
+
+  map.insert(box(0, 0, 10, 10), "downtown");
+  map.insert(box(8, 8, 20, 20), "midtown");
+  map.insert(box(30, 30, 40, 40), "airport");
+  map.insert(box(5, 5, 6, 6), "central-park");
+
+  cout << "Indexed " << map.size() << " regions, tree height "
+       << map.height() << "." << endl;
+
+  // Which regions overlap the query window (7,7)-(9,9)?
+  cout << "Regions intersecting (7,7)-(9,9):";
+  map.for_each_intersecting(box(7, 7, 9, 9),
+    [](const Rectangle &, const string &name) { cout << ' ' << name; });
+  cout << endl;
+
+  // Which regions contain the point (35,35)?
+  Array<string> here = map.search_contains(Point(Geom_Number(35), Geom_Number(35)));
+  cout << "Region(s) containing point (35,35):";
+  for (size_t i = 0; i < here.size(); ++i)
+    cout << ' ' << here(i);
+  cout << endl;
+  assert(here.size() == 1);
+
+  // A far-away query returns nothing.
+  assert(map.search_intersects(box(100, 100, 110, 110)).is_empty());
+
+  // Remove a region; the index stays consistent and queryable.
+  const bool removed = map.erase(box(30, 30, 40, 40), "airport");
+  assert(removed);
+  assert(map.size() == 3);
+  assert(map.search_contains(Point(Geom_Number(35), Geom_Number(35))).is_empty());
+  assert(map.verify());
+
+  cout << "After removing 'airport': " << map.size()
+       << " regions, all invariants valid." << endl;
+
+  // RStarTree has the exact same API but uses the R*-tree heuristics
+  // (overlap-minimizing subtree choice, margin/overlap split and forced
+  // reinsertion), which typically yield less node overlap and faster queries.
+  RStarTree<string> rstar;
+  rstar.insert(box(0, 0, 10, 10), "a");
+  rstar.insert(box(8, 8, 20, 20), "b");
+  rstar.insert(box(30, 30, 40, 40), "c");
+  assert(rstar.search_intersects(box(7, 7, 9, 9)).size() == 2);
+  assert(rstar.verify());
+  cout << "RStarTree indexed " << rstar.size()
+       << " regions with the same API." << endl;
+
+  return 0;
+}

--- a/README.es.md
+++ b/README.es.md
@@ -1152,7 +1152,7 @@ Aleph-w ofrece una suite robusta para geometría computacional 2D y 3D, construi
 | **Intersections** | Segment Sweep (Bentley-Ottmann), Half-Plane Intersection, Convex Polygon Clipping, Boolean Polygon Ops (Greiner-Hormann) | O((n+k)log n), O(n log n) |
 | **Simplification** | Douglas-Peucker, Visvalingam-Whyatt, Chaikin Smoothing | O(n log n), O(n*2^k) |
 | **Pathfinding** | Shortest Path in Simple Polygon (Funnel Algorithm) | O(n) |
-| **Spatial Indexing** | AABB Tree, KD-Tree | O(log n) queries |
+| **Spatial Indexing** | AABB Tree (estático), R-tree y R*-tree (dinámico, `tpl_r_tree.H` / `tpl_r_star_tree.H`), KD-Tree | Consultas O(log n) esperadas, O(n) peor caso |
 
 **Visualización (`tikzgeom.H`, `eepicgeom.H`):**
 
@@ -1188,6 +1188,60 @@ Point q = segment_intersection_point(v, d);  // exactly (3, 3)
 // --- Triangle area (exact rational) ---
 Geom_Number area = area_of_triangle(a, b, c);  // exact
 ```
+
+#### R-tree / R*-tree dinámico (`tpl_r_tree.H`, `tpl_r_star_tree.H`)
+
+```cpp
+#include <tpl_r_tree.H>
+
+int main() {
+    Aleph::RTree<int> tree;                          // Payload = int
+    tree.insert(Aleph::Rectangle(0, 0, 10, 10), 1);
+    tree.insert(Aleph::Rectangle(8, 8, 20, 20), 2);
+
+    auto hits = tree.search_intersects(Aleph::Rectangle(7, 7, 9, 9)); // {1, 2}
+    (void) tree.erase(Aleph::Rectangle(8, 8, 20, 20), 2);            // retorna bool
+
+    return hits.size() == 2 and tree.size() == 1 ? 0 : 1;
+}
+```
+
+`RTree<Payload, MaxEntries = 16, MinEntries = MaxEntries / 2>` es un índice
+espacial *dinámico* sobre rectángulos alineados a los ejes (`Rectangle`), que
+implementa el R-tree de Guttman con la heurística de split cuadrático. Soporta
+`insert(bbox, value)` / `erase(bbox, value)` incrementales, consultas de
+solapamiento (`search_intersects`, `for_each_intersecting`) y de contención de
+punto (`search_contains`), además de `size`, `height` y `clear`. Como guarda
+coordenadas racionales exactas (`Geom_Number`), la estructura es determinista y
+sin errores de redondeo de punto flotante. `for_each_intersecting` pasa
+referencias, así que también funciona con payloads move-only.
+
+Cómo se compara con las otras estructuras espaciales:
+
+- **`AABBTree` (`geom_algorithms.H`)** es *estático*: se construye una sola vez a
+  partir de un lote fijo de cajas y probablemente sea más rápido para datos
+  inmutables, pero no se puede actualizar en sitio. `RTree` es la contraparte
+  *dinámica y general* con `insert`/`erase`.
+- **`QuadTree` (`quadtree.H`)** subdivide el espacio recursivamente en cuadrantes;
+  es simple y bueno para puntos y distribuciones uniformes, pero no se balancea
+  por ocupación y puede degradarse con datos sesgados. `RTree` agrupa objetos por
+  su rectángulo mínimo envolvente y acota la ocupación de nodos.
+- **`K2Tree`** es una representación compacta/sucinta orientada a matrices binarias
+  ralas y adyacencia (p. ej. grafos web), no a indexar rectángulos generales.
+- **`RangeTree2D`** responde *range reporting* ortogonal sobre un conjunto de
+  puntos estático con buenas cotas de peor caso; `RTree` apunta a indexar
+  rectángulos/objetos de forma dinámica, no a consultas de rango sobre puntos
+  estáticos.
+
+`RStarTree<Payload, MaxEntries, MinEntries>` (`tpl_r_star_tree.H`) es el mismo
+índice construido con las heurísticas del R\*-tree: elección de subárbol que
+minimiza el solapamiento, un split que minimiza primero el margen y luego el área
+de solapamiento de los grupos, y reinserción forzada a nivel de hoja. Tiene la
+API idéntica (es un alias de `RTree<..., RTreeVariant::RStar>`) y suele producir
+menos solapamiento entre nodos y consultas más rápidas, a cambio de algo más de
+trabajo por inserción.
+
+Ver `Examples/r_tree_example.cc` para un recorrido ejecutable de ambos.
 
 <a id="readme-es-algebra-lineal"></a>
 ### Álgebra lineal (estructuras sparse)
@@ -4198,6 +4252,7 @@ cmake --build build
 | Ordenamiento topológico | `topological_sort_example.C` | Ordenamiento de DAG |
 
 | **Geometría** | | |
+| R-tree dinámico | `r_tree_example.cc` | Insert/erase + consultas de intersección y de punto sobre un índice espacial dinámico |
 | Predicados robustos | `robust_predicates_example.cc` | Orientación, intersección, aritmética exacta |
 | Intersección de segmentos dedicada | `segment_segment_intersection_example.cc` | Intersección de segmentos por pares en O(1) (`none`/`point`/`overlap`) |
 | Algoritmos de geometría | `geom_example.C` | Convex hull, triangulación y `-s advanced` (Delaunay/Voronoi/PIP/HPI) |

--- a/README.md
+++ b/README.md
@@ -1312,7 +1312,7 @@ Aleph-w provides a robust suite for 2D and 3D computational geometry, built on *
 | **Intersections** | Segment Sweep (Bentley-Ottmann), Half-Plane Intersection, Convex Polygon Clipping, Boolean Polygon Ops (Greiner-Hormann) | O((n+k)log n), O(n log n) |
 | **Simplification** | Douglas-Peucker, Visvalingam-Whyatt, Chaikin Smoothing | O(n log n), O(n*2^k) |
 | **Pathfinding** | Shortest Path in Simple Polygon (Funnel Algorithm) | O(n) |
-| **Spatial Indexing** | AABB Tree, KD-Tree | O(log n) queries |
+| **Spatial Indexing** | AABB Tree (static), R-tree & R*-tree (dynamic, `tpl_r_tree.H` / `tpl_r_star_tree.H`), KD-Tree | Expected O(log n), worst-case O(n) queries |
 
 **Visualization (`tikzgeom.H`, `eepicgeom.H`):**
 
@@ -1322,6 +1322,57 @@ Aleph-w provides a robust suite for 2D and 3D computational geometry, built on *
 - **Legacy EEPIC Backend**: For compatibility with older LaTeX workflows.
 
 For a deeper tour of the geometry stack and the TikZ tooling, see [docs/GEOMETRY_MODULE_GUIDE.md](docs/GEOMETRY_MODULE_GUIDE.md) and the [TikZ Geometry Guide](docs/TIKZGEOM_GUIDE.md).
+
+#### Dynamic R-tree / R*-tree (`tpl_r_tree.H`, `tpl_r_star_tree.H`)
+
+```cpp
+#include <tpl_r_tree.H>
+
+int main() {
+    Aleph::RTree<int> tree;                          // Payload = int
+    tree.insert(Aleph::Rectangle(0, 0, 10, 10), 1);
+    tree.insert(Aleph::Rectangle(8, 8, 20, 20), 2);
+
+    auto hits = tree.search_intersects(Aleph::Rectangle(7, 7, 9, 9)); // {1, 2}
+    (void) tree.erase(Aleph::Rectangle(8, 8, 20, 20), 2);            // returns bool
+
+    return hits.size() == 2 and tree.size() == 1 ? 0 : 1;
+}
+```
+
+`RTree<Payload, MaxEntries = 16, MinEntries = MaxEntries / 2>` is a dynamic
+spatial index over axis-aligned rectangles (`Rectangle`), implementing Guttman's
+R-tree with the quadratic node-split heuristic. It supports incremental
+`insert(bbox, value)` / `erase(bbox, value)`, overlap queries
+(`search_intersects`, `for_each_intersecting`) and point-containment queries
+(`search_contains`), plus `size`, `height` and `clear`. Because it stores exact
+rational coordinates (`Geom_Number`), the structure is deterministic and free of
+floating-point rounding. `for_each_intersecting` passes references and therefore
+also works for move-only payloads.
+
+How it compares to the other spatial structures:
+
+- **`AABBTree` (`geom_algorithms.H`)** is *static*: it is built once from a fixed
+  batch of boxes and is likely faster for immutable data, but cannot be updated
+  in place. `RTree` is the *dynamic, general* counterpart with `insert`/`erase`.
+- **`QuadTree` (`quadtree.H`)** recursively subdivides space into quadrants; it is
+  simple and good for point data and uniform distributions, but is not balanced
+  by occupancy and can degrade with skewed data. `RTree` groups objects by
+  minimum bounding rectangle and bounds node occupancy.
+- **`K2Tree`** is a compact/succinct representation aimed at sparse binary
+  matrices and adjacency (e.g. web graphs), not general rectangle indexing.
+- **`RangeTree2D`** answers orthogonal *range reporting* over a static point set
+  with strong worst-case bounds; `RTree` targets dynamic rectangle/object
+  indexing rather than static point range queries.
+
+`RStarTree<Payload, MaxEntries, MinEntries>` (`tpl_r_star_tree.H`) is the same
+index built with the R\*-tree heuristics: overlap-minimizing subtree choice, a
+split that minimizes group margin then overlap area, and leaf-level forced
+reinsertion. It has the identical API (it is an alias over
+`RTree<..., RTreeVariant::RStar>`) and typically produces less node overlap and
+faster queries at the cost of somewhat more work per insertion.
+
+See `Examples/r_tree_example.cc` for a runnable walkthrough of both.
 
 See `Examples/` for over a dozen geometry-specific programs, including `tikz_funnel_beamer_twocol_example.cc` which generates animated Beamer slides of the shortest-path funnel algorithm.
 
@@ -4648,6 +4699,7 @@ cmake --build build
 | SCC | `tarjan_example.C` | Strongly connected |
 | Topological | `topological_sort_example.C` | DAG ordering |
 | **Geometry** | | |
+| Dynamic R-tree | `r_tree_example.cc` | Insert/erase + intersection & point queries on a dynamic spatial index |
 | Robust predicates | `robust_predicates_example.cc` | Orientation, intersection, exact arithmetic |
 | Dedicated segment intersection | `segment_segment_intersection_example.cc` | O(1) pairwise segment intersection (`none`/`point`/`overlap`) |
 | Geometry algorithms | `geom_example.C` | Convex hull, triangulation, and `-s advanced` (Delaunay/Voronoi/PIP/HPI) |

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -391,6 +391,8 @@ set(TEST_PROGRAMS
     patricia_trie_test
     persistent_treap_test
     persistent_vector_test
+    r_tree_test
+    r_star_tree_test
     timeoutQueue_test
     graph_traverse_test
     test_ah_errors

--- a/Tests/r_star_tree_test.cc
+++ b/Tests/r_star_tree_test.cc
@@ -1,0 +1,319 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file r_star_tree_test.cc
+ * @brief Tests for Aleph::RStarTree (R*-tree heuristics).
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include <tpl_r_star_tree.H>
+
+using namespace Aleph;
+
+namespace
+{
+  Rectangle rect(const int x1, const int y1, const int x2, const int y2)
+  {
+    return Rectangle(Geom_Number(x1), Geom_Number(y1),
+                     Geom_Number(x2), Geom_Number(y2));
+  }
+
+  Point pt(const int x, const int y)
+  {
+    return Point(Geom_Number(x), Geom_Number(y));
+  }
+
+  template <typename Tree>
+  std::vector<int> sorted_intersects(const Tree &tree, const Rectangle &q)
+  {
+    Array<int> hits = tree.search_intersects(q);
+    std::vector<int> out;
+    for (size_t i = 0; i < hits.size(); ++i)
+      out.push_back(hits(i));
+    std::sort(out.begin(), out.end());
+    return out;
+  }
+
+  std::vector<int> brute_intersects(const std::vector<std::pair<Rectangle, int>> &ref,
+                                    const Rectangle &q)
+  {
+    std::vector<int> out;
+    for (const auto &[b, id] : ref)
+      if (b.intersects(q))
+        out.push_back(id);
+    std::sort(out.begin(), out.end());
+    return out;
+  }
+
+  std::vector<int> brute_contains(const std::vector<std::pair<Rectangle, int>> &ref,
+                                  const Point &p)
+  {
+    std::vector<int> out;
+    for (const auto &[b, id] : ref)
+      if (b.contains(p))
+        out.push_back(id);
+    std::sort(out.begin(), out.end());
+    return out;
+  }
+
+  template <typename Tree>
+  std::vector<int> sorted_contains(const Tree &tree, const Point &p)
+  {
+    Array<int> hits = tree.search_contains(p);
+    std::vector<int> out;
+    for (size_t i = 0; i < hits.size(); ++i)
+      out.push_back(hits(i));
+    std::sort(out.begin(), out.end());
+    return out;
+  }
+
+  // Randomized parity + per-step invariant check for a given fanout.
+  template <size_t Max, size_t Min>
+  void randomized_parity(const unsigned seed, const int iters, const int space,
+                         const int ext)
+  {
+    std::mt19937 rng(seed);
+    std::uniform_int_distribution<int> op_dist(0, 2);
+    std::uniform_int_distribution<int> coord(0, space);
+    std::uniform_int_distribution<int> extent(0, ext);
+
+    RStarTree<int, Max, Min> tree;
+    std::vector<std::pair<Rectangle, int>> ref;
+    int next_id = 0;
+
+    auto random_rect = [&]()
+    {
+      const int x1 = coord(rng);
+      const int y1 = coord(rng);
+      return rect(x1, y1, x1 + extent(rng), y1 + extent(rng));
+    };
+
+    for (int iter = 0; iter < iters; ++iter)
+      {
+        const int op = ref.empty() ? 0 : op_dist(rng);
+        if (op == 0)
+          {
+            const Rectangle b = random_rect();
+            const int id = next_id++;
+            tree.insert(b, id);
+            ref.emplace_back(b, id);
+          }
+        else if (op == 1)
+          {
+            std::uniform_int_distribution<size_t> pick(0, ref.size() - 1);
+            const size_t k = pick(rng);
+            ASSERT_TRUE(tree.erase(ref[k].first, ref[k].second));
+            ref.erase(ref.begin() + k);
+          }
+        else
+          {
+            const Rectangle q = random_rect();
+            EXPECT_EQ(sorted_intersects(tree, q), brute_intersects(ref, q));
+            const Point p = pt(coord(rng), coord(rng));
+            EXPECT_EQ(sorted_contains(tree, p), brute_contains(ref, p));
+          }
+
+        ASSERT_TRUE(tree.verify()) << "invariant broken at iter " << iter;
+        ASSERT_EQ(tree.size(), ref.size());
+      }
+
+    for (int x = 0; x <= space; x += 9)
+      for (int y = 0; y <= space; y += 9)
+        {
+          const Rectangle q = rect(x, y, x + ext, y + ext);
+          ASSERT_EQ(sorted_intersects(tree, q), brute_intersects(ref, q));
+          ASSERT_EQ(sorted_contains(tree, pt(x, y)), brute_contains(ref, pt(x, y)));
+        }
+  }
+}
+
+TEST(RStarTree, EmptyTree)
+{
+  RStarTree<int> tree;
+  EXPECT_TRUE(tree.is_empty());
+  EXPECT_EQ(tree.size(), 0u);
+  EXPECT_EQ(tree.height(), 0u);
+  EXPECT_TRUE(tree.verify());
+  EXPECT_FALSE(tree.erase(rect(0, 0, 1, 1), 5));
+}
+
+TEST(RStarTree, SingletonAndErase)
+{
+  RStarTree<int> tree;
+  tree.insert(rect(0, 0, 2, 2), 42);
+  EXPECT_EQ(tree.size(), 1u);
+  EXPECT_EQ(sorted_intersects(tree, rect(1, 1, 5, 5)), (std::vector<int>{42}));
+  EXPECT_TRUE(tree.erase(rect(0, 0, 2, 2), 42));
+  EXPECT_TRUE(tree.is_empty());
+  EXPECT_EQ(tree.height(), 0u);
+  EXPECT_TRUE(tree.verify());
+}
+
+TEST(RStarTree, ForcedReinsertionKeepsTreeValid)
+{
+  // Default fanout (16/8): forced reinsertion of ~30% of a leaf triggers on the
+  // first leaf overflow of each insert once the tree has depth >= 2.
+  RStarTree<int> tree;   // Max=16, Min=8
+  for (int i = 0; i < 500; ++i)
+    {
+      tree.insert(rect(i % 50, i / 50, i % 50 + 3, i / 50 + 3), i);
+      ASSERT_TRUE(tree.verify());
+    }
+  EXPECT_EQ(tree.size(), 500u);
+  EXPECT_GT(tree.height(), 1u);
+
+  // Every inserted box must still be found by an intersecting query.
+  for (int i = 0; i < 500; ++i)
+    {
+      const Rectangle b = rect(i % 50, i / 50, i % 50 + 3, i / 50 + 3);
+      const std::vector<int> hits = sorted_intersects(tree, b);
+      EXPECT_TRUE(std::find(hits.begin(), hits.end(), i) != hits.end());
+    }
+}
+
+TEST(RStarTree, CoincidentRectangles)
+{
+  RStarTree<int, 4, 2> tree;
+  const Rectangle box = rect(3, 3, 6, 6);
+  for (int i = 0; i < 25; ++i)
+    tree.insert(box, i);
+  ASSERT_TRUE(tree.verify());
+  EXPECT_EQ(sorted_intersects(tree, rect(4, 4, 5, 5)).size(), 25u);
+
+  ASSERT_TRUE(tree.erase(box, 10));
+  ASSERT_TRUE(tree.verify());
+  EXPECT_EQ(sorted_intersects(tree, box).size(), 24u);
+}
+
+TEST(RStarTree, DegenerateRectangles)
+{
+  RStarTree<int, 4, 2> tree;
+  for (int i = 0; i < 40; ++i)
+    tree.insert(rect(i, 5, i, 5), i);            // points
+  for (int i = 0; i < 20; ++i)
+    tree.insert(rect(0, i, 40, i), 100 + i);     // horizontal segments
+  ASSERT_TRUE(tree.verify());
+  EXPECT_EQ(tree.size(), 60u);
+
+  const std::vector<int> hits = sorted_contains(tree, pt(10, 5));
+  EXPECT_TRUE(std::find(hits.begin(), hits.end(), 10) != hits.end());
+  EXPECT_TRUE(std::find(hits.begin(), hits.end(), 105) != hits.end());
+}
+
+TEST(RStarTree, CopyAndMove)
+{
+  RStarTree<int, 6, 3> original;
+  for (int i = 0; i < 60; ++i)
+    original.insert(rect(i, i, i + 2, i + 2), i);
+
+  RStarTree<int, 6, 3> copy = original;
+  ASSERT_TRUE(copy.verify());
+  EXPECT_EQ(copy.size(), original.size());
+  for (int i = 0; i < 30; ++i)
+    ASSERT_TRUE(original.erase(rect(i, i, i + 2, i + 2), i));
+  EXPECT_EQ(original.size(), 30u);
+  EXPECT_EQ(copy.size(), 60u);
+  ASSERT_TRUE(original.verify());
+  ASSERT_TRUE(copy.verify());
+
+  RStarTree<int, 6, 3> moved = std::move(copy);
+  EXPECT_EQ(moved.size(), 60u);
+  EXPECT_TRUE(moved.verify());
+  EXPECT_TRUE(copy.is_empty());   // NOLINT(bugprone-use-after-move)
+  EXPECT_TRUE(copy.verify());
+}
+
+TEST(RStarTree, SupportsMoveOnlyPayload)
+{
+  RStarTree<std::unique_ptr<int>> tree;
+  for (int i = 0; i < 40; ++i)
+    tree.insert(rect(i, i, i + 1, i + 1), std::make_unique<int>(i));
+  ASSERT_TRUE(tree.verify());
+  EXPECT_EQ(tree.size(), 40u);
+
+  int seen = 0;
+  tree.for_each_intersecting(rect(0, 0, 100, 100),
+    [&](const Rectangle &, const std::unique_ptr<int> &) { ++seen; });
+  EXPECT_EQ(seen, 40);
+}
+
+TEST(RStarTree, AssignmentClearAndDrainRemainValid)
+{
+  RStarTree<int, 4, 2> source;
+  std::vector<std::pair<Rectangle, int>> ref;
+  for (int i = 0; i < 100; ++i)
+    {
+      const Rectangle b = rect(i % 20, i / 20, i % 20 + 3, i / 20 + 2);
+      source.insert(b, i);
+      ref.emplace_back(b, i);
+    }
+  ASSERT_TRUE(source.verify());
+
+  RStarTree<int, 4, 2> assigned;
+  assigned = source;
+  EXPECT_EQ(assigned.size(), source.size());
+  EXPECT_TRUE(assigned.verify());
+
+  RStarTree<int, 4, 2> moved;
+  moved = std::move(assigned);
+  EXPECT_EQ(moved.size(), 100u);
+  EXPECT_TRUE(moved.verify());
+  EXPECT_TRUE(assigned.is_empty());   // NOLINT(bugprone-use-after-move)
+  EXPECT_TRUE(assigned.verify());
+
+  for (const auto &[b, id] : ref)
+    {
+      ASSERT_TRUE(moved.erase(b, id));
+      ASSERT_TRUE(moved.verify());
+    }
+  EXPECT_TRUE(moved.is_empty());
+  EXPECT_EQ(moved.height(), 0u);
+
+  source.clear();
+  EXPECT_TRUE(source.is_empty());
+  EXPECT_TRUE(source.verify());
+}
+
+TEST(RStarTree, RandomizedParityDefaultFanout)
+{
+  randomized_parity<16, 8>(20260714u, 4000, 90, 12);
+}
+
+TEST(RStarTree, RandomizedParitySmallFanout)
+{
+  randomized_parity<4, 2>(913u, 3000, 60, 8);
+}

--- a/Tests/r_star_tree_test.cc
+++ b/Tests/r_star_tree_test.cc
@@ -255,6 +255,10 @@ TEST(RStarTree, CopyAndMove)
   EXPECT_TRUE(moved.verify());
   EXPECT_TRUE(copy.is_empty());   // NOLINT(bugprone-use-after-move)
   EXPECT_TRUE(copy.verify());
+
+  copy.insert(rect(-5, -5, -4, -4), -5);   // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(copy.size(), 1u);
+  EXPECT_TRUE(copy.verify());
 }
 
 TEST(RStarTree, SupportsMoveOnlyPayload)
@@ -295,6 +299,11 @@ TEST(RStarTree, AssignmentClearAndDrainRemainValid)
   EXPECT_TRUE(assigned.is_empty());   // NOLINT(bugprone-use-after-move)
   EXPECT_TRUE(assigned.verify());
 
+  assigned.insert(rect(-10, -10, -9, -9), -10);   // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(assigned.size(), 1u);
+  EXPECT_TRUE(assigned.verify());
+  assigned.clear();
+
   for (const auto &[b, id] : ref)
     {
       ASSERT_TRUE(moved.erase(b, id));
@@ -305,6 +314,9 @@ TEST(RStarTree, AssignmentClearAndDrainRemainValid)
 
   source.clear();
   EXPECT_TRUE(source.is_empty());
+  EXPECT_TRUE(source.verify());
+  source.insert(rect(-20, -20, -19, -19), -20);
+  EXPECT_EQ(source.size(), 1u);
   EXPECT_TRUE(source.verify());
 }
 

--- a/Tests/r_tree_test.cc
+++ b/Tests/r_tree_test.cc
@@ -1,0 +1,365 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * @file r_tree_test.cc
+ * @brief Tests for Aleph::RTree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include <tpl_r_tree.H>
+
+using namespace Aleph;
+
+namespace
+{
+  Rectangle rect(const int x1, const int y1, const int x2, const int y2)
+  {
+    return Rectangle(Geom_Number(x1), Geom_Number(y1),
+                     Geom_Number(x2), Geom_Number(y2));
+  }
+
+  Point pt(const int x, const int y)
+  {
+    return Point(Geom_Number(x), Geom_Number(y));
+  }
+
+  template <typename Tree>
+  std::vector<int> sorted_intersects(const Tree &tree, const Rectangle &q)
+  {
+    Array<int> hits = tree.search_intersects(q);
+    std::vector<int> out;
+    for (size_t i = 0; i < hits.size(); ++i)
+      out.push_back(hits(i));
+    std::sort(out.begin(), out.end());
+    return out;
+  }
+
+  template <typename Tree>
+  std::vector<int> sorted_contains(const Tree &tree, const Point &p)
+  {
+    Array<int> hits = tree.search_contains(p);
+    std::vector<int> out;
+    for (size_t i = 0; i < hits.size(); ++i)
+      out.push_back(hits(i));
+    std::sort(out.begin(), out.end());
+    return out;
+  }
+
+  std::vector<int> brute_intersects(const std::vector<std::pair<Rectangle, int>> &ref,
+                                    const Rectangle &q)
+  {
+    std::vector<int> out;
+    for (const auto &[b, id] : ref)
+      if (b.intersects(q))
+        out.push_back(id);
+    std::sort(out.begin(), out.end());
+    return out;
+  }
+
+  std::vector<int> brute_contains(const std::vector<std::pair<Rectangle, int>> &ref,
+                                  const Point &p)
+  {
+    std::vector<int> out;
+    for (const auto &[b, id] : ref)
+      if (b.contains(p))
+        out.push_back(id);
+    std::sort(out.begin(), out.end());
+    return out;
+  }
+}
+
+TEST(RTree, EmptyTree)
+{
+  RTree<int> tree;
+  EXPECT_TRUE(tree.is_empty());
+  EXPECT_EQ(tree.size(), 0u);
+  EXPECT_EQ(tree.height(), 0u);
+  EXPECT_TRUE(tree.verify());
+  EXPECT_EQ(tree.search_intersects(rect(0, 0, 10, 10)).size(), 0u);
+  EXPECT_EQ(tree.search_contains(pt(1, 1)).size(), 0u);
+  EXPECT_FALSE(tree.erase(rect(0, 0, 1, 1), 5));
+}
+
+TEST(RTree, SingletonInsertAndQuery)
+{
+  RTree<int> tree;
+  tree.insert(rect(0, 0, 2, 2), 42);
+
+  EXPECT_FALSE(tree.is_empty());
+  EXPECT_EQ(tree.size(), 1u);
+  EXPECT_EQ(tree.height(), 1u);
+  EXPECT_TRUE(tree.verify());
+
+  EXPECT_EQ(sorted_intersects(tree, rect(1, 1, 5, 5)), (std::vector<int>{42}));
+  EXPECT_EQ(sorted_intersects(tree, rect(10, 10, 20, 20)), (std::vector<int>{}));
+  EXPECT_EQ(sorted_contains(tree, pt(1, 1)), (std::vector<int>{42}));
+  EXPECT_EQ(sorted_contains(tree, pt(9, 9)), (std::vector<int>{}));
+}
+
+TEST(RTree, EraseSingletonEmptiesTree)
+{
+  RTree<int> tree;
+  tree.insert(rect(0, 0, 2, 2), 1);
+  EXPECT_TRUE(tree.erase(rect(0, 0, 2, 2), 1));
+  EXPECT_TRUE(tree.is_empty());
+  EXPECT_EQ(tree.size(), 0u);
+  EXPECT_EQ(tree.height(), 0u);
+  EXPECT_TRUE(tree.verify());
+}
+
+TEST(RTree, EraseNonexistentReturnsFalse)
+{
+  RTree<int> tree;
+  tree.insert(rect(0, 0, 2, 2), 1);
+  EXPECT_FALSE(tree.erase(rect(0, 0, 2, 2), 999));   // wrong value
+  EXPECT_FALSE(tree.erase(rect(5, 5, 6, 6), 1));     // wrong bbox
+  EXPECT_EQ(tree.size(), 1u);
+  EXPECT_TRUE(tree.verify());
+}
+
+TEST(RTree, GrowsInHeightWithManyInserts)
+{
+  RTree<int, 4, 2> tree;   // tiny fanout forces splits early
+  for (int i = 0; i < 200; ++i)
+    {
+      tree.insert(rect(i, i, i + 1, i + 1), i);
+      ASSERT_TRUE(tree.verify());
+    }
+  EXPECT_EQ(tree.size(), 200u);
+  EXPECT_GT(tree.height(), 1u);
+
+  // Every inserted box must be findable at its own corner.
+  for (int i = 0; i < 200; ++i)
+    {
+      const std::vector<int> hits = sorted_contains(tree, pt(i, i));
+      EXPECT_TRUE(std::find(hits.begin(), hits.end(), i) != hits.end());
+    }
+}
+
+TEST(RTree, CoincidentRectangles)
+{
+  RTree<int, 4, 2> tree;
+  const Rectangle box = rect(3, 3, 6, 6);
+  for (int i = 0; i < 20; ++i)
+    tree.insert(box, i);   // identical bbox, distinct payloads
+
+  ASSERT_TRUE(tree.verify());
+  EXPECT_EQ(tree.size(), 20u);
+  EXPECT_EQ(sorted_intersects(tree, rect(4, 4, 5, 5)).size(), 20u);
+
+  // Removing one leaves the other nineteen.
+  ASSERT_TRUE(tree.erase(box, 7));
+  ASSERT_TRUE(tree.verify());
+  const std::vector<int> hits = sorted_intersects(tree, box);
+  EXPECT_EQ(hits.size(), 19u);
+  EXPECT_TRUE(std::find(hits.begin(), hits.end(), 7) == hits.end());
+}
+
+TEST(RTree, DegenerateRectangles)
+{
+  RTree<int, 4, 2> tree;
+  // Points (zero area) and lines (zero width or height).
+  for (int i = 0; i < 30; ++i)
+    tree.insert(rect(i, 5, i, 5), i);          // points on a horizontal line
+  for (int i = 0; i < 30; ++i)
+    tree.insert(rect(0, i, 40, i), 100 + i);   // horizontal segments
+
+  ASSERT_TRUE(tree.verify());
+  EXPECT_EQ(tree.size(), 60u);
+
+  // The point (10,5) is a stored point and lies on segment y=5.
+  const std::vector<int> hits = sorted_contains(tree, pt(10, 5));
+  EXPECT_TRUE(std::find(hits.begin(), hits.end(), 10) != hits.end());
+  EXPECT_TRUE(std::find(hits.begin(), hits.end(), 105) != hits.end());
+}
+
+TEST(RTree, CopyIsIndependentDeepClone)
+{
+  RTree<int, 4, 2> original;
+  for (int i = 0; i < 50; ++i)
+    original.insert(rect(i, i, i + 2, i + 2), i);
+
+  RTree<int, 4, 2> copy = original;   // deep copy
+  ASSERT_TRUE(copy.verify());
+  EXPECT_EQ(copy.size(), original.size());
+
+  // Mutate the original; the copy must not change.
+  for (int i = 0; i < 25; ++i)
+    ASSERT_TRUE(original.erase(rect(i, i, i + 2, i + 2), i));
+
+  ASSERT_TRUE(original.verify());
+  ASSERT_TRUE(copy.verify());
+  EXPECT_EQ(original.size(), 25u);
+  EXPECT_EQ(copy.size(), 50u);
+  EXPECT_EQ(sorted_contains(copy, pt(1, 1)).empty(), false);
+  EXPECT_TRUE(sorted_contains(original, pt(1, 1)).empty());
+}
+
+TEST(RTree, MoveConstructionTransfersOwnership)
+{
+  RTree<int, 4, 2> a;
+  for (int i = 0; i < 30; ++i)
+    a.insert(rect(i, 0, i + 1, 1), i);
+
+  RTree<int, 4, 2> b = std::move(a);
+  EXPECT_EQ(b.size(), 30u);
+  EXPECT_TRUE(b.verify());
+  EXPECT_TRUE(a.is_empty());   // NOLINT(bugprone-use-after-move)
+  EXPECT_TRUE(a.verify());
+}
+
+TEST(RTree, SupportsMoveOnlyPayload)
+{
+  RTree<std::unique_ptr<int>, 4, 2> tree;
+  for (int i = 0; i < 20; ++i)
+    tree.insert(rect(i, i, i + 1, i + 1), std::make_unique<int>(i));
+
+  ASSERT_TRUE(tree.verify());
+  EXPECT_EQ(tree.size(), 20u);
+
+  int seen = 0;
+  int sum = 0;
+  tree.for_each_intersecting(rect(0, 0, 100, 100),
+    [&](const Rectangle &, const std::unique_ptr<int> &v)
+    {
+      ++seen;
+      sum += *v;
+    });
+  EXPECT_EQ(seen, 20);
+  EXPECT_EQ(sum, 190);   // 0 + 1 + ... + 19
+}
+
+TEST(RTree, AssignmentClearAndDrainRemainValid)
+{
+  RTree<int, 4, 2> source;
+  std::vector<std::pair<Rectangle, int>> ref;
+  for (int i = 0; i < 90; ++i)
+    {
+      const Rectangle b = rect(i % 15, i / 15, i % 15 + 2, i / 15 + 2);
+      source.insert(b, i);
+      ref.emplace_back(b, i);
+    }
+  ASSERT_TRUE(source.verify());
+
+  RTree<int, 4, 2> assigned;
+  assigned = source;
+  EXPECT_EQ(assigned.size(), source.size());
+  EXPECT_TRUE(assigned.verify());
+
+  for (int i = 0; i < 30; ++i)
+    ASSERT_TRUE(source.erase(ref[i].first, ref[i].second));
+  EXPECT_EQ(source.size(), 60u);
+  EXPECT_EQ(assigned.size(), 90u);
+  EXPECT_TRUE(source.verify());
+  EXPECT_TRUE(assigned.verify());
+
+  RTree<int, 4, 2> moved;
+  moved = std::move(assigned);
+  EXPECT_EQ(moved.size(), 90u);
+  EXPECT_TRUE(moved.verify());
+  EXPECT_TRUE(assigned.is_empty());   // NOLINT(bugprone-use-after-move)
+  EXPECT_TRUE(assigned.verify());
+
+  moved.clear();
+  EXPECT_TRUE(moved.is_empty());
+  EXPECT_EQ(moved.height(), 0u);
+  EXPECT_TRUE(moved.verify());
+
+  for (const auto &[b, id] : ref)
+    {
+      ASSERT_TRUE(source.erase(b, id) or id < 30);
+      ASSERT_TRUE(source.verify());
+    }
+  EXPECT_TRUE(source.is_empty());
+  EXPECT_EQ(source.height(), 0u);
+}
+
+TEST(RTree, RandomizedParityAgainstBruteForce)
+{
+  std::mt19937 rng(20260714u);   // fixed seed
+  std::uniform_int_distribution<int> op_dist(0, 2);
+  std::uniform_int_distribution<int> coord(0, 80);
+  std::uniform_int_distribution<int> extent(0, 12);
+
+  RTree<int, 6, 3> tree;
+  std::vector<std::pair<Rectangle, int>> ref;
+  int next_id = 0;
+
+  auto random_rect = [&]()
+  {
+    const int x1 = coord(rng);
+    const int y1 = coord(rng);
+    return rect(x1, y1, x1 + extent(rng), y1 + extent(rng));
+  };
+
+  for (int iter = 0; iter < 4000; ++iter)
+    {
+      const int op = ref.empty() ? 0 : op_dist(rng);
+      if (op == 0)   // insert
+        {
+          const Rectangle b = random_rect();
+          const int id = next_id++;
+          tree.insert(b, id);
+          ref.emplace_back(b, id);
+        }
+      else if (op == 1)   // erase a random existing entry
+        {
+          std::uniform_int_distribution<size_t> pick(0, ref.size() - 1);
+          const size_t k = pick(rng);
+          ASSERT_TRUE(tree.erase(ref[k].first, ref[k].second));
+          ref.erase(ref.begin() + k);
+        }
+      else   // query and compare against brute force
+        {
+          const Rectangle q = random_rect();
+          EXPECT_EQ(sorted_intersects(tree, q), brute_intersects(ref, q));
+          const Point p = pt(coord(rng), coord(rng));
+          EXPECT_EQ(sorted_contains(tree, p), brute_contains(ref, p));
+        }
+
+      ASSERT_TRUE(tree.verify()) << "invariant broken at iter " << iter;
+      ASSERT_EQ(tree.size(), ref.size());
+    }
+
+  // Final exhaustive parity over a grid of query rectangles.
+  for (int x = 0; x < 90; x += 7)
+    for (int y = 0; y < 90; y += 7)
+      {
+        const Rectangle q = rect(x, y, x + 10, y + 10);
+        ASSERT_EQ(sorted_intersects(tree, q), brute_intersects(ref, q));
+      }
+}

--- a/Tests/r_tree_test.cc
+++ b/Tests/r_tree_test.cc
@@ -35,8 +35,10 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <concepts>
 #include <memory>
 #include <random>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -100,6 +102,29 @@ namespace
     std::sort(out.begin(), out.end());
     return out;
   }
+
+  struct CopyConstructibleNonCopyAssignablePayload
+  {
+    int value = 0;
+
+    CopyConstructibleNonCopyAssignablePayload() = default;
+    explicit CopyConstructibleNonCopyAssignablePayload(const int v) : value(v) {}
+
+    CopyConstructibleNonCopyAssignablePayload(
+      const CopyConstructibleNonCopyAssignablePayload &) = default;
+    CopyConstructibleNonCopyAssignablePayload(
+      CopyConstructibleNonCopyAssignablePayload &&) noexcept = default;
+
+    CopyConstructibleNonCopyAssignablePayload &operator = (
+      const CopyConstructibleNonCopyAssignablePayload &) = delete;
+    CopyConstructibleNonCopyAssignablePayload &operator = (
+      CopyConstructibleNonCopyAssignablePayload &&) noexcept = default;
+  };
+
+  static_assert(std::default_initializable<CopyConstructibleNonCopyAssignablePayload>);
+  static_assert(std::movable<CopyConstructibleNonCopyAssignablePayload>);
+  static_assert(std::is_copy_constructible_v<CopyConstructibleNonCopyAssignablePayload>);
+  static_assert(not std::is_copy_assignable_v<CopyConstructibleNonCopyAssignablePayload>);
 }
 
 TEST(RTree, EmptyTree)
@@ -261,6 +286,27 @@ TEST(RTree, SupportsMoveOnlyPayload)
     });
   EXPECT_EQ(seen, 20);
   EXPECT_EQ(sum, 190);   // 0 + 1 + ... + 19
+}
+
+TEST(RTree, CopyConstructiblePayloadNeedNotBeCopyAssignable)
+{
+  using Payload = CopyConstructibleNonCopyAssignablePayload;
+
+  RTree<Payload, 4, 2> tree;
+  const Payload first(7);
+  tree.insert(rect(0, 0, 2, 2), first);
+  tree.insert(rect(3, 3, 5, 5), Payload(11));
+
+  const RTree<Payload, 4, 2> copy(tree);
+  ASSERT_TRUE(copy.verify());
+
+  Array<Payload> intersecting = copy.search_intersects(rect(1, 1, 4, 4));
+  ASSERT_EQ(intersecting.size(), 2u);
+  EXPECT_EQ(intersecting(0).value + intersecting(1).value, 18);
+
+  Array<Payload> containing = copy.search_contains(pt(1, 1));
+  ASSERT_EQ(containing.size(), 1u);
+  EXPECT_EQ(containing(0).value, 7);
 }
 
 TEST(RTree, AssignmentClearAndDrainRemainValid)

--- a/ah-cpp-compat.H
+++ b/ah-cpp-compat.H
@@ -201,7 +201,9 @@ public:
   template <class Err = E>
     requires (not std::is_same_v<std::remove_cvref_t<Err>, unexpected> and
               std::is_constructible_v<E, Err>)
-  constexpr explicit unexpected(Err &&e) : err_(std::forward<Err>(e)) {}
+  constexpr explicit unexpected(Err &&e)
+    noexcept(std::is_nothrow_constructible_v<E, Err>)
+    : err_(std::forward<Err>(e)) {}
 
   /** @brief Access the error (const lvalue).
    *  @return Const reference to the stored error.

--- a/ah-cpp-compat.H
+++ b/ah-cpp-compat.H
@@ -184,17 +184,24 @@ class unexpected
   E err_;
 
 public:
-  /** @brief Construct from an lvalue error.
-   *  @param e Error value to copy.
-   *  @throws Any exception thrown by `E`'s copy constructor.
+  /** @brief Construct the stored error from any value convertible to `E`.
+   *
+   *  Mirrors `std::unexpected`'s actual converting constructor: a single
+   *  constrained, perfectly-forwarding constructor instead of separate
+   *  `const E&` / `E&&` overloads. Two fixed overloads force the compiler to
+   *  pick between them when the argument needs a user-defined conversion
+   *  (e.g. building `unexpected<std::string>` from a string literal), which
+   *  some MSVC versions fail to resolve (`error C2672`); a single template
+   *  leaves exactly one candidate.
+   *
+   *  @tparam Err Deduced argument type.
+   *  @param e Value used to construct the stored error.
+   *  @throws Any exception thrown by constructing `E` from `e`.
    */
-  constexpr explicit unexpected(const E &e) : err_(e) {}
-
-  /** @brief Construct from an rvalue error.
-   *  @param e Error value to move.
-   *  @throws Any exception thrown by `E`'s move constructor.
-   */
-  constexpr explicit unexpected(E &&e) : err_(std::move(e)) {}
+  template <class Err = E>
+    requires (not std::is_same_v<std::remove_cvref_t<Err>, unexpected> and
+              std::is_constructible_v<E, Err>)
+  constexpr explicit unexpected(Err &&e) : err_(std::forward<Err>(e)) {}
 
   /** @brief Access the error (const lvalue).
    *  @return Const reference to the stored error.

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.18)
 
 # Performance benchmarks live under per-domain subdirectories: the
-# cellular-automata perf-gate anchors and the informative flat-container
-# comparisons. Future domains can add their own folder.
+# cellular-automata perf-gate anchors and informative comparison suites.
 add_subdirectory(ca)
 add_subdirectory(containers)
+add_subdirectory(spatial)

--- a/benchmarks/spatial/CMakeLists.txt
+++ b/benchmarks/spatial/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.18)
+
+# Informative benchmarks for dynamic spatial indexes. These are not wired to
+# the CA performance gate; they document RTree/RStarTree trade-offs against
+# brute-force scans and the static AABBTree.
+set(SPATIAL_BENCHMARK_PROGRAMS
+    bench_r_tree
+)
+
+foreach(program IN LISTS SPATIAL_BENCHMARK_PROGRAMS)
+    add_executable(${program} "${program}.cc")
+    target_link_libraries(${program} PRIVATE Aleph ${ALEPH_SYSTEM_LIBS})
+endforeach()
+
+add_custom_target(spatial_benchmarks
+    DEPENDS ${SPATIAL_BENCHMARK_PROGRAMS}
+)
+
+message(STATUS "Configured spatial-index benchmarks")

--- a/benchmarks/spatial/bench_r_tree.cc
+++ b/benchmarks/spatial/bench_r_tree.cc
@@ -1,0 +1,197 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+*/
+
+/**
+ * @file bench_r_tree.cc
+ * @brief Informative benchmark for RTree/RStarTree spatial indexes.
+ *
+ * Compares dynamic RTree/RStarTree insertion and intersection-query throughput
+ * against a brute-force rectangle scan and Aleph's static AABBTree.
+ *
+ * Usage:
+ *   bench_r_tree [entry_count] [query_count]
+ */
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <random>
+#include <vector>
+
+#include <geom_algorithms.H>
+#include <tpl_r_star_tree.H>
+#include <tpl_r_tree.H>
+
+using namespace Aleph;
+
+namespace
+{
+
+volatile size_t sink = 0;
+
+Rectangle rect(const int x1, const int y1, const int x2, const int y2)
+{
+  return Rectangle(Geom_Number(x1), Geom_Number(y1),
+                   Geom_Number(x2), Geom_Number(y2));
+}
+
+template <class Fn>
+double best_ms(Fn fn, const int repeats = 3)
+{
+  double best = 1e300;
+  for (int r = 0; r < repeats; ++r)
+    {
+      const auto t0 = std::chrono::steady_clock::now();
+      fn();
+      const auto t1 = std::chrono::steady_clock::now();
+      const double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+      best = std::min(best, ms);
+    }
+  return best;
+}
+
+void row(const char *index, const char *op, const double ms)
+{
+  std::printf("  %-12s %-28s %10.2f ms\n", index, op, ms);
+}
+
+std::vector<Rectangle> make_rectangles(const size_t n, const unsigned seed)
+{
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int> coord(0, 20000);
+  std::uniform_int_distribution<int> extent(1, 80);
+
+  std::vector<Rectangle> out;
+  out.reserve(n);
+  for (size_t i = 0; i < n; ++i)
+    {
+      const int x = coord(rng);
+      const int y = coord(rng);
+      out.push_back(rect(x, y, x + extent(rng), y + extent(rng)));
+    }
+  return out;
+}
+
+RTree<size_t> build_rtree(const std::vector<Rectangle> &rects)
+{
+  RTree<size_t> tree;
+  for (size_t i = 0; i < rects.size(); ++i)
+    tree.insert(rects[i], i);
+  return tree;
+}
+
+RStarTree<size_t> build_rstar(const std::vector<Rectangle> &rects)
+{
+  RStarTree<size_t> tree;
+  for (size_t i = 0; i < rects.size(); ++i)
+    tree.insert(rects[i], i);
+  return tree;
+}
+
+AABBTree build_aabb(const std::vector<Rectangle> &rects)
+{
+  Array<AABBTree::Entry> entries;
+  entries.reserve(rects.size());
+  for (size_t i = 0; i < rects.size(); ++i)
+    entries.append(AABBTree::Entry{rects[i], i});
+
+  AABBTree tree;
+  tree.build(entries);
+  return tree;
+}
+
+size_t brute_query_count(const std::vector<Rectangle> &rects,
+                         const std::vector<Rectangle> &queries)
+{
+  size_t total = 0;
+  for (const Rectangle &q : queries)
+    for (const Rectangle &b : rects)
+      total += b.intersects(q);
+  return total;
+}
+
+template <class Tree>
+size_t rtree_query_count(const Tree &tree, const std::vector<Rectangle> &queries)
+{
+  size_t total = 0;
+  for (const Rectangle &q : queries)
+    tree.for_each_intersecting(q,
+      [&total](const Rectangle &, const size_t &) { ++total; });
+  return total;
+}
+
+size_t aabb_query_count(const AABBTree &tree, const std::vector<Rectangle> &queries)
+{
+  size_t total = 0;
+  for (const Rectangle &q : queries)
+    total += tree.query(q).size();
+  return total;
+}
+
+void validate_counts(const std::vector<Rectangle> &rects,
+                     const std::vector<Rectangle> &queries,
+                     const RTree<size_t> &rtree,
+                     const RStarTree<size_t> &rstar,
+                     const AABBTree &aabb)
+{
+  const size_t brute = brute_query_count(rects, queries);
+  const size_t rt = rtree_query_count(rtree, queries);
+  const size_t rs = rtree_query_count(rstar, queries);
+  const size_t ab = aabb_query_count(aabb, queries);
+  if (brute != rt or brute != rs or brute != ab)
+    {
+      std::fprintf(stderr,
+                   "validation failed: brute=%zu rtree=%zu rstar=%zu aabb=%zu\n",
+                   brute, rt, rs, ab);
+      std::exit(2);
+    }
+  sink += brute + rt + rs + ab;
+}
+
+}  // namespace
+
+int main(int argc, char *argv[])
+{
+  const size_t entry_count = argc > 1 ? std::strtoul(argv[1], nullptr, 10)
+                                      : 10000;
+  const size_t query_count = argc > 2 ? std::strtoul(argv[2], nullptr, 10)
+                                      : 2000;
+
+  const std::vector<Rectangle> rects = make_rectangles(entry_count, 0xA1E9u);
+  const std::vector<Rectangle> queries = make_rectangles(query_count, 0xBEEFu);
+
+  const RTree<size_t> rtree = build_rtree(rects);
+  const RStarTree<size_t> rstar = build_rstar(rects);
+  const AABBTree aabb = build_aabb(rects);
+  validate_counts(rects, queries, rtree, rstar, aabb);
+
+  std::printf("Spatial index benchmark (best of 3 runs, %zu entries, %zu queries)\n",
+              entry_count, query_count);
+  row("RTree", "incremental insert",
+      best_ms([&] { const RTree<size_t> t = build_rtree(rects); sink += t.size(); }));
+  row("RStarTree", "incremental insert",
+      best_ms([&] { const RStarTree<size_t> t = build_rstar(rects); sink += t.size(); }));
+  row("AABBTree", "static build",
+      best_ms([&] { const AABBTree t = build_aabb(rects); sink += t.size(); }));
+
+  row("brute", "intersect queries",
+      best_ms([&] { sink += brute_query_count(rects, queries); }));
+  row("RTree", "intersect queries",
+      best_ms([&] { sink += rtree_query_count(rtree, queries); }));
+  row("RStarTree", "intersect queries",
+      best_ms([&] { sink += rtree_query_count(rstar, queries); }));
+  row("AABBTree", "intersect queries",
+      best_ms([&] { sink += aabb_query_count(aabb, queries); }));
+
+  std::printf("\n(sink=%zu)\n", static_cast<size_t>(sink));
+  return 0;
+}

--- a/benchmarks/spatial/bench_r_tree.cc
+++ b/benchmarks/spatial/bench_r_tree.cc
@@ -21,10 +21,12 @@
  */
 
 #include <algorithm>
+#include <charconv>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <random>
+#include <string_view>
 #include <vector>
 
 #include <geom_algorithms.H>
@@ -109,6 +111,21 @@ AABBTree build_aabb(const std::vector<Rectangle> &rects)
   return tree;
 }
 
+/// Strictly parse `text` as a base-10 `size_t`. Rejects empty input, a
+/// leading sign, non-digit characters, trailing characters, and overflow.
+/// `std::strtoul` is too lax for CLI input whose validity should be reported
+/// back to the user instead of silently wrapping or truncating.
+bool parse_size(const char *text, size_t &out)
+{
+  if (text == nullptr)
+    return false;
+  const std::string_view sv{text};
+  if (sv.empty() or sv.front() == '+' or sv.front() == '-')
+    return false;
+  const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), out, 10);
+  return ec == std::errc{} and ptr == sv.data() + sv.size();
+}
+
 size_t brute_query_count(const std::vector<Rectangle> &rects,
                          const std::vector<Rectangle> &queries)
 {
@@ -161,10 +178,19 @@ void validate_counts(const std::vector<Rectangle> &rects,
 
 int main(int argc, char *argv[])
 {
-  const size_t entry_count = argc > 1 ? std::strtoul(argv[1], nullptr, 10)
-                                      : 10000;
-  const size_t query_count = argc > 2 ? std::strtoul(argv[2], nullptr, 10)
-                                      : 2000;
+  size_t entry_count = 10000;
+  size_t query_count = 2000;
+
+  if (argc > 1 and not parse_size(argv[1], entry_count))
+    {
+      std::fprintf(stderr, "invalid entry_count: '%s'\n", argv[1]);
+      return 1;
+    }
+  if (argc > 2 and not parse_size(argv[2], query_count))
+    {
+      std::fprintf(stderr, "invalid query_count: '%s'\n", argv[2]);
+      return 1;
+    }
 
   const std::vector<Rectangle> rects = make_rectangles(entry_count, 0xA1E9u);
   const std::vector<Rectangle> queries = make_rectangles(query_count, 0xBEEFu);

--- a/tpl_r_star_tree.H
+++ b/tpl_r_star_tree.H
@@ -1,0 +1,86 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/** @file tpl_r_star_tree.H
+ *  @brief R*-tree: an R-tree tuned with the Beckmann-Kriegel-Schneider-Seeger
+ *         heuristics.
+ *
+ *  `RStarTree<Payload, MaxEntries, MinEntries>` is the same dynamic spatial
+ *  index as `RTree` (same API, same `Rectangle`/`Payload` entries, same exact
+ *  rational coordinates), but built with the R*-tree insertion strategy instead
+ *  of Guttman's quadratic split. It is a thin alias over
+ *  `RTree<Payload, MaxEntries, MinEntries, RTreeVariant::RStar>`, so it shares
+ *  all of `RTree`'s query, deletion, verification and copy/move machinery.
+ *
+ *  Relative to the plain R-tree, the R*-tree changes three things:
+ *
+ *  - **ChooseSubtree**: when descending into a node whose children are leaves,
+ *    it picks the child whose growth adds the least *overlap* with its siblings
+ *    (ties broken by least area enlargement, then least area), instead of only
+ *    minimizing area enlargement.
+ *  - **Node split**: it chooses the split axis that minimizes the summed
+ *    perimeter (margin) of the two resulting groups, then the distribution along
+ *    that axis that minimizes their overlap area (ties: minimum total area),
+ *    instead of Guttman's quadratic seed/assignment split.
+ *  - **Forced reinsertion**: the first time a *leaf* overflows during an
+ *    insertion, rather than splitting immediately it removes the entries
+ *    farthest from the leaf centre and reinserts them from the root. This tends
+ *    to produce more compact, less overlapping trees and better query
+ *    performance. Reinsertion here is applied at the leaf level (internal
+ *    overflows split with the R*-tree heuristic).
+ *
+ *  These heuristics usually yield lower node overlap and faster queries than the
+ *  plain R-tree at the cost of somewhat more work per insertion. All structural
+ *  invariants, complexity classes, exception-safety, thread-safety and
+ *  reference-invalidation rules are exactly those documented for `RTree` in
+ *  `tpl_r_tree.H`.
+ *
+ *  @ingroup Geometry
+ */
+
+#ifndef TPL_R_STAR_TREE_H
+#define TPL_R_STAR_TREE_H
+
+#include <tpl_r_tree.H>
+
+namespace Aleph {
+
+/** @brief Dynamic R*-tree spatial index (R-tree with the R*-tree heuristics).
+ *
+ *  @tparam Payload Value associated with each stored bounding box.
+ *  @tparam MaxEntries Maximum number of entries per node (>= 2).
+ *  @tparam MinEntries Minimum number of entries per non-root node. Defaults to
+ *          `MaxEntries / 2`; must satisfy `2 * MinEntries <= MaxEntries + 1`.
+ */
+template <typename Payload, size_t MaxEntries = 16, size_t MinEntries = MaxEntries / 2>
+using RStarTree = RTree<Payload, MaxEntries, MinEntries, RTreeVariant::RStar>;
+
+}  // namespace Aleph
+
+#endif  // TPL_R_STAR_TREE_H

--- a/tpl_r_tree.H
+++ b/tpl_r_tree.H
@@ -113,8 +113,7 @@ enum class RTreeVariant
  *  @tparam Variant Node-split/insertion strategy (@ref RTreeVariant). Defaults
  *          to Guttman's quadratic split; `RStar` selects the R*-tree heuristics.
  */
-template <typename Payload, size_t MaxEntries = 16, size_t MinEntries = MaxEntries / 2,
-          RTreeVariant Variant = RTreeVariant::Guttman>
+template <typename Payload, size_t MaxEntries = 16, size_t MinEntries = MaxEntries / 2, RTreeVariant Variant = RTreeVariant::Guttman>
 class RTree
 {
   static_assert(MaxEntries >= 2, "RTree requires MaxEntries >= 2");
@@ -157,6 +156,13 @@ private:
   // R*-only transient state (empty/false while no insertion is in progress).
   bool rstar_reinsert_available_ = false;  ///< Leaf-level reinsert not yet used this insert.
   Array<Entry> rstar_reinsert_buffer_;     ///< Entries pending forced reinsertion.
+
+  /// @brief Drop R*-tree transient insertion state.
+  void clear_rstar_reinsert_state() noexcept
+  {
+    rstar_reinsert_available_ = false;
+    rstar_reinsert_buffer_.clear();
+  }
 
   // ---- geometry helpers -------------------------------------------------
 
@@ -630,6 +636,7 @@ private:
         insert_one(std::move(entry));
         while (not rstar_reinsert_buffer_.is_empty())
           insert_one(rstar_reinsert_buffer_.remove_last());
+        clear_rstar_reinsert_state();
       }
     else
       insert_one(std::move(entry));
@@ -840,6 +847,7 @@ public:
   {
     other.size_ = 0;
     other.height_ = 0;
+    other.clear_rstar_reinsert_state();
   }
 
   /** @brief Move-assign from @p other, leaving it empty and valid.
@@ -857,8 +865,10 @@ public:
     root_ = std::move(other.root_);
     size_ = other.size_;
     height_ = other.height_;
+    clear_rstar_reinsert_state();
     other.size_ = 0;
     other.height_ = 0;
+    other.clear_rstar_reinsert_state();
     return *this;
   }
 
@@ -928,6 +938,7 @@ public:
     root_.reset();
     size_ = 0;
     height_ = 0;
+    clear_rstar_reinsert_state();
   }
 
   /** @brief Insert a (bbox, value) entry, copying @p value.
@@ -1055,7 +1066,8 @@ public:
    *          occupancy is within `[MinEntries, MaxEntries]` (root exempt from
    *          the lower bound), all leaves share one depth, and the counted
    *          entries match `size()`.
-   *  @throws Nothing.
+   *  @throws Exceptions propagated by rectangle coordinate operations while
+   *          recomputing bounding boxes; `Payload` is not inspected.
    *  @note Intended for tests and diagnostics; it is O(n).
    */
   [[nodiscard]] bool verify() const

--- a/tpl_r_tree.H
+++ b/tpl_r_tree.H
@@ -1,0 +1,1059 @@
+/*
+                          Aleph_w
+
+  Data structures & Algorithms
+  https://github.com/lrleon/Aleph-w
+
+  This file is part of Aleph-w library
+
+  Copyright (c) 2002-2026 Leandro Rabindranath Leon
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/** @file tpl_r_tree.H
+ *  @brief Dynamic R-tree spatial index over axis-aligned rectangles.
+ *
+ *  `RTree<Payload, MaxEntries, MinEntries>` is a dynamic spatial index that
+ *  associates axis-aligned bounding boxes (`Aleph::Rectangle`) with user
+ *  payloads and supports incremental `insert` / `erase` plus intersection and
+ *  point-containment queries. It is Guttman's R-tree with the quadratic node
+ *  split heuristic.
+ *
+ *  Unlike the static `AABBTree` (in `geom_algorithms.H`), which is built once
+ *  from a fixed batch of boxes, `RTree` may be updated in place after
+ *  construction. `AABBTree` is likely faster for immutable batches; `RTree`
+ *  targets workloads that insert and delete over time.
+ *
+ *  @par Complexity
+ *  With well-distributed data, `insert`, `erase` and point queries are expected
+ *  O(log n). Overlapping-region queries cost O(log n + k) for k reported
+ *  entries, degrading to O(n) when many node bounding boxes overlap the query.
+ *  `height()` and `size()` are O(1).
+ *
+ *  @par Exception safety
+ *  All operations use exact rational coordinates (`Aleph::Geom_Number`), so no
+ *  floating-point rounding affects the structure. Allocation failure throws
+ *  `std::bad_alloc`; size overflow throws `std::overflow_error`. Mutating
+ *  operations are not transactional: they do not provide the strong guarantee
+ *  after tree mutation has started, and exceptions from `Payload` operations
+ *  propagate according to the payload type's own guarantees. Public
+ *  preconditions are checked with the macros of `ah-errors.H`.
+ *
+ *  @par Thread safety
+ *  `RTree` is a sequential container: it is not internally synchronized.
+ *  Concurrent read-only queries on a tree that no one is mutating are safe;
+ *  any concurrent mutation requires external synchronization.
+ *
+ *  @par Reference/iterator invalidation
+ *  The tree exposes no live iterators. `search_intersects` and
+ *  `search_contains` return independent `Array` copies. References passed to
+ *  `for_each_intersecting` are valid only during the callback invocation. Any
+ *  `insert`, `erase` or `clear` invalidates every previously obtained
+ *  reference into the tree.
+ *
+ *  @ingroup Geometry
+ */
+
+#ifndef TPL_R_TREE_H
+#define TPL_R_TREE_H
+
+#include <algorithm>
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <ah-errors.H>
+#include <point.H>
+#include <tpl_array.H>
+
+namespace Aleph {
+
+/** @brief Node-split / insertion strategy for `RTree`.
+ *
+ *  `Guttman` uses the original quadratic split. `RStar` uses the R*-tree
+ *  heuristics (overlap-minimizing subtree choice, margin/overlap/area split and
+ *  leaf-level forced reinsertion). See `RStarTree` in `tpl_r_star_tree.H`.
+ */
+enum class RTreeVariant
+{
+  Guttman,
+  RStar
+};
+
+/** @brief Dynamic R-tree indexing axis-aligned rectangles by payload.
+ *
+ *  @tparam Payload Value associated with each stored bounding box.
+ *  @tparam MaxEntries Maximum number of entries per node. Must be at least 2.
+ *  @tparam MinEntries Minimum number of entries per non-root node. Must be at
+ *          least 1 and satisfy `2 * MinEntries <= MaxEntries + 1`. Defaults to
+ *          `MaxEntries / 2`.
+ *  @tparam Variant Node-split/insertion strategy (@ref RTreeVariant). Defaults
+ *          to Guttman's quadratic split; `RStar` selects the R*-tree heuristics.
+ */
+template <typename Payload, size_t MaxEntries = 16, size_t MinEntries = MaxEntries / 2,
+          RTreeVariant Variant = RTreeVariant::Guttman>
+class RTree
+{
+  static_assert(MaxEntries >= 2, "RTree requires MaxEntries >= 2");
+  static_assert(MinEntries >= 1, "RTree requires MinEntries >= 1");
+  static_assert(2 * MinEntries <= MaxEntries + 1, "RTree requires 2 * MinEntries <= MaxEntries + 1");
+
+public:
+  /** @brief A stored (bounding box, payload) pair. */
+  struct Entry
+  {
+    Rectangle bbox;  ///< Axis-aligned bounding box.
+    Payload value;   ///< User payload associated with @ref bbox.
+  };
+
+private:
+  struct Node;
+
+  /// @brief Internal-node entry: a child subtree plus its tight bounding box.
+  struct Child
+  {
+    Rectangle bbox;               ///< Tight MBR of @ref child.
+    std::unique_ptr<Node> child;  ///< Owned child subtree.
+  };
+
+  /// @brief A node is a leaf holding @ref data or an internal node holding @ref children.
+  struct Node
+  {
+    bool leaf = true;
+    Array<Entry> data;      ///< Data entries (used iff @ref leaf).
+    Array<Child> children;  ///< Child entries (used iff not @ref leaf).
+  };
+
+  std::unique_ptr<Node> root_;
+  size_t size_ = 0;    ///< Number of stored data entries.
+  size_t height_ = 0;  ///< Number of node levels (0 when empty).
+
+  // R*-only transient state (empty/false while no insertion is in progress).
+  bool rstar_reinsert_available_ = false;  ///< Leaf-level reinsert not yet used this insert.
+  Array<Entry> rstar_reinsert_buffer_;     ///< Entries pending forced reinsertion.
+
+  // ---- geometry helpers -------------------------------------------------
+
+  [[nodiscard]] static Rectangle union_bbox(const Rectangle &a, const Rectangle &b)
+  {
+    const Geom_Number xmin = a.get_xmin() < b.get_xmin() ? a.get_xmin() : b.get_xmin();
+    const Geom_Number ymin = a.get_ymin() < b.get_ymin() ? a.get_ymin() : b.get_ymin();
+    const Geom_Number xmax = a.get_xmax() > b.get_xmax() ? a.get_xmax() : b.get_xmax();
+    const Geom_Number ymax = a.get_ymax() > b.get_ymax() ? a.get_ymax() : b.get_ymax();
+    return {xmin, ymin, xmax, ymax};
+  }
+
+  /// @brief Area added to @p base by growing it to also cover @p added.
+  [[nodiscard]] static Geom_Number enlargement(const Rectangle &base, const Rectangle &added)
+  {
+    return union_bbox(base, added).area() - base.area();
+  }
+
+  /// @brief Area of the overlap between two rectangles (0 if disjoint).
+  [[nodiscard]] static Geom_Number overlap_area(const Rectangle &a, const Rectangle &b)
+  {
+    const Geom_Number xlo = a.get_xmin() > b.get_xmin() ? a.get_xmin() : b.get_xmin();
+    const Geom_Number xhi = a.get_xmax() < b.get_xmax() ? a.get_xmax() : b.get_xmax();
+    if (xhi <= xlo)
+      return Geom_Number(0);
+    const Geom_Number ylo = a.get_ymin() > b.get_ymin() ? a.get_ymin() : b.get_ymin();
+    const Geom_Number yhi = a.get_ymax() < b.get_ymax() ? a.get_ymax() : b.get_ymax();
+    if (yhi <= ylo)
+      return Geom_Number(0);
+    return (xhi - xlo) * (yhi - ylo);
+  }
+
+  [[nodiscard]] static size_t entry_count(const Node &node)
+  {
+    return node.leaf ? node.data.size() : node.children.size();
+  }
+
+  /// @brief Tight bounding box covering every entry of @p node.
+  [[nodiscard]] static Rectangle compute_mbr(const Node &node)
+  {
+    if (node.leaf)
+      {
+        Rectangle acc = node.data(0).bbox;
+        for (size_t i = 1; i < node.data.size(); ++i)
+          acc = union_bbox(acc, node.data(i).bbox);
+        return acc;
+      }
+    Rectangle acc = node.children(0).bbox;
+    for (size_t i = 1; i < node.children.size(); ++i)
+      acc = union_bbox(acc, node.children(i).bbox);
+    return acc;
+  }
+
+  /// @brief Choose the child of @p node into which @p bbox should be inserted.
+  ///        R*-tree minimizes overlap enlargement when the children are leaves.
+  [[nodiscard]] static size_t choose_subtree(const Node &node, const Rectangle &bbox)
+  {
+    if constexpr (Variant == RTreeVariant::RStar)
+      if (node.children(0).child->leaf)
+        return rstar_choose_overlap(node, bbox);
+
+    size_t best = 0;
+    Geom_Number best_enlarge = enlargement(node.children(0).bbox, bbox);
+    Geom_Number best_area = node.children(0).bbox.area();
+    for (size_t i = 1; i < node.children.size(); ++i)
+      {
+        const Geom_Number e = enlargement(node.children(i).bbox, bbox);
+        const Geom_Number a = node.children(i).bbox.area();
+        if (e < best_enlarge or (e == best_enlarge and a < best_area))
+          {
+            best = i;
+            best_enlarge = e;
+            best_area = a;
+          }
+      }
+    return best;
+  }
+
+  /// @brief R*-tree ChooseSubtree for a node whose children are leaves: pick the
+  ///        child whose growth adds the least overlap with its siblings (ties:
+  ///        least area enlargement, then least area).
+  [[nodiscard]] static size_t rstar_choose_overlap(const Node &node, const Rectangle &bbox)
+  {
+    const size_t k = node.children.size();
+    size_t best = 0;
+    bool first = true;
+    Geom_Number best_ov = 0;
+    Geom_Number best_enl = 0;
+    Geom_Number best_area = 0;
+    for (size_t i = 0; i < k; ++i)
+      {
+        const Rectangle grown = union_bbox(node.children(i).bbox, bbox);
+        Geom_Number ov = 0;
+        for (size_t j = 0; j < k; ++j)
+          if (j != i)
+            ov += overlap_area(grown, node.children(j).bbox) -
+              overlap_area(node.children(i).bbox, node.children(j).bbox);
+        const Geom_Number enl = grown.area() - node.children(i).bbox.area();
+        const Geom_Number area = node.children(i).bbox.area();
+        if (first or ov < best_ov or
+            (ov == best_ov and (enl < best_enl or (enl == best_enl and area < best_area))))
+          {
+            best = i;
+            best_ov = ov;
+            best_enl = enl;
+            best_area = area;
+            first = false;
+          }
+      }
+    return best;
+  }
+
+  // ---- quadratic split (Guttman) ----------------------------------------
+
+  /// @brief Split an overflowed entry array in two using the quadratic
+  ///        heuristic. @p entries keeps the first group; the second group is
+  ///        returned. @tparam EntryT is either @ref Entry or @ref Child.
+  template <typename EntryT>
+  [[nodiscard]] static Array<EntryT> quadratic_split(Array<EntryT> &entries)
+  {
+    const size_t n = entries.size();
+    Array<EntryT> group1;
+    Array<EntryT> group2;
+    group1.reserve(n);
+    group2.reserve(n);
+
+    Array<EntryT> items = std::move(entries);
+    entries = Array<EntryT>();
+
+    // PickSeeds: the pair wasting the most area if grouped together.
+    size_t seed1 = 0;
+    size_t seed2 = 1;
+    Geom_Number worst =
+      union_bbox(items(0).bbox, items(1).bbox).area() - items(0).bbox.area() - items(1).bbox.area();
+    for (size_t i = 0; i < n; ++i)
+      for (size_t j = i + 1; j < n; ++j)
+        {
+          const Geom_Number d = union_bbox(items(i).bbox, items(j).bbox).area() -
+            items(i).bbox.area() - items(j).bbox.area();
+          if (d > worst)
+            {
+              worst = d;
+              seed1 = i;
+              seed2 = j;
+            }
+        }
+
+    std::array<bool, MaxEntries + 1> assigned{};
+    Rectangle mbr1 = items(seed1).bbox;
+    Rectangle mbr2 = items(seed2).bbox;
+    assigned[seed1] = true;
+    assigned[seed2] = true;
+    group1.append(std::move(items(seed1)));
+    group2.append(std::move(items(seed2)));
+    size_t remaining = n - 2;
+
+    auto dump_into = [&](Array<EntryT> &group)
+      {
+        for (size_t k = 0; k < n; ++k)
+          if (not assigned[k])
+            {
+              assigned[k] = true;
+              group.append(std::move(items(k)));
+            }
+        remaining = 0;
+      };
+
+    while (remaining > 0)
+      {
+        // Force the rest into a group that would otherwise miss MinEntries.
+        if (group1.size() + remaining == MinEntries)
+          {
+            dump_into(group1);
+            break;
+          }
+        if (group2.size() + remaining == MinEntries)
+          {
+            dump_into(group2);
+            break;
+          }
+
+        // PickNext: entry with the strongest preference for one group.
+        size_t pick = n;
+        Geom_Number best_diff = 0;
+        Geom_Number pick_d1 = 0;
+        Geom_Number pick_d2 = 0;
+        for (size_t k = 0; k < n; ++k)
+          {
+            if (assigned[k])
+              continue;
+            const Geom_Number d1 = enlargement(mbr1, items(k).bbox);
+            const Geom_Number d2 = enlargement(mbr2, items(k).bbox);
+            const Geom_Number diff = d1 > d2 ? d1 - d2 : d2 - d1;
+            if (pick == n or diff > best_diff)
+              {
+                best_diff = diff;
+                pick = k;
+                pick_d1 = d1;
+                pick_d2 = d2;
+              }
+          }
+
+        // Assign to the group needing less enlargement (ties: smaller area,
+        // then fewer entries).
+        bool to_group1;
+        if (pick_d1 < pick_d2)
+          to_group1 = true;
+        else if (pick_d2 < pick_d1)
+          to_group1 = false;
+        else if (mbr1.area() != mbr2.area())
+          to_group1 = mbr1.area() < mbr2.area();
+        else
+          to_group1 = group1.size() <= group2.size();
+
+        assigned[pick] = true;
+        if (to_group1)
+          {
+            mbr1 = union_bbox(mbr1, items(pick).bbox);
+            group1.append(std::move(items(pick)));
+          }
+        else
+          {
+            mbr2 = union_bbox(mbr2, items(pick).bbox);
+            group2.append(std::move(items(pick)));
+          }
+        --remaining;
+      }
+
+    entries = std::move(group1);
+    return group2;
+  }
+
+  /// @brief R*-tree split: choose the split axis minimizing the total margin of
+  ///        the two groups, then the distribution minimizing their overlap area
+  ///        (ties: minimum total area). @p entries keeps the first group; the
+  ///        second group is returned.
+  template <typename EntryT>
+  [[nodiscard]] static Array<EntryT> rstar_split(Array<EntryT> &entries)
+  {
+    const size_t n = entries.size();
+    Array<EntryT> group1;
+    Array<EntryT> group2;
+    group1.reserve(n);
+    group2.reserve(n);
+
+    Array<EntryT> items = std::move(entries);
+    entries = Array<EntryT>();
+
+    auto make_mbr_cache = [&items, n](const std::array<size_t, MaxEntries + 1> &order)
+      {
+        std::array<Rectangle, MaxEntries + 1> prefix{};
+        std::array<Rectangle, MaxEntries + 1> suffix{};
+        prefix[1] = items(order[0]).bbox;
+        for (size_t k = 2; k <= n; ++k)
+          prefix[k] = union_bbox(prefix[k - 1], items(order[k - 1]).bbox);
+        suffix[n - 1] = items(order[n - 1]).bbox;
+        for (size_t k = n - 1; k > 0; --k)
+          suffix[k - 1] = union_bbox(items(order[k - 1]).bbox, suffix[k]);
+        return std::pair{prefix, suffix};
+      };
+
+    auto make_order = [&items, n](const int axis, const int edge)
+      {
+        std::array<size_t, MaxEntries + 1> order{};
+        for (size_t i = 0; i < n; ++i)
+          order[i] = i;
+        std::sort(order.begin(), order.begin() + n,
+                  [&items, axis, edge](const size_t a, const size_t b)
+          {
+            const Rectangle &ra = items(a).bbox;
+            const Rectangle &rb = items(b).bbox;
+            const Geom_Number la = axis == 0 ? ra.get_xmin() : ra.get_ymin();
+            const Geom_Number ua = axis == 0 ? ra.get_xmax() : ra.get_ymax();
+            const Geom_Number lb = axis == 0 ? rb.get_xmin() : rb.get_ymin();
+            const Geom_Number ub = axis == 0 ? rb.get_xmax() : rb.get_ymax();
+            const Geom_Number pa = edge == 0 ? la : ua;
+            const Geom_Number pb = edge == 0 ? lb : ub;
+            if (pa != pb)
+              return pa < pb;
+            return (edge == 0 ? ua : la) < (edge == 0 ? ub : lb);
+          });
+        return order;
+      };
+
+    // ChooseSplitAxis: minimize the summed margin over both edge sortings and
+    // all valid distributions.
+    int chosen_axis = 0;
+    Geom_Number best_margin_sum = 0;
+    for (int axis = 0; axis < 2; ++axis)
+      {
+        Geom_Number margin_sum = 0;
+        for (int edge = 0; edge < 2; ++edge)
+          {
+            const std::array<size_t, MaxEntries + 1> order = make_order(axis, edge);
+            const auto [prefix, suffix] = make_mbr_cache(order);
+            for (size_t sz = MinEntries; sz <= n - MinEntries; ++sz)
+              margin_sum += prefix[sz].perimeter() + suffix[sz].perimeter();
+          }
+        if (axis == 0 or margin_sum < best_margin_sum)
+          {
+            best_margin_sum = margin_sum;
+            chosen_axis = axis;
+          }
+      }
+
+    // ChooseSplitIndex: on the chosen axis, minimize overlap area, then area.
+    std::array<size_t, MaxEntries + 1> best_order{};
+    size_t best_sz = MinEntries;
+    bool first = true;
+    Geom_Number best_overlap = 0;
+    Geom_Number best_area = 0;
+    for (int edge = 0; edge < 2; ++edge)
+      {
+        const std::array<size_t, MaxEntries + 1> order = make_order(chosen_axis, edge);
+        const auto [prefix, suffix] = make_mbr_cache(order);
+        for (size_t sz = MinEntries; sz <= n - MinEntries; ++sz)
+          {
+            const Rectangle &g1 = prefix[sz];
+            const Rectangle &g2 = suffix[sz];
+            const Geom_Number ov = overlap_area(g1, g2);
+            const Geom_Number ar = g1.area() + g2.area();
+            if (first or ov < best_overlap or (ov == best_overlap and ar < best_area))
+              {
+                first = false;
+                best_overlap = ov;
+                best_area = ar;
+                best_order = order;
+                best_sz = sz;
+              }
+          }
+      }
+
+    for (size_t k = 0; k < best_sz; ++k)
+      group1.append(std::move(items(best_order[k])));
+    for (size_t k = best_sz; k < n; ++k)
+      group2.append(std::move(items(best_order[k])));
+    entries = std::move(group1);
+    return group2;
+  }
+
+  // ---- insertion --------------------------------------------------------
+
+  /// @brief Split the entry array of @p node according to the active variant.
+  template <typename EntryT>
+  [[nodiscard]] static Array<EntryT> split_entries(Array<EntryT> &entries)
+  {
+    if constexpr (Variant == RTreeVariant::RStar)
+      return rstar_split(entries);
+    else
+      return quadratic_split(entries);
+  }
+
+  /// @brief Move the R*-tree forced-reinsert candidates (the entries farthest
+  ///        from the node centre) out of the overflowed leaf @p node and into
+  ///        @ref rstar_reinsert_buffer_, leaving @p node validly sized.
+  void reinsert_farthest(Node &node)
+  {
+    const size_t n = node.data.size();
+    const Point centre = compute_mbr(node).center();
+
+    std::array<size_t, MaxEntries + 1> order{};
+    for (size_t i = 0; i < n; ++i)
+      order[i] = i;
+    std::sort(order.begin(), order.begin() + n, [&node, &centre](const size_t a, const size_t b)
+      {
+        return node.data(a).bbox.center().distance_squared_to(centre) >
+          node.data(b).bbox.center().distance_squared_to(centre);
+      });
+
+    size_t p = (3 * MaxEntries) / 10;
+    if (p < 1)
+      p = 1;
+    if (p > MaxEntries + 1 - MinEntries)
+      p = MaxEntries + 1 - MinEntries;
+
+    Array<Entry> kept;
+    kept.reserve(n - p);
+    rstar_reinsert_buffer_.reserve(rstar_reinsert_buffer_.size() + p);
+    for (size_t k = p; k < n; ++k)
+      kept.append(std::move(node.data(order[k])));
+    for (size_t k = 0; k < p; ++k)
+      rstar_reinsert_buffer_.append(std::move(node.data(order[k])));
+    node.data = std::move(kept);
+  }
+
+  /// @brief Insert @p entry at the leaf level of @p node. Returns a new sibling
+  ///        node when @p node overflowed and had to be split, else nullptr.
+  [[nodiscard]] std::unique_ptr<Node> insert_descend(Node &node, Entry entry)
+  {
+    if (node.leaf)
+      {
+        node.data.reserve(MaxEntries + 1);
+        node.data.append(std::move(entry));
+        if (node.data.size() <= MaxEntries)
+          return nullptr;
+
+        if constexpr (Variant == RTreeVariant::RStar)
+          if (rstar_reinsert_available_ and &node != root_.get())
+            {
+              rstar_reinsert_available_ = false;
+              reinsert_farthest(node);
+              return nullptr;
+            }
+
+        Array<Entry> group2 = split_entries(node.data);
+        auto sibling = std::make_unique<Node>();
+        sibling->leaf = true;
+        sibling->data = std::move(group2);
+        return sibling;
+      }
+
+    const size_t idx = choose_subtree(node, entry.bbox);
+    std::unique_ptr<Node> split = insert_descend(*node.children(idx).child, std::move(entry));
+    node.children(idx).bbox = compute_mbr(*node.children(idx).child);
+    if (split == nullptr)
+      return nullptr;
+
+    Rectangle split_mbr = compute_mbr(*split);
+    node.children.reserve(MaxEntries + 1);
+    node.children.append(Child{std::move(split_mbr), std::move(split)});
+    if (node.children.size() <= MaxEntries)
+      return nullptr;
+
+    Array<Child> group2 = split_entries(node.children);
+    auto sibling = std::make_unique<Node>();
+    sibling->leaf = false;
+    sibling->children = std::move(group2);
+    return sibling;
+  }
+
+  /// @brief Insert one data entry into the tree (no @ref size_ change, no
+  ///        reinsert-buffer management).
+  void insert_one(Entry entry)
+  {
+    if (root_ == nullptr)
+      {
+        auto root = std::make_unique<Node>();
+        root->leaf = true;
+        root->data.reserve(1);
+        root->data.append(std::move(entry));
+        root_ = std::move(root);
+        height_ = 1;
+        return;
+      }
+
+    std::unique_ptr<Node> split = insert_descend(*root_, std::move(entry));
+    if (split == nullptr)
+      return;
+
+    auto new_root = std::make_unique<Node>();
+    new_root->leaf = false;
+    new_root->children.reserve(2);
+    new_root->children.append(Child{compute_mbr(*root_), std::move(root_)});
+    new_root->children.append(Child{compute_mbr(*split), std::move(split)});
+    root_ = std::move(new_root);
+    ++height_;
+  }
+
+  /// @brief Add a data entry without touching @ref size_ (shared by `insert`
+  ///        and by erase-time reinsertion). For the R*-tree variant this also
+  ///        drives one round of leaf-level forced reinsertion.
+  void add_entry(Entry entry)
+  {
+    if constexpr (Variant == RTreeVariant::RStar)
+      {
+        rstar_reinsert_available_ = true;
+        insert_one(std::move(entry));
+        while (not rstar_reinsert_buffer_.is_empty())
+          insert_one(rstar_reinsert_buffer_.remove_last());
+      }
+    else
+      insert_one(std::move(entry));
+  }
+
+  // ---- deletion ---------------------------------------------------------
+
+  /// @brief Move every data entry in @p node's subtree into @p out.
+  static void collect_data_entries(Node &node, Array<Entry> &out)
+  {
+    if (node.leaf)
+      {
+        for (size_t i = 0; i < node.data.size(); ++i)
+          out.append(std::move(node.data(i)));
+        return;
+      }
+    for (size_t i = 0; i < node.children.size(); ++i)
+      collect_data_entries(*node.children(i).child, out);
+  }
+
+  [[nodiscard]] static size_t data_entry_count(const Node &node)
+  {
+    if (node.leaf)
+      return node.data.size();
+    size_t total = 0;
+    for (size_t i = 0; i < node.children.size(); ++i)
+      {
+        const size_t subtree_count = data_entry_count(*node.children(i).child);
+        ah_overflow_error_if(total > std::numeric_limits<size_t>::max() - subtree_count)
+          << "RTree: data entry count would overflow";
+        total += subtree_count;
+      }
+    return total;
+  }
+
+  /// @brief Remove one entry equal to (@p bbox, @p value) from @p node's
+  ///        subtree. On success sets @p removed and moves the data entries of
+  ///        any underflowing descendant into @p orphans (for reinsertion).
+  void erase_descend(Node &node, const Rectangle &bbox, const Payload &value, Array<Entry> &orphans,
+                     bool &removed)
+    requires std::equality_comparable<Payload>
+  {
+    if (node.leaf)
+      {
+        for (size_t i = 0; i < node.data.size(); ++i)
+          if (node.data(i).bbox == bbox and node.data(i).value == value)
+            {
+              Array<Entry> kept;
+              kept.reserve(node.data.size() - 1);
+              for (size_t j = 0; j < node.data.size(); ++j)
+                if (j != i)
+                  kept.append(std::move(node.data(j)));
+              node.data = std::move(kept);
+              removed = true;
+              return;
+            }
+        return;
+      }
+
+    for (size_t i = 0; i < node.children.size(); ++i)
+      {
+        Child &c = node.children(i);
+        if (not box_contains_box(c.bbox, bbox))
+          continue;
+
+        erase_descend(*c.child, bbox, value, orphans, removed);
+        if (not removed)
+          continue;
+
+        if (entry_count(*c.child) < MinEntries)
+          {
+            const size_t orphan_count = data_entry_count(*c.child);
+            ah_overflow_error_if(orphans.size() >
+                                 std::numeric_limits<size_t>::max() - orphan_count)
+              << "RTree: orphan collection would overflow";
+            orphans.reserve(orphans.size() + orphan_count);
+            Array<Child> kept;
+            kept.reserve(node.children.size() - 1);
+            collect_data_entries(*c.child, orphans);
+            for (size_t j = 0; j < node.children.size(); ++j)
+              if (j != i)
+                kept.append(std::move(node.children(j)));
+            node.children = std::move(kept);
+          }
+        else
+          c.bbox = compute_mbr(*c.child);
+        return;
+      }
+  }
+
+  /// @brief True iff @p outer fully covers @p inner.
+  [[nodiscard]] static bool box_contains_box(const Rectangle &outer, const Rectangle &inner)
+  {
+    return outer.get_xmin() <= inner.get_xmin() and outer.get_xmax() >= inner.get_xmax() and
+      outer.get_ymin() <= inner.get_ymin() and outer.get_ymax() >= inner.get_ymax();
+  }
+
+  // ---- queries ----------------------------------------------------------
+
+  template <typename F>
+  void for_each_intersecting_rec(const Node &node, const Rectangle &rect, F &f) const
+  {
+    if (node.leaf)
+      {
+        for (size_t i = 0; i < node.data.size(); ++i)
+          if (node.data(i).bbox.intersects(rect))
+            f(node.data(i).bbox, node.data(i).value);
+        return;
+      }
+    for (size_t i = 0; i < node.children.size(); ++i)
+      if (node.children(i).bbox.intersects(rect))
+        for_each_intersecting_rec(*node.children(i).child, rect, f);
+  }
+
+  template <typename F>
+  void for_each_containing_rec(const Node &node, const Point &p, F &f) const
+  {
+    if (node.leaf)
+      {
+        for (size_t i = 0; i < node.data.size(); ++i)
+          if (node.data(i).bbox.contains(p))
+            f(node.data(i).bbox, node.data(i).value);
+        return;
+      }
+    for (size_t i = 0; i < node.children.size(); ++i)
+      if (node.children(i).bbox.contains(p))
+        for_each_containing_rec(*node.children(i).child, p, f);
+  }
+
+  // ---- copy / verify ----------------------------------------------------
+
+  [[nodiscard]] static std::unique_ptr<Node> clone_node(const Node &node)
+    requires std::is_copy_constructible_v<Payload>
+  {
+    auto copy = std::make_unique<Node>();
+    copy->leaf = node.leaf;
+    if (node.leaf)
+      {
+        copy->data.reserve(node.data.size());
+        for (size_t i = 0; i < node.data.size(); ++i)
+          copy->data.append(Entry{node.data(i).bbox, node.data(i).value});
+      }
+    else
+      {
+        copy->children.reserve(node.children.size());
+        for (size_t i = 0; i < node.children.size(); ++i)
+          copy->children.append(Child{node.children(i).bbox, clone_node(*node.children(i).child)});
+      }
+    return copy;
+  }
+
+  [[nodiscard]] bool verify_rec(const Node &node, const size_t depth, const bool is_root,
+                                size_t &leaf_depth, size_t &count, Rectangle &out_mbr) const
+  {
+    const size_t n = entry_count(node);
+    if (n > MaxEntries)
+      return false;
+    if (not is_root and n < MinEntries)
+      return false;
+    if (n == 0)
+      return false;  // an empty node must never be retained
+
+    if (node.leaf)
+      {
+        if (leaf_depth == std::numeric_limits<size_t>::max())
+          leaf_depth = depth;
+        else if (leaf_depth != depth)
+          return false;
+        out_mbr = compute_mbr(node);
+        if (count > std::numeric_limits<size_t>::max() - n)
+          return false;
+        count += n;
+        return true;
+      }
+
+    if (is_root and n < 2)
+      return false;  // a non-leaf root must have at least two children
+
+    Rectangle acc;
+    for (size_t i = 0; i < node.children.size(); ++i)
+      {
+        Rectangle child_mbr;
+        if (not verify_rec(*node.children(i).child, depth + 1, false, leaf_depth, count, child_mbr))
+          return false;
+        if (node.children(i).bbox != child_mbr)
+          return false;  // stored MBR must be tight
+        acc = i == 0 ? child_mbr : union_bbox(acc, child_mbr);
+      }
+    out_mbr = acc;
+    return true;
+  }
+
+public:
+  /** @brief Construct an empty R-tree.
+   *  @throws Nothing.
+   */
+  RTree() noexcept = default;
+
+  /** @brief Move-construct from @p other, leaving it empty and valid.
+   *  @throws Nothing.
+   */
+  RTree(RTree &&other) noexcept
+    : root_(std::move(other.root_)), size_(other.size_), height_(other.height_)
+  {
+    other.size_ = 0;
+    other.height_ = 0;
+  }
+
+  /** @brief Move-assign from @p other, leaving it empty and valid.
+   *  @throws Nothing.
+   */
+  RTree &operator = (RTree &&other) noexcept
+  {
+    if (this == &other)
+      return *this;
+    root_ = std::move(other.root_);
+    size_ = other.size_;
+    height_ = other.height_;
+    other.size_ = 0;
+    other.height_ = 0;
+    return *this;
+  }
+
+  /** @brief Deep-copy @p other (requires copy-constructible `Payload`).
+   *  @param other Tree to clone.
+   *  @throws std::bad_alloc or whatever copying `Payload` throws.
+   */
+  RTree(const RTree &other)
+    requires std::is_copy_constructible_v<Payload>
+    : size_(other.size_), height_(other.height_)
+  {
+    if (other.root_ != nullptr)
+      root_ = clone_node(*other.root_);
+  }
+
+  /** @brief Deep-copy assign from @p other (requires copy-constructible `Payload`).
+   *  @param other Tree to clone.
+   *  @return Reference to this tree.
+   *  @throws std::bad_alloc or whatever copying `Payload` throws.
+   */
+  RTree &operator = (const RTree &other)
+    requires std::is_copy_constructible_v<Payload>
+  {
+    if (this == &other)
+      return *this;
+    std::unique_ptr<Node> new_root;
+    if (other.root_ != nullptr)
+      new_root = clone_node(*other.root_);
+    root_ = std::move(new_root);
+    size_ = other.size_;
+    height_ = other.height_;
+    return *this;
+  }
+
+  /** @brief Return true when the tree has no entries.
+   *  @return `true` iff `size() == 0`.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] bool is_empty() const noexcept
+  {
+    return size_ == 0;
+  }
+
+  /** @brief Return the number of stored entries.
+   *  @return Entry count.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] size_t size() const noexcept
+  {
+    return size_;
+  }
+
+  /** @brief Return the number of node levels (0 when empty, 1 for a lone leaf).
+   *  @return Tree height in levels.
+   *  @throws Nothing.
+   */
+  [[nodiscard]] size_t height() const noexcept
+  {
+    return height_;
+  }
+
+  /** @brief Remove all entries.
+   *  @throws Nothing.
+   */
+  void clear() noexcept
+  {
+    root_.reset();
+    size_ = 0;
+    height_ = 0;
+  }
+
+  /** @brief Insert a (bbox, value) entry, copying @p value.
+   *  @param bbox Bounding box of the entry.
+   *  @param value Payload to store.
+   *  @throws std::bad_alloc if node allocation fails.
+   *  @throws std::overflow_error if the stored-entry count would overflow.
+   *  @throws Whatever copying `Payload` throws.
+   */
+  void insert(const Rectangle &bbox, const Payload &value)
+  {
+    ah_overflow_error_if(size_ == std::numeric_limits<size_t>::max())
+      << "RTree: size would overflow";
+    add_entry(Entry{bbox, value});
+    ++size_;
+  }
+
+  /** @brief Insert a (bbox, value) entry, moving @p value.
+   *  @param bbox Bounding box of the entry.
+   *  @param value Payload to move into the tree.
+   *  @throws std::bad_alloc if node allocation fails.
+   *  @throws std::overflow_error if the stored-entry count would overflow.
+   *  @throws Whatever moving `Payload` throws.
+   */
+  void insert(const Rectangle &bbox, Payload &&value)
+  {
+    ah_overflow_error_if(size_ == std::numeric_limits<size_t>::max())
+      << "RTree: size would overflow";
+    add_entry(Entry{bbox, std::move(value)});
+    ++size_;
+  }
+
+  /** @brief Remove one entry equal to (@p bbox, @p value).
+   *  @param bbox Bounding box of the entry to remove.
+   *  @param value Payload to match (by `==`).
+   *  @return `true` if an entry was removed, `false` if none matched.
+   *  @throws std::bad_alloc if reinsertion of condensed entries allocates.
+   *  @note Requires `Payload` to be equality-comparable. Uses a CondenseTree
+   *        variant that reinserts the data entries of any underflowing node.
+   */
+  [[nodiscard]] bool erase(const Rectangle &bbox, const Payload &value)
+    requires std::equality_comparable<Payload>
+  {
+    if (root_ == nullptr)
+      return false;
+
+    Array<Entry> orphans;
+    bool removed = false;
+    erase_descend(*root_, bbox, value, orphans, removed);
+    if (not removed)
+      return false;
+
+    --size_;
+
+    // Reinsert the entries orphaned by condensing (they remain in the tree, so
+    // add_entry must not change size_).
+    for (size_t i = 0; i < orphans.size(); ++i)
+      add_entry(std::move(orphans(i)));
+
+    // Shrink a non-leaf root that ended up with a single child.
+    while (root_ != nullptr and not root_->leaf and root_->children.size() == 1)
+      {
+        root_ = std::move(root_->children(0).child);
+        --height_;
+      }
+    // Drop an emptied leaf root.
+    if (root_ != nullptr and root_->leaf and root_->data.is_empty())
+      {
+        root_.reset();
+        height_ = 0;
+      }
+    return true;
+  }
+
+  /** @brief Invoke @p f for every entry whose bbox intersects @p rect.
+   *  @tparam F Callable as `f(const Rectangle &bbox, const Payload &value)`.
+   *  @param rect Query rectangle.
+   *  @param f Visitor invoked for each intersecting entry.
+   *  @throws Whatever @p f throws.
+   *  @note Works for move-only `Payload`: it passes references, never copies.
+   */
+  template <typename F>
+  void for_each_intersecting(const Rectangle &rect, F &&f) const
+  {
+    if (root_ != nullptr)
+      for_each_intersecting_rec(*root_, rect, f);
+  }
+
+  /** @brief Return the payloads of every entry whose bbox intersects @p rect.
+   *  @param rect Query rectangle.
+   *  @return Array with a copy of each matching payload.
+   *  @throws std::bad_alloc or whatever copying `Payload` throws.
+   */
+  [[nodiscard]] Array<Payload> search_intersects(const Rectangle &rect) const
+    requires std::is_copy_constructible_v<Payload>
+  {
+    Array<Payload> out;
+    for_each_intersecting(rect, [&out](const Rectangle &, const Payload &v)
+      {
+        out.append(v);
+      });
+    return out;
+  }
+
+  /** @brief Return the payloads of every entry whose bbox contains @p p.
+   *  @param p Query point.
+   *  @return Array with a copy of each matching payload.
+   *  @throws std::bad_alloc or whatever copying `Payload` throws.
+   */
+  [[nodiscard]] Array<Payload> search_contains(const Point &p) const
+    requires std::is_copy_constructible_v<Payload>
+  {
+    Array<Payload> out;
+    auto collect = [&out](const Rectangle &, const Payload &v)
+      {
+        out.append(v);
+      };
+    if (root_ != nullptr)
+      for_each_containing_rec(*root_, p, collect);
+    return out;
+  }
+
+  /** @brief Verify the R-tree structural invariants.
+   *  @return `true` iff parent boxes are tight unions of their children, node
+   *          occupancy is within `[MinEntries, MaxEntries]` (root exempt from
+   *          the lower bound), all leaves share one depth, and the counted
+   *          entries match `size()`.
+   *  @throws Nothing unless `Payload` comparison in geometry throws.
+   *  @note Intended for tests and diagnostics; it is O(n).
+   */
+  [[nodiscard]] bool verify() const
+  {
+    if (root_ == nullptr)
+      return size_ == 0 and height_ == 0;
+
+    size_t leaf_depth = std::numeric_limits<size_t>::max();
+    size_t count = 0;
+    Rectangle mbr;
+    if (not verify_rec(*root_, 1, true, leaf_depth, count, mbr))
+      return false;
+    return count == size_ and leaf_depth == height_;
+  }
+};
+
+}  // namespace Aleph
+
+#endif  // TPL_R_TREE_H

--- a/tpl_r_tree.H
+++ b/tpl_r_tree.H
@@ -103,7 +103,9 @@ enum class RTreeVariant
 
 /** @brief Dynamic R-tree indexing axis-aligned rectangles by payload.
  *
- *  @tparam Payload Value associated with each stored bounding box.
+ *  @tparam Payload Value associated with each stored bounding box. Must be
+ *          default-initializable and movable. Copying APIs additionally require
+ *          copy construction.
  *  @tparam MaxEntries Maximum number of entries per node. Must be at least 2.
  *  @tparam MinEntries Minimum number of entries per non-root node. Must be at
  *          least 1 and satisfy `2 * MinEntries <= MaxEntries + 1`. Defaults to
@@ -118,6 +120,9 @@ class RTree
   static_assert(MaxEntries >= 2, "RTree requires MaxEntries >= 2");
   static_assert(MinEntries >= 1, "RTree requires MinEntries >= 1");
   static_assert(2 * MinEntries <= MaxEntries + 1, "RTree requires 2 * MinEntries <= MaxEntries + 1");
+  static_assert(std::default_initializable<Payload>,
+                "RTree requires default-initializable Payload");
+  static_assert(std::movable<Payload>, "RTree requires movable Payload");
 
 public:
   /** @brief A stored (bounding box, payload) pair. */
@@ -400,10 +405,14 @@ private:
     Array<EntryT> items = std::move(entries);
     entries = Array<EntryT>();
 
+    // prefix/suffix are indexed up to and including n (prefix[n], suffix
+    // accessed down to suffix[0]), and n can reach MaxEntries + 1, so both
+    // need MaxEntries + 2 slots -- one more than the MaxEntries + 1 used for
+    // per-entry arrays like `order`.
     auto make_mbr_cache = [&items, n](const std::array<size_t, MaxEntries + 1> &order)
       {
-        std::array<Rectangle, MaxEntries + 1> prefix{};
-        std::array<Rectangle, MaxEntries + 1> suffix{};
+        std::array<Rectangle, MaxEntries + 2> prefix{};
+        std::array<Rectangle, MaxEntries + 2> suffix{};
         prefix[1] = items(order[0]).bbox;
         for (size_t k = 2; k <= n; ++k)
           prefix[k] = union_bbox(prefix[k - 1], items(order[k - 1]).bbox);
@@ -753,7 +762,7 @@ private:
   // ---- copy / verify ----------------------------------------------------
 
   [[nodiscard]] static std::unique_ptr<Node> clone_node(const Node &node)
-    requires std::is_copy_constructible_v<Payload>
+    requires (std::is_copy_constructible_v<Payload> and std::movable<Payload>)
   {
     auto copy = std::make_unique<Node>();
     copy->leaf = node.leaf;
@@ -820,6 +829,10 @@ public:
   RTree() noexcept = default;
 
   /** @brief Move-construct from @p other, leaving it empty and valid.
+   *  @param other Tree to move from.
+   *  @post `other.is_empty()` is `true` and `other` remains a valid,
+   *        usable tree (not merely moved-from).
+   *  @par Complexity O(1).
    *  @throws Nothing.
    */
   RTree(RTree &&other) noexcept
@@ -830,6 +843,11 @@ public:
   }
 
   /** @brief Move-assign from @p other, leaving it empty and valid.
+   *  @param other Tree to move from.
+   *  @return Reference to this tree.
+   *  @post `other.is_empty()` is `true` and `other` remains a valid,
+   *        usable tree (not merely moved-from).
+   *  @par Complexity O(1).
    *  @throws Nothing.
    */
   RTree &operator = (RTree &&other) noexcept
@@ -844,25 +862,25 @@ public:
     return *this;
   }
 
-  /** @brief Deep-copy @p other (requires copy-constructible `Payload`).
+  /** @brief Deep-copy @p other (requires copy-constructible, movable `Payload`).
    *  @param other Tree to clone.
    *  @throws std::bad_alloc or whatever copying `Payload` throws.
    */
   RTree(const RTree &other)
-    requires std::is_copy_constructible_v<Payload>
+    requires (std::is_copy_constructible_v<Payload> and std::movable<Payload>)
     : size_(other.size_), height_(other.height_)
   {
     if (other.root_ != nullptr)
       root_ = clone_node(*other.root_);
   }
 
-  /** @brief Deep-copy assign from @p other (requires copy-constructible `Payload`).
+  /** @brief Deep-copy assign from @p other (requires copy-constructible, movable `Payload`).
    *  @param other Tree to clone.
    *  @return Reference to this tree.
    *  @throws std::bad_alloc or whatever copying `Payload` throws.
    */
   RTree &operator = (const RTree &other)
-    requires std::is_copy_constructible_v<Payload>
+    requires (std::is_copy_constructible_v<Payload> and std::movable<Payload>)
   {
     if (this == &other)
       return *this;
@@ -1002,14 +1020,14 @@ public:
    *  @param rect Query rectangle.
    *  @return Array with a copy of each matching payload.
    *  @throws std::bad_alloc or whatever copying `Payload` throws.
-   */
+  */
   [[nodiscard]] Array<Payload> search_intersects(const Rectangle &rect) const
-    requires std::is_copy_constructible_v<Payload>
+    requires (std::is_copy_constructible_v<Payload> and std::movable<Payload>)
   {
     Array<Payload> out;
     for_each_intersecting(rect, [&out](const Rectangle &, const Payload &v)
       {
-        out.append(v);
+        out.append(Payload(v));
       });
     return out;
   }
@@ -1018,14 +1036,14 @@ public:
    *  @param p Query point.
    *  @return Array with a copy of each matching payload.
    *  @throws std::bad_alloc or whatever copying `Payload` throws.
-   */
+  */
   [[nodiscard]] Array<Payload> search_contains(const Point &p) const
-    requires std::is_copy_constructible_v<Payload>
+    requires (std::is_copy_constructible_v<Payload> and std::movable<Payload>)
   {
     Array<Payload> out;
     auto collect = [&out](const Rectangle &, const Payload &v)
       {
-        out.append(v);
+        out.append(Payload(v));
       };
     if (root_ != nullptr)
       for_each_containing_rec(*root_, p, collect);
@@ -1037,7 +1055,7 @@ public:
    *          occupancy is within `[MinEntries, MaxEntries]` (root exempt from
    *          the lower bound), all leaves share one depth, and the counted
    *          entries match `size()`.
-   *  @throws Nothing unless `Payload` comparison in geometry throws.
+   *  @throws Nothing.
    *  @note Intended for tests and diagnostics; it is O(n).
    */
   [[nodiscard]] bool verify() const


### PR DESCRIPTION
Introduce R-tree and R*-tree implementations (tpl_r_tree.H, tpl_r_star_tree.H). Add comprehensive tests for both (r_tree_test.cc, r_star_tree_test.cc). Include benchmarks (bench_r_tree.cc) and an example (r_tree_example.cc). Update CMakeLists.txt files and READMEs to reflect new features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nuevas funcionalidades**
  - Añadidos índices espaciales dinámicos **R-tree** y **R*-tree** con operaciones de inserción, borrado y consultas por intersección o contención.
  - Los encabezados instalados ahora incluyen estas variantes.
  - Incorporado un ejemplo completo para ambas estructuras.

- **Documentación**
  - Actualizadas las secciones de indexación espacial (es/en) con complejidad, comparativas y guía de uso.

- **Pruebas**
  - Añadidas pruebas automáticas para **R-tree** y **R*-tree** (operaciones, consistencia y casos geométricos).

- **Benchmarks y compatibilidad**
  - Añadido benchmark específico para comparar **R-tree**, **R*-tree** y una alternativa estática.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->