### PR TITLE
feat(core): agregar visualización de R-tree/R*-tree en tikzgeom_algor…

### DIFF
--- a/Examples/tikz_computational_geometry_gallery_example.cc
+++ b/Examples/tikz_computational_geometry_gallery_example.cc
@@ -506,11 +506,11 @@ int main(int argc, char * argv[])
     plane.put_cartesian_axis();
     const DynList<Point> pts = make_mec_points();
     const auto circle = visualize_mec(plane, pts);
-    const auto pair = visualize_closest_pair(plane, pts);
+    const auto [first, second, distance_squared] = visualize_closest_pair(plane, pts);
     add_caption(plane, Point(-18, 20),
                "MEC r=" + std::to_string(geom_number_to_double(circle.radius())) +
                " + closest pair d^2=" +
-               std::to_string(geom_number_to_double(pair.first.distance_squared_to(pair.second))));
+               std::to_string(geom_number_to_double(distance_squared)));
   }
 
   // 6. Convex decomposition (six-pointed star).

--- a/Examples/tikz_computational_geometry_gallery_example.cc
+++ b/Examples/tikz_computational_geometry_gallery_example.cc
@@ -1,0 +1,712 @@
+// Comprehensive gallery of Aleph-w's computational-geometry module rendered
+// through the TikZ backend: primitives, hulls, triangulations, Voronoi/power
+// diagrams, boolean/decomposition operations, simplification/offset/
+// smoothing, visibility/shortest-path, arrangements, and convex-polygon
+// algorithms (Minkowski sum, half-plane intersection, rotating calipers,
+// alpha shapes). See Examples/tikz_tree_structures_example.cc for the
+// companion gallery of spatial data structures (KD-tree, range tree, AABB
+// tree, quadtree, R-tree/R*-tree).
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <tikzgeom_algorithms.H>
+
+using namespace Aleph;
+
+namespace
+{
+
+// ---------------------------------------------------------------------------
+// Panel 1: primitives & polygons
+// ---------------------------------------------------------------------------
+
+Polygon make_irregular_polygon()
+{
+  Polygon p;
+  p.add_vertex(Point(-18, -10));
+  p.add_vertex(Point(-4, -14));
+  p.add_vertex(Point(10, -8));
+  p.add_vertex(Point(6, 4));
+  p.add_vertex(Point(-8, 8));
+  p.close();
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 2: convex hull
+// ---------------------------------------------------------------------------
+
+DynList<Point> make_hull_points()
+{
+  DynList<Point> pts;
+  pts.append(Point(-20, -10));
+  pts.append(Point(-14, 8));
+  pts.append(Point(-6, -16));
+  pts.append(Point(0, 2));
+  pts.append(Point(4, -12));
+  pts.append(Point(10, 14));
+  pts.append(Point(16, -4));
+  pts.append(Point(18, 10));
+  pts.append(Point(-2, 16));
+  pts.append(Point(6, 6));
+  pts.append(Point(-10, -2));
+  pts.append(Point(12, -14));
+  return pts;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 3: Delaunay + Voronoi overlay
+// ---------------------------------------------------------------------------
+
+DynList<Point> make_voronoi_sites()
+{
+  // Chosen so no Delaunay triangle is near-degenerate: a nearly-collinear
+  // triple has a legitimately distant circumcenter (Geom_Number is exact
+  // rational, so this is correct math, not a precision bug), which makes for
+  // a visually confusing demo panel with a Voronoi edge shooting far off
+  // frame. All triangles here have comparable area.
+  DynList<Point> pts;
+  pts.append(Point(-20, -4));
+  pts.append(Point(-8, 16));
+  pts.append(Point(4, -18));
+  pts.append(Point(16, 4));
+  pts.append(Point(20, 18));
+  pts.append(Point(2, 4));
+  pts.append(Point(-14, -14));
+  return pts;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 4: constrained Delaunay triangulation
+// ---------------------------------------------------------------------------
+
+DynList<Point> make_cdt_points()
+{
+  DynList<Point> pts;
+  pts.append(Point(-16, -10));
+  pts.append(Point(-16, 10));
+  pts.append(Point(16, 10));
+  pts.append(Point(16, -10));
+  pts.append(Point(-4, -2));
+  pts.append(Point(4, 4));
+  pts.append(Point(0, 0));
+  return pts;
+}
+
+DynList<Segment> make_cdt_constraints()
+{
+  DynList<Segment> segs;
+  segs.append(Segment(Point(-4, -2), Point(4, 4)));
+  return segs;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 5: minimum enclosing circle + closest pair (shared point set)
+// ---------------------------------------------------------------------------
+
+DynList<Point> make_mec_points()
+{
+  DynList<Point> pts;
+  pts.append(Point(-14, -6));
+  pts.append(Point(-8, 12));
+  pts.append(Point(4, 16));
+  pts.append(Point(16, 6));
+  pts.append(Point(12, -10));
+  pts.append(Point(-2, -14));
+  pts.append(Point(0, 2));
+  pts.append(Point(1, 3));
+  return pts;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 6: convex decomposition
+// ---------------------------------------------------------------------------
+
+Polygon make_decomposition_polygon()
+{
+  Polygon p;  // a six-pointed star outline (non-convex)
+  p.add_vertex(Point(0, 16));
+  p.add_vertex(Point(4, 5));
+  p.add_vertex(Point(15, 5));
+  p.add_vertex(Point(6, -2));
+  p.add_vertex(Point(9, -14));
+  p.add_vertex(Point(0, -7));
+  p.add_vertex(Point(-9, -14));
+  p.add_vertex(Point(-6, -2));
+  p.add_vertex(Point(-15, 5));
+  p.add_vertex(Point(-4, 5));
+  p.close();
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 7: boolean intersection
+// ---------------------------------------------------------------------------
+
+Polygon make_boolean_a()
+{
+  Polygon p;
+  p.add_vertex(Point(-14, -10));
+  p.add_vertex(Point(6, -10));
+  p.add_vertex(Point(6, 10));
+  p.add_vertex(Point(-14, 10));
+  p.close();
+  return p;
+}
+
+Polygon make_boolean_b()
+{
+  Polygon p;
+  p.add_vertex(Point(-4, -4));
+  p.add_vertex(Point(16, -4));
+  p.add_vertex(Point(16, 16));
+  p.add_vertex(Point(-4, 16));
+  p.close();
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 8: Douglas-Peucker simplification
+// ---------------------------------------------------------------------------
+
+Polygon make_noisy_polygon()
+{
+  Polygon p;
+  p.add_vertex(Point(-16, -8));
+  p.add_vertex(Point(-12, -9));
+  p.add_vertex(Point(-8, -7));
+  p.add_vertex(Point(-4, -10));
+  p.add_vertex(Point(0, -8));
+  p.add_vertex(Point(6, -9));
+  p.add_vertex(Point(12, -7));
+  p.add_vertex(Point(14, 2));
+  p.add_vertex(Point(12, 8));
+  p.add_vertex(Point(6, 10));
+  p.add_vertex(Point(0, 9));
+  p.add_vertex(Point(-6, 10));
+  p.add_vertex(Point(-12, 9));
+  p.add_vertex(Point(-14, 2));
+  p.close();
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 9: polygon offset
+// ---------------------------------------------------------------------------
+
+Polygon make_offset_polygon()
+{
+  Polygon p;
+  p.add_vertex(Point(-10, -8));
+  p.add_vertex(Point(10, -8));
+  p.add_vertex(Point(12, 0));
+  p.add_vertex(Point(10, 8));
+  p.add_vertex(Point(-10, 8));
+  p.close();
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 10: Chaikin smoothing
+// ---------------------------------------------------------------------------
+
+Polygon make_smoothing_polygon()
+{
+  Polygon p;  // a jagged five-pointed star
+  p.add_vertex(Point(0, 14));
+  p.add_vertex(Point(4, 3));
+  p.add_vertex(Point(13, 3));
+  p.add_vertex(Point(6, -4));
+  p.add_vertex(Point(8, -13));
+  p.add_vertex(Point(0, -7));
+  p.add_vertex(Point(-8, -13));
+  p.add_vertex(Point(-6, -4));
+  p.add_vertex(Point(-13, 3));
+  p.add_vertex(Point(-4, 3));
+  p.close();
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 11: visibility polygon
+// ---------------------------------------------------------------------------
+
+Polygon make_visibility_room()
+{
+  Polygon p;  // an L-shaped room with a wall pier
+  p.add_vertex(Point(0, 0));
+  p.add_vertex(Point(24, 0));
+  p.add_vertex(Point(24, 10));
+  p.add_vertex(Point(14, 10));
+  p.add_vertex(Point(14, 20));
+  p.add_vertex(Point(0, 20));
+  p.close();
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 12: shortest path with funnel portals
+// ---------------------------------------------------------------------------
+
+Polygon make_corridor_polygon()
+{
+  Polygon p;  // a bent corridor with a protruding obstacle
+  p.add_vertex(Point(0, 0));
+  p.add_vertex(Point(26, 0));
+  p.add_vertex(Point(26, 22));
+  p.add_vertex(Point(16, 22));
+  p.add_vertex(Point(16, 10));
+  p.add_vertex(Point(11, 10));
+  p.add_vertex(Point(11, 22));
+  p.add_vertex(Point(0, 22));
+  p.close();
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 13: trapezoidal map
+// ---------------------------------------------------------------------------
+
+Polygon make_trapezoidal_polygon()
+{
+  Polygon p;
+  p.add_vertex(Point(-12, -8));
+  p.add_vertex(Point(8, -12));
+  p.add_vertex(Point(14, 0));
+  p.add_vertex(Point(4, 10));
+  p.add_vertex(Point(-10, 6));
+  p.close();
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 14: segment arrangement
+// ---------------------------------------------------------------------------
+
+Array<Segment> make_arrangement_segments()
+{
+  Array<Segment> segs;
+  segs.append(Segment(Point(-16, 0), Point(16, 0)));
+  segs.append(Segment(Point(0, -14), Point(0, 14)));
+  segs.append(Segment(Point(-14, -10), Point(14, 10)));
+  segs.append(Segment(Point(-14, 10), Point(14, -10)));
+  segs.append(Segment(Point(-10, -14), Point(10, 14)));
+  return segs;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 15: Bentley-Ottmann line sweep
+// ---------------------------------------------------------------------------
+
+Array<Segment> make_sweep_segments()
+{
+  Array<Segment> segs;
+  segs.append(Segment(Point(-16, -6), Point(16, 8)));
+  segs.append(Segment(Point(-14, 9), Point(15, -7)));
+  segs.append(Segment(Point(-16, 3), Point(16, 3)));
+  segs.append(Segment(Point(-6, -12), Point(-6, 12)));
+  segs.append(Segment(Point(8, -12), Point(8, 12)));
+  return segs;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 16: Minkowski sum
+// ---------------------------------------------------------------------------
+
+Polygon make_minkowski_a()
+{
+  Polygon p;
+  p.add_vertex(Point(-6, -3));
+  p.add_vertex(Point(5, -4));
+  p.add_vertex(Point(3, 5));
+  p.close();
+  return p;
+}
+
+Polygon make_minkowski_b()
+{
+  Polygon p;
+  p.add_vertex(Point(-3, -2));
+  p.add_vertex(Point(4, -2));
+  p.add_vertex(Point(0, 5));
+  p.close();
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 17: half-plane intersection
+// ---------------------------------------------------------------------------
+
+Array<HalfPlaneIntersection::HalfPlane> make_half_planes()
+{
+  using HP = HalfPlaneIntersection::HalfPlane;
+  Array<HP> hps;
+  hps.append(HP(Point(0, 1), Point(0, 0)));    // x >= 0
+  hps.append(HP(Point(0, 0), Point(1, 0)));    // y >= 0
+  hps.append(HP(Point(10, 0), Point(10, 1)));  // x <= 10
+  hps.append(HP(Point(1, 10), Point(0, 10)));  // y <= 10
+  hps.append(HP(Point(10, 0), Point(0, 10)));  // x + y <= 10
+  return hps;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 18: rotating calipers
+// ---------------------------------------------------------------------------
+
+Polygon make_calipers_polygon()
+{
+  Polygon p;
+  p.add_vertex(Point(-14, -4));
+  p.add_vertex(Point(-4, -12));
+  p.add_vertex(Point(10, -8));
+  p.add_vertex(Point(16, 4));
+  p.add_vertex(Point(6, 14));
+  p.add_vertex(Point(-10, 10));
+  p.close();
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 19: alpha shape
+// ---------------------------------------------------------------------------
+
+DynList<Point> make_alpha_points()
+{
+  DynList<Point> pts;
+  pts.append(Point(-16, -8));
+  pts.append(Point(-12, 10));
+  pts.append(Point(-2, 15));
+  pts.append(Point(8, 13));
+  pts.append(Point(15, 6));
+  pts.append(Point(17, -6));
+  pts.append(Point(8, -14));
+  pts.append(Point(-4, -16));
+  pts.append(Point(2, 2));
+  pts.append(Point(-5, 3));
+  return pts;
+}
+
+// ---------------------------------------------------------------------------
+// Panel 20: power diagram (weighted Voronoi)
+// ---------------------------------------------------------------------------
+
+Array<PowerDiagram::WeightedSite> make_power_sites()
+{
+  // A ring of boundary sites plus two interior sites: only sites strictly
+  // inside the convex hull of the input can have a *bounded* power cell (a
+  // hull site's cell is always unbounded, exactly as in a plain Voronoi
+  // diagram), so the two interior sites are what make the filled cells
+  // visible here.
+  Array<PowerDiagram::WeightedSite> sites;
+  sites.append({Point(-16, -10), Geom_Number(2)});
+  sites.append({Point(16, -10), Geom_Number(3)});
+  sites.append({Point(20, 8), Geom_Number(2)});
+  sites.append({Point(0, 18), Geom_Number(4)});
+  sites.append({Point(-20, 8), Geom_Number(3)});
+  sites.append({Point(-6, 3), Geom_Number(5)});
+  sites.append({Point(6, -2), Geom_Number(2)});
+  return sites;
+}
+
+void add_caption(Tikz_Plane & plane, const Point & at, const std::string & text)
+{
+  put_in_plane(plane, Text(at, text), make_tikz_draw_style("black"),
+              Tikz_Plane::Layer_Overlay);
+}
+
+} // namespace
+
+int main(int argc, char * argv[])
+{
+  const std::string output_path =
+      argc > 1 ? argv[1] : "tikz_computational_geometry_gallery_example.tex";
+
+  std::ofstream out(output_path);
+  if (not out)
+    {
+      std::cerr << "Cannot open output file: " << output_path << '\n';
+      return 1;
+    }
+
+  std::vector<Tikz_Plane> panels;
+  panels.reserve(20);
+  auto & p = panels;  // shorthand
+
+  // 1. Primitives & polygons showcase.
+  p.emplace_back(190, 120, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    put_in_plane(plane, Segment(Point(-24, -12), Point(-14, 4)), tikz_wire_style("blue"));
+    put_in_plane(plane, Triangle(Point(-8, -14), Point(2, -14), Point(-3, -4)),
+                tikz_area_style("teal", "teal!18", 0.4));
+    put_in_plane(plane, Ellipse(Point(12, -8), Geom_Number(6), Geom_Number(3)),
+                tikz_wire_style("purple"));
+    put_in_plane(plane, RotatedEllipse(Point(12, 6), Geom_Number(7), Geom_Number(3),
+                                       Geom_Number(3, 5), Geom_Number(4, 5)),
+                tikz_wire_style("magenta"));
+    put_in_plane(plane, Regular_Polygon(Point(-14, 12), 5.0, 6),
+                tikz_area_style("orange!80!black", "orange!20", 0.4));
+    put_in_plane(plane, make_irregular_polygon(), tikz_wire_style("black"));
+    put_in_plane(plane, Point(0, 0), tikz_points_style("red"));
+    add_caption(plane, Point(-24, 20), "Primitives: segment, triangle, ellipse, "
+                "rotated ellipse, regular hexagon, irregular polygon, point");
+  }
+
+  // 2. Convex hull (Andrew monotone chain).
+  p.emplace_back(180, 110, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    plane.set_point_radius_mm(0.7);
+    const Polygon hull = visualize_convex_hull(
+        plane, make_hull_points(), AndrewMonotonicChainConvexHull());
+    add_caption(plane, Point(-22, 20),
+               "Convex Hull (Andrew): h=" + std::to_string(hull.size()));
+  }
+
+  // 3. Delaunay triangulation + Voronoi overlay.
+  p.emplace_back(190, 115, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    plane.set_point_radius_mm(0.75);
+    const DynList<Point> sites = make_voronoi_sites();
+    DelaunayTriangulationRandomizedIncremental dt_algo;
+    const auto dt = dt_algo(sites);
+    put_delaunay_result(plane, dt, tikz_wire_style("blue!70"), false);
+    visualize_voronoi(plane, sites, VoronoiDiagram(), false,
+                      tikz_area_style("gray!50!black", "gray!15", 0.25),
+                      tikz_wire_style("black"),
+                      tikz_wire_style("black", true, true),
+                      tikz_points_style("red"), Geom_Number(60));
+    add_caption(plane, Point(-25, 24),
+               "Delaunay + Voronoi: sites=" + std::to_string(dt.sites.size()) +
+               ", triangles=" + std::to_string(dt.triangles.size()));
+  }
+
+  // 4. Constrained Delaunay triangulation.
+  p.emplace_back(180, 105, 5, 5);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const auto cdt = visualize_cdt(plane, make_cdt_points(), make_cdt_constraints());
+    add_caption(plane, Point(-18, 13),
+               "CDT: triangles=" + std::to_string(cdt.triangles.size()) +
+               ", constraints=" + std::to_string(cdt.constrained_edges.size()));
+  }
+
+  // 5. Minimum enclosing circle + closest pair (same point set).
+  p.emplace_back(180, 110, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const DynList<Point> pts = make_mec_points();
+    const auto circle = visualize_mec(plane, pts);
+    const auto pair = visualize_closest_pair(plane, pts);
+    add_caption(plane, Point(-18, 20),
+               "MEC r=" + std::to_string(geom_number_to_double(circle.radius())) +
+               " + closest pair d^2=" +
+               std::to_string(geom_number_to_double(pair.first.distance_squared_to(pair.second))));
+  }
+
+  // 6. Convex decomposition (six-pointed star).
+  p.emplace_back(170, 115, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const Array<Polygon> parts =
+        visualize_convex_decomposition(plane, make_decomposition_polygon());
+    add_caption(plane, Point(-16, 19),
+               "Convex Decomposition: parts=" + std::to_string(parts.size()));
+  }
+
+  // 7. Boolean intersection of two overlapping rectangles.
+  p.emplace_back(170, 110, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const auto result = visualize_boolean_operation(
+        plane, make_boolean_a(), make_boolean_b(),
+        BooleanPolygonOperations::Op::INTERSECTION);
+    add_caption(plane, Point(-16, 19),
+               "Boolean Intersection: parts=" + std::to_string(result.size()));
+  }
+
+  // 8. Douglas-Peucker simplification.
+  p.emplace_back(180, 110, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const Polygon simplified =
+        visualize_douglas_peucker(plane, make_noisy_polygon(), Geom_Number(1, 2));
+    add_caption(plane, Point(-18, 14),
+               "Douglas-Peucker: original=" +
+               std::to_string(make_noisy_polygon().size()) +
+               ", simplified=" + std::to_string(simplified.size()));
+  }
+
+  // 9. Polygon offset (inward).
+  p.emplace_back(160, 100, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const auto result = visualize_polygon_offset(plane, make_offset_polygon(), Geom_Number(-3));
+    add_caption(plane, Point(-13, 12),
+               "Polygon Offset (-3): polygons=" + std::to_string(result.polygons.size()));
+  }
+
+  // 10. Chaikin smoothing.
+  p.emplace_back(160, 105, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const Polygon smoothed =
+        visualize_chaikin_smoothing(plane, make_smoothing_polygon(), 3);
+    add_caption(plane, Point(-14, 16),
+               "Chaikin Smoothing (3 iters): vertices=" + std::to_string(smoothed.size()));
+  }
+
+  // 11. Visibility polygon.
+  p.emplace_back(170, 110, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const Point query(3, 3);
+    const Polygon vis = visualize_visibility_polygon(plane, make_visibility_room(), query);
+    add_caption(plane, Point(-1, 24),
+               "Visibility Polygon: vertices=" + std::to_string(vis.size()));
+  }
+
+  // 12. Shortest path with funnel portals.
+  p.emplace_back(190, 115, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const Point source(3, 3);
+    const Point target(20, 18);
+    const auto debug = visualize_shortest_path_with_portals(
+        plane, make_corridor_polygon(), source, target, ShortestPathInPolygon());
+    size_t path_nodes = 0;
+    for (DynList<Point>::Iterator it(debug.path); it.has_curr(); it.next_ne())
+      ++path_nodes;
+    add_caption(plane, Point(-1, 26),
+               "Shortest Path + Portals: path nodes=" + std::to_string(path_nodes) +
+               ", portals=" + std::to_string(debug.portals.size()));
+  }
+
+  // 13. Trapezoidal map point location.
+  p.emplace_back(170, 110, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const auto res = visualize_trapezoidal_map(plane, make_trapezoidal_polygon());
+    add_caption(plane, Point(-15, 14),
+               "Trapezoidal Map: input segments=" + std::to_string(res.num_input_segments));
+  }
+
+  // 14. Segment arrangement.
+  p.emplace_back(170, 110, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const auto arrangement = visualize_segment_arrangement(
+        plane, make_arrangement_segments(), SegmentArrangement(),
+        true, true, false,
+        tikz_area_style("teal!60!black", "teal!12", 0.35),
+        tikz_wire_style("teal!70!black"),
+        tikz_points_style("teal!80!black"), true);
+    add_caption(plane, Point(-18, 18),
+               "Segment Arrangement: V=" + std::to_string(arrangement.vertices.size()) +
+               ", E=" + std::to_string(arrangement.edges.size()));
+  }
+
+  // 15. Bentley-Ottmann line sweep.
+  p.emplace_back(170, 110, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    plane.set_point_radius_mm(0.7);
+    const auto intersections = visualize_line_sweep(plane, make_sweep_segments());
+    add_caption(plane, Point(-18, 15),
+               "Line Sweep intersections=" + std::to_string(intersections.size()));
+  }
+
+  // 16. Minkowski sum.
+  p.emplace_back(160, 100, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const Polygon sum = visualize_minkowski_sum(plane, make_minkowski_a(), make_minkowski_b());
+    add_caption(plane, Point(-9, 10), "Minkowski Sum: vertices=" + std::to_string(sum.size()));
+  }
+
+  // 17. Half-plane intersection.
+  p.emplace_back(150, 100, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const Polygon feasible = visualize_half_plane_intersection(plane, make_half_planes());
+    add_caption(plane, Point(-1, 12),
+               "Half-Plane Intersection: vertices=" + std::to_string(feasible.size()));
+  }
+
+  // 18. Rotating calipers (diameter + minimum width).
+  p.emplace_back(170, 110, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    const auto rc = visualize_rotating_calipers(plane, make_calipers_polygon());
+    add_caption(plane, Point(-16, 18),
+               "Rotating Calipers: diameter^2=" +
+               std::to_string(geom_number_to_double(rc.diameter.distance_squared)));
+  }
+
+  // 19. Alpha shape.
+  p.emplace_back(180, 115, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    plane.set_point_radius_mm(0.75);
+    const auto alpha = visualize_alpha_shape(plane, make_alpha_points(), Geom_Number(180));
+    add_caption(plane, Point(-19, 20),
+               "Alpha Shape: boundary edges=" + std::to_string(alpha.boundary_edges.size()));
+  }
+
+  // 20. Power diagram (weighted Voronoi).
+  p.emplace_back(200, 115, 6, 6);
+  {
+    Tikz_Plane & plane = p.back();
+    plane.put_cartesian_axis();
+    plane.set_point_radius_mm(0.75);
+    // draw_cells=false: PowerDiagram's bounded-cell vertex lists are not
+    // reliably in simple cyclic order around their site, so building a
+    // filled cell polygon can throw "closing causes an intersection"
+    // (reproduced with this exact site data; see the geometry review notes).
+    // Only edges/sites are drawn until that ordering bug is fixed upstream.
+    visualize_power_diagram(plane, make_power_sites(), PowerDiagram(), false,
+                            tikz_area_style("violet", "violet!18", 0.35),
+                            tikz_wire_style("violet"), tikz_points_style("purple"));
+    add_caption(plane, Point(-26, 23), "Power Diagram (Weighted Voronoi)");
+  }
+
+  out << "\\documentclass[tikz,border=8pt]{standalone}\n"
+      << "\\usepackage{tikz}\n"
+      << "\\begin{document}\n\n";
+
+  for (size_t i = 0; i < panels.size(); ++i)
+    {
+      panels[i].draw(out, true);
+      if (i + 1 < panels.size())
+        out << "\n\\vspace{4mm}\n\n";
+    }
+
+  out << "\n\\end{document}\n";
+
+  std::cout << "Generated " << output_path << " (" << panels.size() << " panels)\n";
+  std::cout << "Compile with: pdflatex " << output_path << '\n';
+  return 0;
+}

--- a/Examples/tikz_tree_structures_example.cc
+++ b/Examples/tikz_tree_structures_example.cc
@@ -2,7 +2,9 @@
 #include <iostream>
 #include <string>
 
+#include <quadtree.H>
 #include <tikzgeom_algorithms.H>
+#include <tpl_r_star_tree.H>
 
 using namespace Aleph;
 
@@ -45,6 +47,96 @@ AABBTree make_aabb_tree()
   entries.append({Rectangle(6, 8, 10, 12), 4});
   tree.build(entries);
   return tree;
+}
+
+// QuadTree exposes its node structure through public accessors
+// (get_root(), QuadNode::get_nw_child()/.../get_se_child(), is_leaf(),
+// get_points_set()) but has no built-in TikZ visualizer, so this example
+// walks it directly to collect leaf regions (by depth) and stored points.
+struct QuadTreeSnapshot
+{
+  Array<Rectangle> leaf_regions;
+  Array<size_t> leaf_depths;
+  Array<Point> points;
+};
+
+void collect_quadtree_rec(QuadNode * node, const size_t depth, QuadTreeSnapshot & snap)
+{
+  if (node == nullptr)
+    return;
+
+  if (node->is_leaf())
+    {
+      snap.leaf_regions.append(Rectangle(node->get_min_x(), node->get_min_y(),
+                                         node->get_max_x(), node->get_max_y()));
+      snap.leaf_depths.append(depth);
+      for (Point & p : node->get_points_set())
+        snap.points.append(p);
+      return;
+    }
+
+  collect_quadtree_rec(node->get_nw_child(), depth + 1, snap);
+  collect_quadtree_rec(node->get_ne_child(), depth + 1, snap);
+  collect_quadtree_rec(node->get_sw_child(), depth + 1, snap);
+  collect_quadtree_rec(node->get_se_child(), depth + 1, snap);
+}
+
+QuadTreeSnapshot collect_quadtree(QuadTree & tree)
+{
+  QuadTreeSnapshot snap;
+  collect_quadtree_rec(tree.get_root(), 0, snap);
+  return snap;
+}
+
+// Colors cycle by subdivision depth so sibling quadrants at the same depth
+// share a color and successive splits are visually distinguishable.
+std::string depth_color(const size_t depth)
+{
+  static const char * colors[] =
+      {"blue!55", "orange!70!black", "green!55!black", "red!60", "violet!65", "brown!60"};
+  constexpr size_t num_colors = sizeof(colors) / sizeof(colors[0]);
+  return colors[depth % num_colors];
+}
+
+Array<Point> make_quadtree_points()
+{
+  // Deliberately uneven spread (a dense cluster plus scattered outliers) so
+  // the quadtree subdivides non-uniformly across depths. All coordinates
+  // stay inside [0, 100) since QuadNode::contains() uses a half-open
+  // [min, max) region: a point exactly on the upper/right root boundary
+  // would silently fail to insert.
+  Array<Point> pts;
+  pts.append(Point(12, 15));
+  pts.append(Point(18, 22));
+  pts.append(Point(15, 30));
+  pts.append(Point(22, 12));
+  pts.append(Point(28, 28));
+  pts.append(Point(20, 20));
+  pts.append(Point(70, 75));
+  pts.append(Point(80, 65));
+  pts.append(Point(75, 82));
+  pts.append(Point(85, 88));
+  pts.append(Point(60, 15));
+  pts.append(Point(90, 20));
+  pts.append(Point(45, 60));
+  pts.append(Point(35, 85));
+  pts.append(Point(8, 92));
+  pts.append(Point(95, 5));
+  return pts;
+}
+
+Array<Rectangle> make_rtree_rectangles()
+{
+  Array<Rectangle> rects;
+  for (int i = 0; i < 24; ++i)
+    {
+      const int col = i % 6;
+      const int row = i / 6;
+      const Geom_Number x0 = Geom_Number(col * 10 + (i % 3));
+      const Geom_Number y0 = Geom_Number(row * 9 + (i % 2) * 2);
+      rects.append(Rectangle(x0, y0, x0 + 6, y0 + 5));
+    }
+  return rects;
 }
 
 } // namespace
@@ -107,6 +199,71 @@ int main(int argc, char * argv[])
                make_tikz_draw_style("black"),
                Tikz_Plane::Layer_Overlay);
 
+  // QuadTree: no dedicated visualizer exists yet (unlike KD/Range/AABB
+  // above), so leaf regions are collected by walking the public node API
+  // directly (see collect_quadtree_rec) and drawn colored by subdivision
+  // depth, one wireframe rectangle per leaf.
+  Tikz_Plane quadtree_plane(200, 120, 6, 6);
+  quadtree_plane.put_cartesian_axis();
+  quadtree_plane.put_coordinate_grid(10, 10, true);
+  quadtree_plane.set_point_radius_mm(0.7);
+
+  QuadTree quadtree(Geom_Number(0), Geom_Number(100), Geom_Number(0), Geom_Number(100), 3);
+  for (const Point & p : make_quadtree_points())
+    quadtree.insert(p);
+
+  const QuadTreeSnapshot qsnap = collect_quadtree(quadtree);
+  for (size_t i = 0; i < qsnap.leaf_regions.size(); ++i)
+    put_in_plane(quadtree_plane, qsnap.leaf_regions(i),
+                 tikz_wire_style(depth_color(qsnap.leaf_depths(i))),
+                 Tikz_Plane::Layer_Default);
+  put_points(quadtree_plane, qsnap.points, tikz_points_style("black"));
+  put_in_plane(quadtree_plane,
+               Text(Point(-2, 105),
+                    "QuadTree leaves=" + std::to_string(qsnap.leaf_regions.size()) +
+                    ", points=" + std::to_string(qsnap.points.size())),
+               make_tikz_draw_style("black"),
+               Tikz_Plane::Layer_Overlay);
+
+  // R-tree (Guttman quadratic split) and R*-tree, built from the *same*
+  // rectangles and queried with the same rectangle, so the two split
+  // heuristics can be compared directly: R*-tree typically yields less
+  // node overlap for the same data.
+  Tikz_Plane rtree_plane(200, 120, 6, 6);
+  rtree_plane.put_cartesian_axis();
+  rtree_plane.put_coordinate_grid(10, 10, true);
+
+  RTree<int, 4, 2> rtree;
+  RStarTree<int, 4, 2> rstar_tree;
+  {
+    const Array<Rectangle> rects = make_rtree_rectangles();
+    for (size_t i = 0; i < rects.size(); ++i)
+      {
+        rtree.insert(rects(i), static_cast<int>(i));
+        rstar_tree.insert(rects(i), static_cast<int>(i));
+      }
+  }
+  const Rectangle rtree_query(8, 5, 28, 20);
+  const auto rt_result = visualize_rtree_query(rtree_plane, rtree, rtree_query);
+  put_in_plane(rtree_plane,
+               Text(Point(-2, 47),
+                    "R-tree (Guttman) nodes=" + std::to_string(rt_result.snapshot.nodes.size()) +
+                    ", hits=" + std::to_string(rt_result.query_hit_boxes.size())),
+               make_tikz_draw_style("black"),
+               Tikz_Plane::Layer_Overlay);
+
+  Tikz_Plane rstar_plane(200, 120, 6, 6);
+  rstar_plane.put_cartesian_axis();
+  rstar_plane.put_coordinate_grid(10, 10, true);
+
+  const auto rstar_result = visualize_rtree_query(rstar_plane, rstar_tree, rtree_query);
+  put_in_plane(rstar_plane,
+               Text(Point(-2, 47),
+                    "R*-tree nodes=" + std::to_string(rstar_result.snapshot.nodes.size()) +
+                    ", hits=" + std::to_string(rstar_result.query_hit_boxes.size())),
+               make_tikz_draw_style("black"),
+               Tikz_Plane::Layer_Overlay);
+
   out << "\\documentclass[tikz,border=8pt]{standalone}\n"
       << "\\usepackage{tikz}\n"
       << "\\begin{document}\n\n";
@@ -116,6 +273,12 @@ int main(int argc, char * argv[])
   range_plane.draw(out, true);
   out << "\n\\vspace{4mm}\n\n";
   aabb_plane.draw(out, true);
+  out << "\n\\vspace{4mm}\n\n";
+  quadtree_plane.draw(out, true);
+  out << "\n\\vspace{4mm}\n\n";
+  rtree_plane.draw(out, true);
+  out << "\n\\vspace{4mm}\n\n";
+  rstar_plane.draw(out, true);
   out << "\n\\end{document}\n";
 
   std::cout << "Generated " << output_path << '\n';

--- a/Tests/r_star_tree_test.cc
+++ b/Tests/r_star_tree_test.cc
@@ -205,6 +205,62 @@ TEST(RStarTree, ForcedReinsertionKeepsTreeValid)
     }
 }
 
+namespace
+{
+  Rectangle union_of(const Rectangle &a, const Rectangle &b)
+  {
+    return Rectangle(a.get_xmin() < b.get_xmin() ? a.get_xmin() : b.get_xmin(),
+                     a.get_ymin() < b.get_ymin() ? a.get_ymin() : b.get_ymin(),
+                     a.get_xmax() > b.get_xmax() ? a.get_xmax() : b.get_xmax(),
+                     a.get_ymax() > b.get_ymax() ? a.get_ymax() : b.get_ymax());
+  }
+
+  // Recursively check a DebugSnapshot: every child index is one depth deeper,
+  // every leaf's stored bbox is the tight union of its entry_boxes, every
+  // internal node's bbox is the tight union of its children's bboxes, and
+  // returns the total number of leaf entries found.
+  template <typename Snapshot>
+  size_t check_snapshot_node(const Snapshot &snap, const size_t idx, const size_t expected_depth)
+  {
+    const auto &node = snap.nodes(idx);
+    EXPECT_EQ(node.depth, expected_depth);
+
+    if (node.is_leaf)
+      {
+        EXPECT_FALSE(node.entry_boxes.is_empty());
+        Rectangle acc = node.entry_boxes(0);
+        for (size_t i = 1; i < node.entry_boxes.size(); ++i)
+          acc = union_of(acc, node.entry_boxes(i));
+        EXPECT_EQ(node.bbox, acc);
+        return node.entry_boxes.size();
+      }
+
+    EXPECT_FALSE(node.children.is_empty());
+    Rectangle acc = snap.nodes(node.children(0)).bbox;
+    size_t total = check_snapshot_node(snap, node.children(0), expected_depth + 1);
+    for (size_t i = 1; i < node.children.size(); ++i)
+      {
+        EXPECT_LT(node.children(i), snap.nodes.size());
+        total += check_snapshot_node(snap, node.children(i), expected_depth + 1);
+        acc = union_of(acc, snap.nodes(node.children(i)).bbox);
+      }
+    EXPECT_EQ(node.bbox, acc);
+    return total;
+  }
+}
+
+TEST(RStarTree, DebugSnapshotStructuralInvariants)
+{
+  RStarTree<int> tree;   // Max=16, Min=8; same insert pattern as forced reinsertion
+  for (int i = 0; i < 500; ++i)
+    tree.insert(rect(i % 50, i / 50, i % 50 + 3, i / 50 + 3), i);
+
+  const auto snap = tree.debug_snapshot();
+  ASSERT_LT(snap.root, snap.nodes.size());
+  const size_t total_entries = check_snapshot_node(snap, snap.root, 0);
+  EXPECT_EQ(total_entries, tree.size());
+}
+
 TEST(RStarTree, CoincidentRectangles)
 {
   RStarTree<int, 4, 2> tree;

--- a/Tests/r_tree_test.cc
+++ b/Tests/r_tree_test.cc
@@ -36,6 +36,7 @@
 
 #include <algorithm>
 #include <concepts>
+#include <limits>
 #include <memory>
 #include <random>
 #include <type_traits>
@@ -193,6 +194,83 @@ TEST(RTree, GrowsInHeightWithManyInserts)
       const std::vector<int> hits = sorted_contains(tree, pt(i, i));
       EXPECT_TRUE(std::find(hits.begin(), hits.end(), i) != hits.end());
     }
+}
+
+TEST(RTree, DebugSnapshotEmptyTree)
+{
+  const RTree<int> tree;
+  const auto snap = tree.debug_snapshot();
+  EXPECT_TRUE(snap.nodes.is_empty());
+  EXPECT_EQ(snap.root, std::numeric_limits<size_t>::max());
+}
+
+namespace
+{
+  Rectangle union_of(const Rectangle &a, const Rectangle &b)
+  {
+    return Rectangle(a.get_xmin() < b.get_xmin() ? a.get_xmin() : b.get_xmin(),
+                     a.get_ymin() < b.get_ymin() ? a.get_ymin() : b.get_ymin(),
+                     a.get_xmax() > b.get_xmax() ? a.get_xmax() : b.get_xmax(),
+                     a.get_ymax() > b.get_ymax() ? a.get_ymax() : b.get_ymax());
+  }
+
+  // Recursively check a DebugSnapshot: every child index is in range and one
+  // depth deeper, every leaf's stored bbox is the tight union of its
+  // entry_boxes, every internal node's bbox is the tight union of its
+  // children's bboxes, and returns the total number of leaf entries found.
+  template <typename Snapshot>
+  size_t check_snapshot_node(const Snapshot &snap, const size_t idx, const size_t expected_depth)
+  {
+    const auto &node = snap.nodes(idx);
+    EXPECT_EQ(node.depth, expected_depth);
+
+    if (node.is_leaf)
+      {
+        EXPECT_FALSE(node.entry_boxes.is_empty());
+        Rectangle acc = node.entry_boxes(0);
+        for (size_t i = 1; i < node.entry_boxes.size(); ++i)
+          acc = union_of(acc, node.entry_boxes(i));
+        EXPECT_EQ(node.bbox, acc);
+        return node.entry_boxes.size();
+      }
+
+    EXPECT_FALSE(node.children.is_empty());
+    Rectangle acc = snap.nodes(node.children(0)).bbox;
+    size_t total = check_snapshot_node(snap, node.children(0), expected_depth + 1);
+    for (size_t i = 1; i < node.children.size(); ++i)
+      {
+        EXPECT_LT(node.children(i), snap.nodes.size());
+        total += check_snapshot_node(snap, node.children(i), expected_depth + 1);
+        acc = union_of(acc, snap.nodes(node.children(i)).bbox);
+      }
+    EXPECT_EQ(node.bbox, acc);
+    return total;
+  }
+}
+
+TEST(RTree, DebugSnapshotStructuralInvariants)
+{
+  RTree<int, 4, 2> tree;   // tiny fanout forces multiple levels
+  for (int i = 0; i < 200; ++i)
+    tree.insert(rect(i, i, i + 1, i + 1), i);
+
+  const auto snap = tree.debug_snapshot();
+  ASSERT_LT(snap.root, snap.nodes.size());
+  const size_t total_entries = check_snapshot_node(snap, snap.root, 0);
+  EXPECT_EQ(total_entries, tree.size());
+}
+
+TEST(RTree, DebugSnapshotSingleLeafRoot)
+{
+  RTree<int> tree;
+  tree.insert(rect(0, 0, 1, 1), 42);
+  const auto snap = tree.debug_snapshot();
+  ASSERT_EQ(snap.nodes.size(), 1u);
+  EXPECT_EQ(snap.root, 0u);
+  EXPECT_TRUE(snap.nodes(0).is_leaf);
+  EXPECT_EQ(snap.nodes(0).depth, 0u);
+  ASSERT_EQ(snap.nodes(0).entry_boxes.size(), 1u);
+  EXPECT_EQ(snap.nodes(0).bbox, rect(0, 0, 1, 1));
 }
 
 TEST(RTree, CoincidentRectangles)

--- a/Tests/tikzgeom_algorithms_test.cc
+++ b/Tests/tikzgeom_algorithms_test.cc
@@ -13,6 +13,7 @@
 
 #include <tikzgeom_algorithms.H>
 #include <tikzgeom_scene.H>
+#include <tpl_r_star_tree.H>
 
 using namespace Aleph;
 
@@ -654,6 +655,61 @@ TEST(TikzGeomAlgorithmsTest, VisualizeAABBTreeAndQuery)
   const std::string result = output.str();
   EXPECT_NE(result.find("draw=red"), std::string::npos);
   EXPECT_FALSE(has_nan_or_inf(result));
+}
+
+TEST(TikzGeomAlgorithmsTest, VisualizeRTreeAndQuery)
+{
+  RTree<int, 4, 2> tree;
+  tree.insert(Rectangle(0, 0, 5, 5), 0);
+  tree.insert(Rectangle(3, 3, 8, 8), 1);
+  tree.insert(Rectangle(10, 10, 15, 15), 2);
+
+  Tikz_Plane plane(180, 110);
+  const auto viz = visualize_rtree_query(plane, tree, Rectangle(2, 2, 6, 6));
+
+  EXPECT_GT(viz.snapshot.nodes.size(), 0U);
+  EXPECT_GT(viz.query_hit_boxes.size(), 0U);
+
+  std::ostringstream output;
+  plane.draw(output);
+  const std::string result = output.str();
+  EXPECT_NE(result.find("draw=red"), std::string::npos);
+  EXPECT_FALSE(has_nan_or_inf(result));
+}
+
+TEST(TikzGeomAlgorithmsTest, VisualizeRStarTreeAndQuery)
+{
+  RStarTree<int, 4, 2> tree;
+  tree.insert(Rectangle(0, 0, 5, 5), 0);
+  tree.insert(Rectangle(3, 3, 8, 8), 1);
+  tree.insert(Rectangle(10, 10, 15, 15), 2);
+
+  Tikz_Plane plane(180, 110);
+  const auto viz = visualize_rtree_query(plane, tree, Rectangle(2, 2, 6, 6));
+
+  EXPECT_GT(viz.snapshot.nodes.size(), 0U);
+  EXPECT_GT(viz.query_hit_boxes.size(), 0U);
+
+  std::ostringstream output;
+  plane.draw(output);
+  const std::string result = output.str();
+  EXPECT_NE(result.find("draw=red"), std::string::npos);
+  EXPECT_FALSE(has_nan_or_inf(result));
+}
+
+TEST(TikzGeomAlgorithmsTest, VisualizeRTreeWithoutQuery)
+{
+  RTree<int, 4, 2> tree;
+  for (int i = 0; i < 20; ++i)
+    tree.insert(Rectangle(i, i, i + 2, i + 2), i);
+
+  Tikz_Plane plane(180, 110);
+  const auto snapshot = visualize_rtree(plane, tree);
+  EXPECT_GT(snapshot.nodes.size(), 0U);
+
+  std::ostringstream output;
+  plane.draw(output);
+  EXPECT_FALSE(has_nan_or_inf(output.str()));
 }
 
 TEST(TikzGeomAlgorithmsTest, VisualizeShortestPathWithPortals)

--- a/tikzgeom.H
+++ b/tikzgeom.H
@@ -44,12 +44,12 @@
 # include <type_traits>
 # include <utility>
 # include <variant>
-# include <vector>
 
 # include "line.H"
 # include "point.H"
 # include "polygon.H"
 # include "tpl_array.H"
+# include "tpl_sort_utils.H"
 
 namespace Aleph
 {
@@ -164,8 +164,8 @@ namespace Aleph
    */
   struct Tikz_Polyline
   {
-    std::vector<Point> vertices; ///< Ordered vertices.
-    bool closed = false;         ///< Whether to close the polyline.
+    Array<Point> vertices; ///< Ordered vertices.
+    bool closed = false;   ///< Whether to close the polyline.
   };
 
   /** @brief Create a basic draw style with a custom color. */
@@ -283,10 +283,10 @@ namespace Aleph
       Tikz_Style style;
     };
 
-    std::vector<Legend_Entry> legend_entries_;
+    Array<Legend_Entry> legend_entries_;
     std::map<std::string, Tikz_Style> tikz_style_defs_;
 
-    std::vector<Styled_Object> objects_;
+    Array<Styled_Object> objects_;
     size_t next_order_ = 0;
 
     [[nodiscard]] static std::string fmt_double(const double v)
@@ -709,17 +709,17 @@ namespace Aleph
 
     template <typename Out>
     void draw_polyline(Out & output,
-                       const std::vector<Point> & vertices,
+                       const Array<Point> & vertices,
                        const bool closed,
                        const Tikz_Style & style,
                        const Geom_Box & box, const Mapping & map) const
     {
-      if (vertices.empty())
+      if (vertices.is_empty())
         return;
 
       if (vertices.size() == 1)
         {
-          draw_point(vertices.front(), style, output, box, map);
+          draw_point(vertices.get_first(), style, output, box, map);
           return;
         }
 
@@ -746,14 +746,21 @@ namespace Aleph
     void draw_segment(const Segment & s, const Tikz_Style & style, Out & output,
                       const Geom_Box & box, const Mapping & map) const
     {
-      draw_polyline(output, {s.get_src_point(), s.get_tgt_point()}, false, style, box, map);
+      Array<Point> vertices(2);
+      vertices.append(s.get_src_point());
+      vertices.append(s.get_tgt_point());
+      draw_polyline(output, vertices, false, style, box, map);
     }
 
     template <typename Out>
     void draw_triangle(const Triangle & t, const Tikz_Style & style, Out & output,
                        const Geom_Box & box, const Mapping & map) const
     {
-      draw_polyline(output, {t.get_p1(), t.get_p2(), t.get_p3()}, true, style, box, map);
+      Array<Point> vertices(3);
+      vertices.append(t.get_p1());
+      vertices.append(t.get_p2());
+      vertices.append(t.get_p3());
+      draw_polyline(output, vertices, true, style, box, map);
     }
 
     template <typename Out>
@@ -838,10 +845,10 @@ namespace Aleph
     void draw_polygon(const Polygon & poly, const Tikz_Style & style, Out & output,
                       const Geom_Box & box, const Mapping & map) const
     {
-      std::vector<Point> vertices;
+      Array<Point> vertices;
       vertices.reserve(poly.size());
       for (Polygon::Vertex_Iterator it(poly); it.has_curr(); it.next_ne())
-        vertices.push_back(it.get_current_vertex().to_point());
+        vertices.append(it.get_current_vertex().to_point());
 
       draw_polyline(output, vertices, poly.is_closed(), style, box, map);
     }
@@ -851,10 +858,10 @@ namespace Aleph
                               Out & output, const Geom_Box & box,
                               const Mapping & map) const
     {
-      std::vector<Point> vertices;
+      Array<Point> vertices;
       vertices.reserve(poly.size());
       for (size_t i = 0; i < poly.size(); ++i)
-        vertices.push_back(poly.get_vertex(i));
+        vertices.append(poly.get_vertex(i));
 
       draw_polyline(output, vertices, true, style, box, map);
     }
@@ -863,11 +870,11 @@ namespace Aleph
     void draw_rectangle(const Rectangle & r, const Tikz_Style & style, Out & output,
                         const Geom_Box & box, const Mapping & map) const
     {
-      std::vector<Point> vertices;
+      Array<Point> vertices;
       vertices.reserve(4);
       const std::array<Point, 4> corners = r.corners();
       for (const Point & p: corners)
-        vertices.push_back(p);
+        vertices.append(p);
       draw_polyline(output, vertices, true, style, box, map);
     }
 
@@ -878,7 +885,7 @@ namespace Aleph
       if (not box.initialized)
         return;
 
-      std::vector<Point> clipped;
+      Array<Point> clipped;
       clipped.reserve(4);
 
       const auto append_if_new = [&](const Point & p)
@@ -886,7 +893,7 @@ namespace Aleph
           for (const Point & existing: clipped)
             if (existing == p)
               return;
-          clipped.push_back(p);
+          clipped.append(p);
         };
 
       const auto y_in_range = [&](const Geom_Number & y)
@@ -1062,9 +1069,9 @@ namespace Aleph
           }
     }
 
-    [[nodiscard]] std::vector<Legend_Entry> collect_legend_entries() const
+    [[nodiscard]] Array<Legend_Entry> collect_legend_entries() const
     {
-      std::vector<Legend_Entry> entries = legend_entries_;
+      Array<Legend_Entry> entries = legend_entries_;
       if (not with_auto_legend_)
         return entries;
 
@@ -1088,7 +1095,7 @@ namespace Aleph
           legend_style.fill = obj.style.fill;
           legend_style.pattern = obj.style.pattern;
           legend_style.pattern_color = obj.style.pattern_color;
-          entries.push_back({color, legend_style});
+          entries.append(Legend_Entry{color, legend_style});
           seen.insert(color);
         }
 
@@ -1098,8 +1105,8 @@ namespace Aleph
     template <typename Out>
     void draw_legend(Out & output) const
     {
-      const std::vector<Legend_Entry> entries = collect_legend_entries();
-      if (entries.empty())
+      const Array<Legend_Entry> entries = collect_legend_entries();
+      if (entries.is_empty())
         return;
 
       for (size_t i = 0; i < entries.size(); ++i)
@@ -1365,7 +1372,7 @@ namespace Aleph
     /** @brief Add a legend entry to be rendered in the top-left corner. */
     void add_legend_entry(const std::string & label, const Tikz_Style & style)
     {
-      legend_entries_.push_back({label, style});
+      legend_entries_.append(Legend_Entry{label, style});
     }
 
     /// @brief Remove user-provided legend entries.
@@ -1403,7 +1410,7 @@ namespace Aleph
     /** @brief Insert an object with explicit style/layer. */
     void put(const Object & obj, const Tikz_Style & style, const int layer)
     {
-      objects_.push_back(Styled_Object{obj, style, layer, next_order_++});
+      objects_.append(Styled_Object{obj, style, layer, next_order_++});
     }
 
     /** @brief Emit a complete `tikzpicture` with all inserted objects.
@@ -1448,17 +1455,19 @@ namespace Aleph
       draw_coordinate_grid(output, box, map);
       draw_cartesian_axis(output, box, map);
 
-      std::vector<size_t> order(objects_.size());
+      Array<size_t> order = Array<size_t>::create(objects_.size());
       for (size_t i = 0; i < objects_.size(); ++i)
-        order[i] = i;
+        order(i) = i;
 
-      std::stable_sort(order.begin(), order.end(),
-                       [&](const size_t lhs, const size_t rhs)
-                         {
-                           if (objects_[lhs].layer != objects_[rhs].layer)
-                             return objects_[lhs].layer < objects_[rhs].layer;
-                           return objects_[lhs].order < objects_[rhs].order;
-                         });
+      // objects_[...].order is a unique insertion index, so (layer, order)
+      // is a total order with no real ties: an unstable sort here yields the
+      // same result as a stable one.
+      quicksort_op(order, [&](const size_t lhs, const size_t rhs)
+        {
+          if (objects_[lhs].layer != objects_[rhs].layer)
+            return objects_[lhs].layer < objects_[rhs].layer;
+          return objects_[lhs].order < objects_[rhs].order;
+        });
 
       if (with_native_layers_)
         {
@@ -1533,7 +1542,7 @@ namespace Aleph
         const Geom_Number y = s * s * p0.get_y() +
                               Geom_Number(2) * s * t * p1.get_y() +
                               t * t * p2.get_y();
-        curve.vertices.emplace_back(x, y);
+        curve.vertices.append(Point(x, y));
       }
 
     put_in_plane(plane, curve, style, layer);
@@ -1568,7 +1577,7 @@ namespace Aleph
                               Geom_Number(3) * s2 * t * p1.get_y() +
                               Geom_Number(3) * s * t2 * p2.get_y() +
                               t2 * t * p3.get_y();
-        curve.vertices.emplace_back(x, y);
+        curve.vertices.append(Point(x, y));
       }
 
     put_in_plane(plane, curve, style, layer);

--- a/tikzgeom_algorithms.H
+++ b/tikzgeom_algorithms.H
@@ -28,2354 +28,2198 @@
   SOFTWARE.
 */
 
-# ifndef TIKZGEOM_ALGORITHMS_H
-# define TIKZGEOM_ALGORITHMS_H
+#ifndef TIKZGEOM_ALGORITHMS_H
+#define TIKZGEOM_ALGORITHMS_H
 
-# include "geom_algorithms.H"
-# include "tikzgeom.H"
+#include "geom_algorithms.H"
+#include "tikzgeom.H"
+#include "tpl_r_tree.H"
 
-namespace Aleph
+namespace Aleph {
+namespace detail {
+inline std::string tikz_palette_color(const size_t idx)
 {
-  namespace detail
+  static const char *colors[] = {"blue!20",    "orange!25", "green!20", "red!20",  "cyan!22",
+                                 "magenta!20", "yellow!28", "teal!22",  "lime!24", "brown!20"};
+  static constexpr size_t kNumColors = sizeof(colors) / sizeof(colors[0]);
+  return colors[idx % kNumColors];
+}
+
+struct SPP_ITri
+{
+  size_t v[3];
+  size_t adj[3];
+};
+
+struct SPP_Portal
+{
+  Point left;
+  Point right;
+};
+
+constexpr size_t SPP_NONE = ~static_cast<size_t>(0);
+
+[[nodiscard]] inline size_t spp_find_index(const Array<Point> &pts, const Point &p)
+{
+  for (size_t i = 0; i < pts.size(); ++i)
+    if (pts(i) == p)
+      return i;
+  return SPP_NONE;
+}
+
+[[nodiscard]] inline Array<SPP_ITri> spp_build_tris(const Array<Point> &pts,
+                                                    const DynList<Triangle> &tl)
+{
+  Array<SPP_ITri> tris;
+  for (DynList<Triangle>::Iterator it(tl); it.has_curr(); it.next_ne())
+    {
+      const Triangle &t = it.get_curr();
+      SPP_ITri ti{};
+      ti.v[0] = spp_find_index(pts, t.get_p1());
+      ti.v[1] = spp_find_index(pts, t.get_p2());
+      ti.v[2] = spp_find_index(pts, t.get_p3());
+      ti.adj[0] = ti.adj[1] = ti.adj[2] = SPP_NONE;
+      tris.append(ti);
+    }
+
+  struct EdgeEntry
   {
-    inline std::string tikz_palette_color(const size_t idx)
-    {
-      static const char *colors[] =
-          {
-            "blue!20", "orange!25", "green!20", "red!20", "cyan!22",
-            "magenta!20", "yellow!28", "teal!22", "lime!24", "brown!20"
-          };
-      static constexpr size_t kNumColors = sizeof(colors) / sizeof(colors[0]);
-      return colors[idx % kNumColors];
-    }
+    size_t u;
+    size_t v;
+    size_t tri;
+    size_t local;
+  };
 
-    struct SPP_ITri
-    {
-      size_t v[3];
-      size_t adj[3];
-    };
+  Array<EdgeEntry> edges;
+  edges.reserve(tris.size() * 3);
 
-    struct SPP_Portal
-    {
-      Point left;
-      Point right;
-    };
-
-    constexpr size_t SPP_NONE = ~static_cast<size_t>(0);
-
-    [[nodiscard]] inline size_t spp_find_index(const Array<Point> & pts,
-                                               const Point & p)
-    {
-      for (size_t i = 0; i < pts.size(); ++i)
-        if (pts(i) == p) return i;
-      return SPP_NONE;
-    }
-
-    [[nodiscard]] inline Array<SPP_ITri> spp_build_tris(const Array<Point> & pts,
-                                                        const DynList<Triangle> & tl)
-    {
-      Array<SPP_ITri> tris;
-      for (DynList<Triangle>::Iterator it(tl); it.has_curr(); it.next_ne())
-        {
-          const Triangle & t = it.get_curr();
-          SPP_ITri ti{};
-          ti.v[0] = spp_find_index(pts, t.get_p1());
-          ti.v[1] = spp_find_index(pts, t.get_p2());
-          ti.v[2] = spp_find_index(pts, t.get_p3());
-          ti.adj[0] = ti.adj[1] = ti.adj[2] = SPP_NONE;
-          tris.append(ti);
-        }
-
-      struct EdgeEntry
+  for (size_t ti = 0; ti < tris.size(); ++ti)
+    for (int e = 0; e < 3; ++e)
       {
-        size_t u;
-        size_t v;
-        size_t tri;
-        size_t local;
-      };
-
-      Array<EdgeEntry> edges;
-      edges.reserve(tris.size() * 3);
-
-      for (size_t ti = 0; ti < tris.size(); ++ti)
-        for (int e = 0; e < 3; ++e)
-          {
-            size_t u = tris(ti).v[(e + 1) % 3];
-            size_t v = tris(ti).v[(e + 2) % 3];
-            if (u > v)
-              std::swap(u, v);
-            edges.append(EdgeEntry{u, v, ti, static_cast<size_t>(e)});
-          }
-
-      quicksort_op(edges, [](const EdgeEntry & a, const EdgeEntry & b)
-                     {
-                       if (a.u != b.u) return a.u < b.u;
-                       if (a.v != b.v) return a.v < b.v;
-                       return a.tri < b.tri;
-                     });
-
-      for (size_t i = 0; i + 1 < edges.size(); ++i)
-        if (edges(i).u == edges(i + 1).u and edges(i).v == edges(i + 1).v)
-          {
-            const size_t t1 = edges(i).tri;
-            const size_t l1 = edges(i).local;
-            const size_t t2 = edges(i + 1).tri;
-            const size_t l2 = edges(i + 1).local;
-            tris(t1).adj[l1] = t2;
-            tris(t2).adj[l2] = t1;
-            ++i;
-          }
-
-      return tris;
-    }
-
-    [[nodiscard]] inline bool spp_point_in_triangle(const Array<Point> & pts,
-                                                    const SPP_ITri & t,
-                                                    const Point & p)
-    {
-      const Orientation o0 = orientation(pts(t.v[0]), pts(t.v[1]), p);
-      const Orientation o1 = orientation(pts(t.v[1]), pts(t.v[2]), p);
-      const Orientation o2 = orientation(pts(t.v[2]), pts(t.v[0]), p);
-      const bool has_cw = o0 == Orientation::CW or o1 == Orientation::CW
-                          or o2 == Orientation::CW;
-      const bool has_ccw = o0 == Orientation::CCW or o1 == Orientation::CCW
-                           or o2 == Orientation::CCW;
-      return not (has_cw and has_ccw);
-    }
-
-    [[nodiscard]] inline size_t spp_find_tri(const Array<Point> & pts,
-                                             const Array<SPP_ITri> & tris,
-                                             const Point & p)
-    {
-      for (size_t i = 0; i < tris.size(); ++i)
-        if (spp_point_in_triangle(pts, tris(i), p))
-          return i;
-      return SPP_NONE;
-    }
-
-    [[nodiscard]] inline Array<size_t> spp_find_sleeve(const Array<SPP_ITri> & tris,
-                                                       const size_t src,
-                                                       const size_t dst)
-    {
-      if (src == dst)
-        {
-          Array<size_t> s;
-          s.append(src);
-          return s;
-        }
-
-      Array<size_t> parent;
-      parent.reserve(tris.size());
-      for (size_t i = 0; i < tris.size(); ++i)
-        parent.append(SPP_NONE);
-      parent(src) = src;
-
-      DynList<size_t> queue;
-      queue.append(src);
-
-      while (not queue.is_empty())
-        {
-          const size_t cur = queue.remove_first();
-          if (cur == dst)
-            break;
-
-          for (unsigned long nb: tris(cur).adj)
-            if (nb != SPP_NONE and parent(nb) == SPP_NONE)
-              {
-                parent(nb) = cur;
-                queue.append(nb);
-              }
-        }
-
-      Array<size_t> path;
-      if (parent(dst) == SPP_NONE)
-        return path;
-
-      for (size_t cur = dst; cur != src; cur = parent(cur))
-        path.append(cur);
-      path.append(src);
-
-      for (size_t i = 0; i < path.size() / 2; ++i)
-        std::swap(path(i), path(path.size() - 1 - i));
-
-      return path;
-    }
-
-    [[nodiscard]] inline Geom_Number spp_cross(const Point & a,
-                                               const Point & b,
-                                               const Point & c)
-    {
-      return (b.get_x() - a.get_x()) * (c.get_y() - a.get_y()) -
-             (b.get_y() - a.get_y()) * (c.get_x() - a.get_x());
-    }
-
-    [[nodiscard]] inline Array<SPP_Portal>
-    shortest_path_portals(const Polygon & polygon,
-                          const Point & source,
-                          const Point & target)
-    {
-      ah_domain_error_if(not polygon.is_closed()) << "Polygon must be closed";
-      ah_domain_error_if(polygon.size() < 3) << "Polygon must have >= 3 vertices";
-      ah_domain_error_if(not PointInPolygonWinding::contains(polygon, source))
-        << "Source must be inside the polygon";
-      ah_domain_error_if(not PointInPolygonWinding::contains(polygon, target))
-        << "Target must be inside the polygon";
-
-      Array<SPP_Portal> portals;
-      if (source == target)
-        {
-          portals.append(SPP_Portal{source, source});
-          return portals;
-        } {
-        const Segment seg(source, target);
-        bool blocked = false;
-        for (Polygon::Segment_Iterator it(polygon); it.has_curr() and not blocked; it.next_ne())
-          if (const Segment edge = it.get_current_segment();
-            seg.intersects_properly_with(edge))
-            blocked = true;
-        if (not blocked)
-          {
-            portals.append(SPP_Portal{source, source});
-            portals.append(SPP_Portal{target, target});
-            return portals;
-          }
+        size_t u = tris(ti).v[(e + 1) % 3];
+        size_t v = tris(ti).v[(e + 2) % 3];
+        if (u > v)
+          std::swap(u, v);
+        edges.append(EdgeEntry{u, v, ti, static_cast<size_t>(e)});
       }
 
-      Array<Point> pts;
-      for (Polygon::Vertex_Iterator it(polygon); it.has_curr(); it.next_ne())
-        pts.append(it.get_current_vertex());
+  quicksort_op(edges, [](const EdgeEntry &a, const EdgeEntry &b)
+    {
+      if (a.u != b.u)
+        return a.u < b.u;
+      if (a.v != b.v)
+        return a.v < b.v;
+      return a.tri < b.tri;
+    });
 
-      CuttingEarsTriangulation triangulator;
-      const DynList<Triangle> tri_list = triangulator(polygon);
+  for (size_t i = 0; i + 1 < edges.size(); ++i)
+    if (edges(i).u == edges(i + 1).u and edges(i).v == edges(i + 1).v)
+      {
+        const size_t t1 = edges(i).tri;
+        const size_t l1 = edges(i).local;
+        const size_t t2 = edges(i + 1).tri;
+        const size_t l2 = edges(i + 1).local;
+        tris(t1).adj[l1] = t2;
+        tris(t2).adj[l2] = t1;
+        ++i;
+      }
 
-      ah_domain_error_if(tri_list.is_empty()) << "Triangulation failed";
+  return tris;
+}
 
-      const Array<SPP_ITri> tris = spp_build_tris(pts, tri_list);
-      const size_t src_t = spp_find_tri(pts, tris, source);
-      const size_t dst_t = spp_find_tri(pts, tris, target);
+[[nodiscard]] inline bool spp_point_in_triangle(const Array<Point> &pts, const SPP_ITri &t,
+                                                const Point &p)
+{
+  const Orientation o0 = orientation(pts(t.v[0]), pts(t.v[1]), p);
+  const Orientation o1 = orientation(pts(t.v[1]), pts(t.v[2]), p);
+  const Orientation o2 = orientation(pts(t.v[2]), pts(t.v[0]), p);
+  const bool has_cw = o0 == Orientation::CW or o1 == Orientation::CW or o2 == Orientation::CW;
+  const bool has_ccw = o0 == Orientation::CCW or o1 == Orientation::CCW or o2 == Orientation::CCW;
+  return not (has_cw and has_ccw);
+}
 
-      ah_domain_error_if(src_t == SPP_NONE) << "Could not locate source in triangulation";
-      ah_domain_error_if(dst_t == SPP_NONE) << "Could not locate target in triangulation";
+[[nodiscard]] inline size_t spp_find_tri(const Array<Point> &pts, const Array<SPP_ITri> &tris,
+                                         const Point &p)
+{
+  for (size_t i = 0; i < tris.size(); ++i)
+    if (spp_point_in_triangle(pts, tris(i), p))
+      return i;
+  return SPP_NONE;
+}
 
-      const Array<size_t> sleeve = spp_find_sleeve(tris, src_t, dst_t);
+[[nodiscard]] inline Array<size_t> spp_find_sleeve(const Array<SPP_ITri> &tris, const size_t src,
+                                                   const size_t dst)
+{
+  if (src == dst)
+    {
+      Array<size_t> s;
+      s.append(src);
+      return s;
+    }
 
+  Array<size_t> parent;
+  parent.reserve(tris.size());
+  for (size_t i = 0; i < tris.size(); ++i)
+    parent.append(SPP_NONE);
+  parent(src) = src;
+
+  DynList<size_t> queue;
+  queue.append(src);
+
+  while (not queue.is_empty())
+    {
+      const size_t cur = queue.remove_first();
+      if (cur == dst)
+        break;
+
+      for (unsigned long nb : tris(cur).adj)
+        if (nb != SPP_NONE and parent(nb) == SPP_NONE)
+          {
+            parent(nb) = cur;
+            queue.append(nb);
+          }
+    }
+
+  Array<size_t> path;
+  if (parent(dst) == SPP_NONE)
+    return path;
+
+  for (size_t cur = dst; cur != src; cur = parent(cur))
+    path.append(cur);
+  path.append(src);
+
+  for (size_t i = 0; i < path.size() / 2; ++i)
+    std::swap(path(i), path(path.size() - 1 - i));
+
+  return path;
+}
+
+[[nodiscard]] inline Geom_Number spp_cross(const Point &a, const Point &b, const Point &c)
+{
+  return (b.get_x() - a.get_x()) * (c.get_y() - a.get_y()) -
+    (b.get_y() - a.get_y()) * (c.get_x() - a.get_x());
+}
+
+[[nodiscard]] inline Array<SPP_Portal> shortest_path_portals(const Polygon &polygon,
+                                                             const Point &source, const Point &target)
+{
+  ah_domain_error_if(not polygon.is_closed()) << "Polygon must be closed";
+  ah_domain_error_if(polygon.size() < 3) << "Polygon must have >= 3 vertices";
+  ah_domain_error_if(not PointInPolygonWinding::contains(polygon, source))
+    << "Source must be inside the polygon";
+  ah_domain_error_if(not PointInPolygonWinding::contains(polygon, target))
+    << "Target must be inside the polygon";
+
+  Array<SPP_Portal> portals;
+  if (source == target)
+    {
       portals.append(SPP_Portal{source, source});
+      return portals;
+    }
+  {
+    const Segment seg(source, target);
+    bool blocked = false;
+    for (Polygon::Segment_Iterator it(polygon); it.has_curr() and not blocked; it.next_ne())
+      if (const Segment edge = it.get_current_segment(); seg.intersects_properly_with(edge))
+        blocked = true;
+    if (not blocked)
+      {
+        portals.append(SPP_Portal{source, source});
+        portals.append(SPP_Portal{target, target});
+        return portals;
+      }
+  }
 
-      if (sleeve.size() <= 1)
-        {
-          portals.append(SPP_Portal{target, target});
-          return portals;
-        }
+  Array<Point> pts;
+  for (Polygon::Vertex_Iterator it(polygon); it.has_curr(); it.next_ne())
+    pts.append(it.get_current_vertex());
 
-      for (size_t i = 0; i + 1 < sleeve.size(); ++i)
-        {
-          size_t s0 = 0, s1 = 0;
-          size_t v_prev = 0;
+  CuttingEarsTriangulation triangulator;
+  const DynList<Triangle> tri_list = triangulator(polygon);
 
-          int sc = 0;
-          bool found[3] = {false, false, false};
-          for (int a = 0; a < 3; ++a)
-            for (const unsigned long b: tris(sleeve(i + 1)).v)
-              if (tris(sleeve(i)).v[a] == b)
-                {
-                  found[a] = true;
-                  break;
-                }
+  ah_domain_error_if(tri_list.is_empty()) << "Triangulation failed";
 
-          for (int a = 0; a < 3; ++a)
-            if (found[a])
-              {
-                if (sc == 0) s0 = tris(sleeve(i)).v[a];
-                else s1 = tris(sleeve(i)).v[a];
-                ++sc;
-              }
-            else
-              v_prev = tris(sleeve(i)).v[a];
+  const Array<SPP_ITri> tris = spp_build_tris(pts, tri_list);
+  const size_t src_t = spp_find_tri(pts, tris, source);
+  const size_t dst_t = spp_find_tri(pts, tris, target);
 
-          const Geom_Number c = spp_cross(pts(v_prev), pts(s0), pts(s1));
-          if (c < 0)
-            portals.append(SPP_Portal{pts(s0), pts(s1)});
-          else
-            portals.append(SPP_Portal{pts(s1), pts(s0)});
-        }
+  ah_domain_error_if(src_t == SPP_NONE) << "Could not locate source in triangulation";
+  ah_domain_error_if(dst_t == SPP_NONE) << "Could not locate target in triangulation";
 
+  const Array<size_t> sleeve = spp_find_sleeve(tris, src_t, dst_t);
+
+  portals.append(SPP_Portal{source, source});
+
+  if (sleeve.size() <= 1)
+    {
       portals.append(SPP_Portal{target, target});
       return portals;
     }
-  } // namespace detail
 
-  /** @file tikzgeom_algorithms.H
-   *  @ingroup Geometry
-   *  @brief Helpers to visualize computational-geometry algorithm results in TikZ.
-   *
-   *  This header builds on top of `tikzgeom.H` and provides convenience
-   *  functions for common outputs:
-   *  - point clouds
-   *  - convex hull overlays
-   *  - polygon intersection / boolean results
-   *  - Delaunay triangulation
-   *  - Voronoi and Power diagrams
-   */
+  for (size_t i = 0; i + 1 < sleeve.size(); ++i)
+    {
+      size_t s0 = 0, s1 = 0;
+      size_t v_prev = 0;
 
-  /** @brief Creates a style optimized for point clouds.
-   *
-   *  Generates a @ref Tikz_Style where points are drawn as small filled circles.
-   *  The draw and fill colors are set to the same value.
-   *
-   *  @param color The color for the points.
-   *  @param opacity The opacity for the points (0.0 to 1.0). -1 means default.
-   *  @return A @ref Tikz_Style suitable for `put_points`.
-   */
-  inline Tikz_Style tikz_points_style(const std::string & color = "black",
-                                      const double opacity = -1.0)
-  {
-    Tikz_Style s;
-    s.draw_color = color;
-    s.fill_color = color;
-    s.opacity = opacity;
-    return s;
-  }
+      int sc = 0;
+      bool found[3] = {false, false, false};
+      for (int a = 0; a < 3; ++a)
+        for (const unsigned long b : tris(sleeve(i + 1)).v)
+          if (tris(sleeve(i)).v[a] == b)
+            {
+              found[a] = true;
+              break;
+            }
 
-  /** @brief Creates a style optimized for wireframe segments and polygons.
-   *
-   *  @param color The stroke color.
-   *  @param dashed Whether to use a dashed line style.
-   *  @param with_arrow Whether to add an arrowhead to segments.
-   *  @return A @ref Tikz_Style suitable for drawing outlines.
-   */
-  inline Tikz_Style tikz_wire_style(const std::string & color = "black",
-                                    const bool dashed = false,
-                                    const bool with_arrow = false)
-  {
-    Tikz_Style s;
-    s.draw_color = color;
-    s.dashed = dashed;
-    s.with_arrow = with_arrow;
-    return s;
-  }
+      for (int a = 0; a < 3; ++a)
+        if (found[a])
+          {
+            if (sc == 0)
+              s0 = tris(sleeve(i)).v[a];
+            else
+              s1 = tris(sleeve(i)).v[a];
+            ++sc;
+          }
+        else
+          v_prev = tris(sleeve(i)).v[a];
 
-  /** @brief Creates a style optimized for polyline paths.
-   *
-   *  This style is intended for highlighting paths, such as the result of a
-   *  shortest-path algorithm. It defaults to a thick, solid line.
-   *
-   *  @param color The path color.
-   *  @param with_arrow Whether to add an arrowhead to the path segments.
-   *  @return A prominent @ref Tikz_Style for paths.
-   */
-  inline Tikz_Style tikz_path_style(const std::string & color = "red",
-                                    const bool with_arrow = false)
-  {
-    Tikz_Style s = tikz_wire_style(color, false, with_arrow);
-    s.thick = true;
-    return s;
-  }
-
-  /** @brief Creates a style for drawing filled polygons.
-   *
-   *  This style is used for representing areas, like polygon intersections or
-   *  Voronoi cells. It enables filling and sets an opacity for visualization.
-   *
-   *  @param draw_color The stroke color for the polygon boundary.
-   *  @param fill_color The fill color for the polygon's interior.
-   *  @param opacity The opacity of the fill (0.0 to 1.0).
-   *  @return A @ref Tikz_Style for filled shapes.
-   */
-  inline Tikz_Style tikz_area_style(const std::string & draw_color = "black",
-                                    const std::string & fill_color = "gray!25",
-                                    const double opacity = 0.6)
-  {
-    Tikz_Style s;
-    s.draw_color = draw_color;
-    s.fill_color = fill_color;
-    s.fill = true;
-    s.opacity = opacity;
-    return s;
-  }
-
-  /** @brief Inserts all points from an `Array<Point>` into the plane.
-   *
-   *  @param plane The target TikZ plane.
-   *  @param pts An array of points to insert.
-   *  @param style The style to apply to each point.
-   *  @param layer The layer on which to draw the points.
-   */
-  inline void put_points(Tikz_Plane & plane, const Array<Point> & pts,
-                         const Tikz_Style & style = tikz_points_style(),
-                         const int layer = Tikz_Plane::Layer_Default)
-  {
-    for (size_t i = 0; i < pts.size(); ++i)
-      put_in_plane(plane, pts(i), style, layer);
-  }
-
-  /** @brief Inserts all points from a `DynList<Point>` into the plane.
-   *
-   *  @param plane The target TikZ plane.
-   *  @param pts A dynamic list of points to insert.
-   *  @param style The style to apply to each point.
-   *  @param layer The layer on which to draw the points.
-   */
-  inline void put_points(Tikz_Plane & plane, const DynList<Point> & pts,
-                         const Tikz_Style & style = tikz_points_style(),
-                         const int layer = Tikz_Plane::Layer_Default)
-  {
-    for (DynList<Point>::Iterator it(pts); it.has_curr(); it.next_ne())
-      put_in_plane(plane, it.get_curr(), style, layer);
-  }
-
-  /** @brief Adds a text label to each point in an `Array<Point>`.
-   *
-   *  Labels are generated as `prefix + index`. For example, `p0`, `p1`, etc.
-   *
-   *  @param plane The target TikZ plane.
-   *  @param pts The array of points to label.
-   *  @param prefix A string prefix for each label.
-   *  @param placement The TikZ placement string (e.g., "above", "below left").
-   *  @param style The style for the text labels.
-   *  @param layer The layer on which to draw the labels.
-   */
-  inline void put_point_labels(Tikz_Plane & plane,
-                               const Array<Point> & pts,
-                               const std::string & prefix = "p",
-                               const std::string & placement = "above right",
-                               const Tikz_Style & style = make_tikz_draw_style("black"),
-                               const int layer = Tikz_Plane::Layer_Overlay)
-  {
-    for (size_t i = 0; i < pts.size(); ++i)
-      put_point_label_in_plane(plane, pts(i),
-                               prefix + std::to_string(i),
-                               placement, style, layer);
-  }
-
-  /** @brief Adds a text label to each point in a `DynList<Point>`.
-   *
-   *  Labels are generated as `prefix + index` based on iteration order.
-   *
-   *  @param plane The target TikZ plane.
-   *  @param pts The list of points to label.
-   *  @param prefix A string prefix for each label.
-   *  @param placement The TikZ placement string (e.g., "above", "below left").
-   *  @param style The style for the text labels.
-   *  @param layer The layer on which to draw the labels.
-   */
-  inline void put_point_labels(Tikz_Plane & plane,
-                               const DynList<Point> & pts,
-                               const std::string & prefix = "p",
-                               const std::string & placement = "above right",
-                               const Tikz_Style & style = make_tikz_draw_style("black"),
-                               const int layer = Tikz_Plane::Layer_Overlay)
-  {
-    size_t idx = 0;
-    for (DynList<Point>::Iterator it(pts); it.has_curr(); it.next_ne(), ++idx)
-      put_point_label_in_plane(plane, it.get_curr(),
-                               prefix + std::to_string(idx),
-                               placement, style, layer);
-  }
-
-  /** @brief Inserts all polygons from an `Array<Polygon>` into the plane.
-   *
-   *  @param plane The target TikZ plane.
-   *  @param polys An array of polygons to insert.
-   *  @param style The style to apply to each polygon.
-   *  @param layer The layer on which to draw the polygons.
-   */
-  inline void put_polygons(Tikz_Plane & plane, const Array<Polygon> & polys,
-                           const Tikz_Style & style = tikz_wire_style(),
-                           const int layer = Tikz_Plane::Layer_Default)
-  {
-    for (size_t i = 0; i < polys.size(); ++i)
-      put_in_plane(plane, polys(i), style, layer);
-  }
-
-  /** @brief Inserts the vertices of a polygon as styled points.
-   *
-   *  @param plane The target TikZ plane.
-   *  @param poly The polygon whose vertices are to be drawn.
-   *  @param style The style for the vertex points.
-   *  @param layer The layer on which to draw the points.
-   */
-  inline void put_polygon_vertices(Tikz_Plane & plane, const Polygon & poly,
-                                   const Tikz_Style & style = tikz_points_style(),
-                                   const int layer = Tikz_Plane::Layer_Overlay)
-  {
-    for (Polygon::Vertex_Iterator it(poly); it.has_curr(); it.next_ne())
-      put_in_plane(plane, it.get_current_vertex().to_point(), style, layer);
-  }
-
-  /** @brief Inserts the vertices of a regular polygon as styled points.
-   *
-   *  @param plane The target TikZ plane.
-   *  @param poly The regular polygon whose vertices are to be drawn.
-   *  @param style The style for the vertex points.
-   *  @param layer The layer on which to draw the points.
-   */
-  inline void put_polygon_vertices(Tikz_Plane & plane, const Regular_Polygon & poly,
-                                   const Tikz_Style & style = tikz_points_style(),
-                                   const int layer = Tikz_Plane::Layer_Overlay)
-  {
-    for (size_t i = 0; i < poly.size(); ++i)
-      put_in_plane(plane, poly.get_vertex(i), style, layer);
-  }
-
-  /** @brief Constructs a `Polygon` from an ordered array of vertices.
-   *
-   *  @param vertices An array of `Point`s in the desired order.
-   *  @param close If true, closes the polygon by adding an edge from the last
-   *         vertex back to the first.
-   *  @return The constructed `Polygon`.
-   */
-  inline Polygon polygon_from_vertices(const Array<Point> & vertices,
-                                       const bool close = true)
-  {
-    Polygon poly;
-    for (size_t i = 0; i < vertices.size(); ++i)
-      poly.add_vertex(vertices(i));
-
-    if (close and poly.size() >= 3)
-      poly.close();
-
-    return poly;
-  }
-
-  /** @brief Constructs a `Polygon` from a list of indices into a vertex array.
-   *
-   *  This is useful for algorithms that return faces or boundaries as lists of
-   *  indices (e.g., `SegmentArrangement`).
-   *
-   *  @param vertices The master array of `Point` vertices.
-   *  @param indices The indices of the vertices that form this polygon.
-   *  @param close If true, closes the polygon.
-   *  @return The constructed `Polygon`.
-   */
-  inline Polygon polygon_from_vertex_indices(const Array<Point> & vertices,
-                                             const DynList<size_t> & indices,
-                                             const bool close = true)
-  {
-    Polygon poly;
-    for (DynList<size_t>::Iterator it(indices); it.has_curr(); it.next_ne())
-      if (const size_t idx = it.get_curr(); idx < vertices.size())
-        poly.add_vertex(vertices(idx));
-
-    if (close and poly.size() >= 3)
-      poly.close();
-
-    return poly;
-  }
-
-  /** @brief Runs a convex hull algorithm and visualizes the result.
-   *
-   *  This helper function takes a list of points, computes their convex hull
-   *  using the provided algorithm object, and inserts both the original points
-   *  and the resulting hull polygon into the `Tikz_Plane`.
-   *
-   *  @tparam HullAlgorithm The type of the convex hull algorithm object. It must
-   *          be a callable that takes a `DynList<Point>` and returns a `Polygon`.
-   *  @param plane The target TikZ plane.
-   *  @param points The input point cloud.
-   *  @param hull_algorithm An instance of the hull algorithm to use.
-   *  @param point_style The style for the input points.
-   *  @param hull_style The style for the convex hull polygon's outline.
-   *  @param hull_vertex_style The style for the vertices of the hull.
-   *  @param point_layer The layer for the input points.
-   *  @param hull_layer The layer for the hull polygon and its vertices.
-   *  @param draw_hull_vertices If true, the vertices of the hull are drawn.
-   *  @return The computed convex hull `Polygon`.
-   */
-  template <typename HullAlgorithm>
-  Polygon visualize_convex_hull(Tikz_Plane & plane,
-                                const DynList<Point> & points,
-                                const HullAlgorithm & hull_algorithm,
-                                const Tikz_Style & point_style =
-                                    tikz_points_style("black", 0.6),
-                                const Tikz_Style & hull_style =
-                                    tikz_wire_style("red"),
-                                const Tikz_Style & hull_vertex_style =
-                                    tikz_points_style("red"),
-                                const int point_layer = Tikz_Plane::Layer_Default,
-                                const int hull_layer = Tikz_Plane::Layer_Foreground,
-                                const bool draw_hull_vertices = true)
-  {
-    put_points(plane, points, point_style, point_layer);
-
-    Polygon hull = hull_algorithm(points);
-    if (hull.size() > 0)
-      put_in_plane(plane, hull, hull_style, hull_layer);
-
-    if (draw_hull_vertices and hull.size() > 0)
-      put_polygon_vertices(plane, hull, hull_vertex_style, hull_layer + 1);
-
-    return hull;
-  }
-
-  /** @brief Visualizes the intersection of two convex polygons.
-   *
-   *  Draws the subject and clip polygons with semi-transparent fills and
-   *  overlays their intersection with a distinct, solid fill.
-   *
-   *  @param plane The target TikZ plane.
-   *  @param subject The subject polygon.
-   *  @param clip The clipping polygon.
-   *  @param intersection_algorithm The algorithm to use for intersection.
-   *  @param subject_style The style for the subject polygon.
-   *  @param clip_style The style for the clip polygon.
-   *  @param result_style The style for the resulting intersection polygon.
-   *  @param input_layer The base layer for the input polygons.
-   *  @param result_layer The layer for the intersection polygon.
-   *  @return The `Polygon` representing the intersection.
-   */
-  inline Polygon visualize_convex_intersection(
-      Tikz_Plane & plane,
-      const Polygon & subject,
-      const Polygon & clip,
-      const ConvexPolygonIntersectionBasic & intersection_algorithm = {},
-      const Tikz_Style & subject_style = tikz_area_style("blue", "blue!15", 0.45),
-      const Tikz_Style & clip_style = tikz_area_style("orange", "orange!20", 0.45),
-      const Tikz_Style & result_style = tikz_area_style("red", "red!30", 0.60),
-      const int input_layer = Tikz_Plane::Layer_Default,
-      const int result_layer = Tikz_Plane::Layer_Foreground)
-  {
-    put_in_plane(plane, subject, subject_style, input_layer);
-    put_in_plane(plane, clip, clip_style, input_layer + 1);
-
-    Polygon inter = intersection_algorithm(subject, clip);
-    if (inter.size() > 0)
-      put_in_plane(plane, inter, result_style, result_layer);
-
-    return inter;
-  }
-
-  /** @brief Visualizes a boolean operation (union, intersection, difference) on two polygons.
-   *
-   *  Draws the two input polygons (`a` and `b`) with semi-transparent fills
-   *  and overlays the result of the boolean operation with a distinct style.
-   *  This function can handle non-convex polygons.
-   *
-   *  @param plane The target TikZ plane.
-   *  @param a The subject polygon.
-   *  @param b The clip polygon.
-   *  @param op The boolean operation to perform (e.g., `Op::Union`).
-   *  @param bop The boolean operations algorithm object.
-   *  @param a_style The style for polygon `a`.
-   *  @param b_style The style for polygon `b`.
-   *  @param result_style The style for the resulting polygon(s).
-   *  @param input_layer The base layer for the input polygons.
-   *  @param result_layer The layer for the resulting polygon(s).
-   *  @return An `Array<Polygon>` containing the result of the operation.
-   *          The result can be multiple disjoint polygons.
-   */
-  inline Array<Polygon> visualize_boolean_operation(
-      Tikz_Plane & plane,
-      const Polygon & a,
-      const Polygon & b,
-      const BooleanPolygonOperations::Op op,
-      const BooleanPolygonOperations & bop = {},
-      const Tikz_Style & a_style = tikz_area_style("blue", "blue!15", 0.35),
-      const Tikz_Style & b_style = tikz_area_style("green!60!black", "green!20", 0.35),
-      const Tikz_Style & result_style = tikz_area_style("red", "red!35", 0.65),
-      const int input_layer = Tikz_Plane::Layer_Default,
-      const int result_layer = Tikz_Plane::Layer_Foreground)
-  {
-    put_in_plane(plane, a, a_style, input_layer);
-    put_in_plane(plane, b, b_style, input_layer + 1);
-
-    Array<Polygon> result = bop(a, b, op);
-    put_polygons(plane, result, result_style, result_layer);
-    return result;
-  }
-
-  /** @brief Insert Delaunay triangulation as triangle outlines.
-   *
-   *  Optionally draws sites as points on top.
-   */
-  inline void put_delaunay_result(
-      Tikz_Plane & plane,
-      const DelaunayTriangulationBowyerWatson::Result & dt,
-      const Tikz_Style & triangle_style = tikz_wire_style("blue"),
-      const bool draw_sites = true,
-      const Tikz_Style & site_style = tikz_points_style("black"),
-      const int triangle_layer = Tikz_Plane::Layer_Default,
-      const int site_layer = Tikz_Plane::Layer_Foreground)
-  {
-    for (size_t i = 0; i < dt.triangles.size(); ++i)
-      {
-        const auto & tri = dt.triangles(i);
-        Triangle t(dt.sites(tri.i), dt.sites(tri.j), dt.sites(tri.k));
-        put_in_plane(plane, t, triangle_style, triangle_layer);
-      }
-
-    if (draw_sites)
-      put_points(plane, dt.sites, site_style, site_layer);
-  }
-
-  /** @brief Compute and insert Delaunay triangulation as triangle outlines. */
-  [[nodiscard]] inline DelaunayTriangulationBowyerWatson::Result
-  visualize_delaunay(
-      Tikz_Plane & plane,
-      const DynList<Point> & points,
-      const DelaunayTriangulationBowyerWatson & algorithm = {},
-      const Tikz_Style & triangle_style = tikz_wire_style("blue"),
-      const bool draw_sites = true,
-      const Tikz_Style & site_style = tikz_points_style("black"))
-  {
-    auto dt = algorithm(points);
-    put_delaunay_result(plane, dt, triangle_style, draw_sites, site_style);
-    return dt;
-  }
-
-  [[nodiscard]] inline Point ray_endpoint(const Point & src, const Point & direction,
-                                          const Geom_Number & length)
-  {
-    const Geom_Number & dx = direction.get_x();
-    const Geom_Number & dy = direction.get_y();
-    const Geom_Number n2 = dx * dx + dy * dy;
-    if (n2 == 0)
-      return src;
-
-    const Geom_Number n = square_root(n2);
-    const Geom_Number scale = length / n;
-    return {src.get_x() + dx * scale, src.get_y() + dy * scale};
-  }
-
-  /** @brief Insert Voronoi diagram structures (cells, edges, sites).
-   *
-   *  Works with `VoronoiDiagram::Result` and
-   *  `VoronoiDiagramFromDelaunay::Result`.
-   */
-  template <typename VoronoiResult>
-  void put_voronoi_result(
-      Tikz_Plane & plane,
-      const VoronoiResult & vor,
-      const bool draw_cells = false,
-      const Tikz_Style & cell_style = tikz_area_style("gray!50!black", "gray!15", 0.35),
-      const Tikz_Style & edge_style = tikz_wire_style("black"),
-      const Tikz_Style & unbounded_edge_style = tikz_wire_style("black", true, true),
-      const Tikz_Style & site_style = tikz_points_style("red"),
-      const Geom_Number & unbounded_ray_length = Geom_Number(50),
-      const int cell_layer = Tikz_Plane::Layer_Background,
-      const int edge_layer = Tikz_Plane::Layer_Default,
-      const int site_layer = Tikz_Plane::Layer_Foreground)
-  {
-    if (draw_cells)
-      for (size_t i = 0; i < vor.cells.size(); ++i)
-        {
-          const auto & cell = vor.cells(i);
-          if (not cell.bounded or cell.vertices.size() < 3)
-            continue;
-
-          Polygon poly = polygon_from_vertices(cell.vertices, true);
-          put_in_plane(plane, poly, cell_style, cell_layer);
-        }
-
-    for (size_t i = 0; i < vor.edges.size(); ++i)
-      if (const auto & e = vor.edges(i); e.unbounded)
-        {
-          const Point tgt = ray_endpoint(e.src, e.direction, unbounded_ray_length);
-          put_in_plane(plane, Segment(e.src, tgt), unbounded_edge_style, edge_layer);
-        }
+      const Geom_Number c = spp_cross(pts(v_prev), pts(s0), pts(s1));
+      if (c < 0)
+        portals.append(SPP_Portal{pts(s0), pts(s1)});
       else
-        put_in_plane(plane, Segment(e.src, e.tgt), edge_style, edge_layer);
+        portals.append(SPP_Portal{pts(s1), pts(s0)});
+    }
 
-    put_points(plane, vor.sites, site_style, site_layer);
-  }
+  portals.append(SPP_Portal{target, target});
+  return portals;
+}
+}  // namespace detail
 
-  /** @brief Compute and insert Voronoi diagram for input sites.
-   *
-   *  Returns the generated Voronoi result so callers can reuse it.
-   */
-  inline VoronoiDiagram::Result visualize_voronoi(
-      Tikz_Plane & plane,
-      const DynList<Point> & sites,
-      const VoronoiDiagram & algorithm = {},
-      const bool draw_cells = false,
-      const Tikz_Style & cell_style = tikz_area_style("gray!50!black", "gray!15", 0.35),
-      const Tikz_Style & edge_style = tikz_wire_style("black"),
-      const Tikz_Style & unbounded_edge_style = tikz_wire_style("black", true, true),
-      const Tikz_Style & site_style = tikz_points_style("red"),
-      const Geom_Number & unbounded_ray_length = Geom_Number(50))
-  {
-    VoronoiDiagram::Result vor = algorithm(sites);
-    put_voronoi_result(plane, vor,
-                       draw_cells, cell_style,
-                       edge_style, unbounded_edge_style, site_style,
-                       unbounded_ray_length,
-                       Tikz_Plane::Layer_Background,
-                       Tikz_Plane::Layer_Default,
-                       Tikz_Plane::Layer_Foreground);
-    return vor;
-  }
+/** @file tikzgeom_algorithms.H
+ *  @ingroup Geometry
+ *  @brief Helpers to visualize computational-geometry algorithm results in TikZ.
+ *
+ *  This header builds on top of `tikzgeom.H` and provides convenience
+ *  functions for common outputs:
+ *  - point clouds
+ *  - convex hull overlays
+ *  - polygon intersection / boolean results
+ *  - Delaunay triangulation
+ *  - Voronoi and Power diagrams
+ */
 
-  /** @brief Insert Power diagram structures (cells, edges, weighted sites). */
-  inline void put_power_diagram_result(
-      Tikz_Plane & plane,
-      const PowerDiagram::Result & pd,
-      const bool draw_cells = true,
-      const Tikz_Style & cell_style = tikz_area_style("violet", "violet!18", 0.35),
-      const Tikz_Style & edge_style = tikz_wire_style("violet"),
-      const Tikz_Style & site_style = tikz_points_style("purple"),
-      const int cell_layer = Tikz_Plane::Layer_Background,
-      const int edge_layer = Tikz_Plane::Layer_Default,
-      const int site_layer = Tikz_Plane::Layer_Foreground)
-  {
-    if (draw_cells)
-      for (size_t i = 0; i < pd.cells.size(); ++i)
+/** @brief Creates a style optimized for point clouds.
+ *
+ *  Generates a @ref Tikz_Style where points are drawn as small filled circles.
+ *  The draw and fill colors are set to the same value.
+ *
+ *  @param color The color for the points.
+ *  @param opacity The opacity for the points (0.0 to 1.0). -1 means default.
+ *  @return A @ref Tikz_Style suitable for `put_points`.
+ */
+inline Tikz_Style tikz_points_style(const std::string &color = "black", const double opacity = -1.0)
+{
+  Tikz_Style s;
+  s.draw_color = color;
+  s.fill_color = color;
+  s.opacity = opacity;
+  return s;
+}
+
+/** @brief Creates a style optimized for wireframe segments and polygons.
+ *
+ *  @param color The stroke color.
+ *  @param dashed Whether to use a dashed line style.
+ *  @param with_arrow Whether to add an arrowhead to segments.
+ *  @return A @ref Tikz_Style suitable for drawing outlines.
+ */
+inline Tikz_Style tikz_wire_style(const std::string &color = "black", const bool dashed = false,
+                                  const bool with_arrow = false)
+{
+  Tikz_Style s;
+  s.draw_color = color;
+  s.dashed = dashed;
+  s.with_arrow = with_arrow;
+  return s;
+}
+
+/** @brief Creates a style optimized for polyline paths.
+ *
+ *  This style is intended for highlighting paths, such as the result of a
+ *  shortest-path algorithm. It defaults to a thick, solid line.
+ *
+ *  @param color The path color.
+ *  @param with_arrow Whether to add an arrowhead to the path segments.
+ *  @return A prominent @ref Tikz_Style for paths.
+ */
+inline Tikz_Style tikz_path_style(const std::string &color = "red", const bool with_arrow = false)
+{
+  Tikz_Style s = tikz_wire_style(color, false, with_arrow);
+  s.thick = true;
+  return s;
+}
+
+/** @brief Creates a style for drawing filled polygons.
+ *
+ *  This style is used for representing areas, like polygon intersections or
+ *  Voronoi cells. It enables filling and sets an opacity for visualization.
+ *
+ *  @param draw_color The stroke color for the polygon boundary.
+ *  @param fill_color The fill color for the polygon's interior.
+ *  @param opacity The opacity of the fill (0.0 to 1.0).
+ *  @return A @ref Tikz_Style for filled shapes.
+ */
+inline Tikz_Style tikz_area_style(const std::string &draw_color = "black",
+                                  const std::string &fill_color = "gray!25",
+                                  const double opacity = 0.6)
+{
+  Tikz_Style s;
+  s.draw_color = draw_color;
+  s.fill_color = fill_color;
+  s.fill = true;
+  s.opacity = opacity;
+  return s;
+}
+
+/** @brief Inserts all points from an `Array<Point>` into the plane.
+ *
+ *  @param plane The target TikZ plane.
+ *  @param pts An array of points to insert.
+ *  @param style The style to apply to each point.
+ *  @param layer The layer on which to draw the points.
+ */
+inline void put_points(Tikz_Plane &plane, const Array<Point> &pts,
+                       const Tikz_Style &style = tikz_points_style(),
+                       const int layer = Tikz_Plane::Layer_Default)
+{
+  for (size_t i = 0; i < pts.size(); ++i)
+    put_in_plane(plane, pts(i), style, layer);
+}
+
+/** @brief Inserts all points from a `DynList<Point>` into the plane.
+ *
+ *  @param plane The target TikZ plane.
+ *  @param pts A dynamic list of points to insert.
+ *  @param style The style to apply to each point.
+ *  @param layer The layer on which to draw the points.
+ */
+inline void put_points(Tikz_Plane &plane, const DynList<Point> &pts,
+                       const Tikz_Style &style = tikz_points_style(),
+                       const int layer = Tikz_Plane::Layer_Default)
+{
+  for (DynList<Point>::Iterator it(pts); it.has_curr(); it.next_ne())
+    put_in_plane(plane, it.get_curr(), style, layer);
+}
+
+/** @brief Adds a text label to each point in an `Array<Point>`.
+ *
+ *  Labels are generated as `prefix + index`. For example, `p0`, `p1`, etc.
+ *
+ *  @param plane The target TikZ plane.
+ *  @param pts The array of points to label.
+ *  @param prefix A string prefix for each label.
+ *  @param placement The TikZ placement string (e.g., "above", "below left").
+ *  @param style The style for the text labels.
+ *  @param layer The layer on which to draw the labels.
+ */
+inline void put_point_labels(Tikz_Plane &plane, const Array<Point> &pts,
+                             const std::string &prefix = "p",
+                             const std::string &placement = "above right",
+                             const Tikz_Style &style = make_tikz_draw_style("black"),
+                             const int layer = Tikz_Plane::Layer_Overlay)
+{
+  for (size_t i = 0; i < pts.size(); ++i)
+    put_point_label_in_plane(plane, pts(i), prefix + std::to_string(i), placement, style, layer);
+}
+
+/** @brief Adds a text label to each point in a `DynList<Point>`.
+ *
+ *  Labels are generated as `prefix + index` based on iteration order.
+ *
+ *  @param plane The target TikZ plane.
+ *  @param pts The list of points to label.
+ *  @param prefix A string prefix for each label.
+ *  @param placement The TikZ placement string (e.g., "above", "below left").
+ *  @param style The style for the text labels.
+ *  @param layer The layer on which to draw the labels.
+ */
+inline void put_point_labels(Tikz_Plane &plane, const DynList<Point> &pts,
+                             const std::string &prefix = "p",
+                             const std::string &placement = "above right",
+                             const Tikz_Style &style = make_tikz_draw_style("black"),
+                             const int layer = Tikz_Plane::Layer_Overlay)
+{
+  size_t idx = 0;
+  for (DynList<Point>::Iterator it(pts); it.has_curr(); it.next_ne(), ++idx)
+    put_point_label_in_plane(plane, it.get_curr(), prefix + std::to_string(idx), placement, style,
+                             layer);
+}
+
+/** @brief Inserts all polygons from an `Array<Polygon>` into the plane.
+ *
+ *  @param plane The target TikZ plane.
+ *  @param polys An array of polygons to insert.
+ *  @param style The style to apply to each polygon.
+ *  @param layer The layer on which to draw the polygons.
+ */
+inline void put_polygons(Tikz_Plane &plane, const Array<Polygon> &polys,
+                         const Tikz_Style &style = tikz_wire_style(),
+                         const int layer = Tikz_Plane::Layer_Default)
+{
+  for (size_t i = 0; i < polys.size(); ++i)
+    put_in_plane(plane, polys(i), style, layer);
+}
+
+/** @brief Inserts the vertices of a polygon as styled points.
+ *
+ *  @param plane The target TikZ plane.
+ *  @param poly The polygon whose vertices are to be drawn.
+ *  @param style The style for the vertex points.
+ *  @param layer The layer on which to draw the points.
+ */
+inline void put_polygon_vertices(Tikz_Plane &plane, const Polygon &poly,
+                                 const Tikz_Style &style = tikz_points_style(),
+                                 const int layer = Tikz_Plane::Layer_Overlay)
+{
+  for (Polygon::Vertex_Iterator it(poly); it.has_curr(); it.next_ne())
+    put_in_plane(plane, it.get_current_vertex().to_point(), style, layer);
+}
+
+/** @brief Inserts the vertices of a regular polygon as styled points.
+ *
+ *  @param plane The target TikZ plane.
+ *  @param poly The regular polygon whose vertices are to be drawn.
+ *  @param style The style for the vertex points.
+ *  @param layer The layer on which to draw the points.
+ */
+inline void put_polygon_vertices(Tikz_Plane &plane, const Regular_Polygon &poly,
+                                 const Tikz_Style &style = tikz_points_style(),
+                                 const int layer = Tikz_Plane::Layer_Overlay)
+{
+  for (size_t i = 0; i < poly.size(); ++i)
+    put_in_plane(plane, poly.get_vertex(i), style, layer);
+}
+
+/** @brief Constructs a `Polygon` from an ordered array of vertices.
+ *
+ *  @param vertices An array of `Point`s in the desired order.
+ *  @param close If true, closes the polygon by adding an edge from the last
+ *         vertex back to the first.
+ *  @return The constructed `Polygon`.
+ */
+inline Polygon polygon_from_vertices(const Array<Point> &vertices, const bool close = true)
+{
+  Polygon poly;
+  for (size_t i = 0; i < vertices.size(); ++i)
+    poly.add_vertex(vertices(i));
+
+  if (close and poly.size() >= 3)
+    poly.close();
+
+  return poly;
+}
+
+/** @brief Constructs a `Polygon` from a list of indices into a vertex array.
+ *
+ *  This is useful for algorithms that return faces or boundaries as lists of
+ *  indices (e.g., `SegmentArrangement`).
+ *
+ *  @param vertices The master array of `Point` vertices.
+ *  @param indices The indices of the vertices that form this polygon.
+ *  @param close If true, closes the polygon.
+ *  @return The constructed `Polygon`.
+ */
+inline Polygon polygon_from_vertex_indices(const Array<Point> &vertices,
+                                           const DynList<size_t> &indices, const bool close = true)
+{
+  Polygon poly;
+  for (DynList<size_t>::Iterator it(indices); it.has_curr(); it.next_ne())
+    if (const size_t idx = it.get_curr(); idx < vertices.size())
+      poly.add_vertex(vertices(idx));
+
+  if (close and poly.size() >= 3)
+    poly.close();
+
+  return poly;
+}
+
+/** @brief Runs a convex hull algorithm and visualizes the result.
+ *
+ *  This helper function takes a list of points, computes their convex hull
+ *  using the provided algorithm object, and inserts both the original points
+ *  and the resulting hull polygon into the `Tikz_Plane`.
+ *
+ *  @tparam HullAlgorithm The type of the convex hull algorithm object. It must
+ *          be a callable that takes a `DynList<Point>` and returns a `Polygon`.
+ *  @param plane The target TikZ plane.
+ *  @param points The input point cloud.
+ *  @param hull_algorithm An instance of the hull algorithm to use.
+ *  @param point_style The style for the input points.
+ *  @param hull_style The style for the convex hull polygon's outline.
+ *  @param hull_vertex_style The style for the vertices of the hull.
+ *  @param point_layer The layer for the input points.
+ *  @param hull_layer The layer for the hull polygon and its vertices.
+ *  @param draw_hull_vertices If true, the vertices of the hull are drawn.
+ *  @return The computed convex hull `Polygon`.
+ */
+template <typename HullAlgorithm>
+Polygon visualize_convex_hull(Tikz_Plane &plane, const DynList<Point> &points,
+                              const HullAlgorithm &hull_algorithm,
+                              const Tikz_Style &point_style = tikz_points_style("black", 0.6),
+                              const Tikz_Style &hull_style = tikz_wire_style("red"),
+                              const Tikz_Style &hull_vertex_style = tikz_points_style("red"),
+                              const int point_layer = Tikz_Plane::Layer_Default,
+                              const int hull_layer = Tikz_Plane::Layer_Foreground,
+                              const bool draw_hull_vertices = true)
+{
+  put_points(plane, points, point_style, point_layer);
+
+  Polygon hull = hull_algorithm(points);
+  if (hull.size() > 0)
+    put_in_plane(plane, hull, hull_style, hull_layer);
+
+  if (draw_hull_vertices and hull.size() > 0)
+    put_polygon_vertices(plane, hull, hull_vertex_style, hull_layer + 1);
+
+  return hull;
+}
+
+/** @brief Visualizes the intersection of two convex polygons.
+ *
+ *  Draws the subject and clip polygons with semi-transparent fills and
+ *  overlays their intersection with a distinct, solid fill.
+ *
+ *  @param plane The target TikZ plane.
+ *  @param subject The subject polygon.
+ *  @param clip The clipping polygon.
+ *  @param intersection_algorithm The algorithm to use for intersection.
+ *  @param subject_style The style for the subject polygon.
+ *  @param clip_style The style for the clip polygon.
+ *  @param result_style The style for the resulting intersection polygon.
+ *  @param input_layer The base layer for the input polygons.
+ *  @param result_layer The layer for the intersection polygon.
+ *  @return The `Polygon` representing the intersection.
+ */
+inline Polygon visualize_convex_intersection(
+  Tikz_Plane &plane, const Polygon &subject, const Polygon &clip,
+  const ConvexPolygonIntersectionBasic &intersection_algorithm = {},
+  const Tikz_Style &subject_style = tikz_area_style("blue", "blue!15", 0.45),
+  const Tikz_Style &clip_style = tikz_area_style("orange", "orange!20", 0.45),
+  const Tikz_Style &result_style = tikz_area_style("red", "red!30", 0.60),
+  const int input_layer = Tikz_Plane::Layer_Default,
+  const int result_layer = Tikz_Plane::Layer_Foreground)
+{
+  put_in_plane(plane, subject, subject_style, input_layer);
+  put_in_plane(plane, clip, clip_style, input_layer + 1);
+
+  Polygon inter = intersection_algorithm(subject, clip);
+  if (inter.size() > 0)
+    put_in_plane(plane, inter, result_style, result_layer);
+
+  return inter;
+}
+
+/** @brief Visualizes a boolean operation (union, intersection, difference) on two polygons.
+ *
+ *  Draws the two input polygons (`a` and `b`) with semi-transparent fills
+ *  and overlays the result of the boolean operation with a distinct style.
+ *  This function can handle non-convex polygons.
+ *
+ *  @param plane The target TikZ plane.
+ *  @param a The subject polygon.
+ *  @param b The clip polygon.
+ *  @param op The boolean operation to perform (e.g., `Op::Union`).
+ *  @param bop The boolean operations algorithm object.
+ *  @param a_style The style for polygon `a`.
+ *  @param b_style The style for polygon `b`.
+ *  @param result_style The style for the resulting polygon(s).
+ *  @param input_layer The base layer for the input polygons.
+ *  @param result_layer The layer for the resulting polygon(s).
+ *  @return An `Array<Polygon>` containing the result of the operation.
+ *          The result can be multiple disjoint polygons.
+ */
+inline Array<Polygon> visualize_boolean_operation(
+  Tikz_Plane &plane, const Polygon &a, const Polygon &b, const BooleanPolygonOperations::Op op,
+  const BooleanPolygonOperations &bop = {},
+  const Tikz_Style &a_style = tikz_area_style("blue", "blue!15", 0.35),
+  const Tikz_Style &b_style = tikz_area_style("green!60!black", "green!20", 0.35),
+  const Tikz_Style &result_style = tikz_area_style("red", "red!35", 0.65),
+  const int input_layer = Tikz_Plane::Layer_Default,
+  const int result_layer = Tikz_Plane::Layer_Foreground)
+{
+  put_in_plane(plane, a, a_style, input_layer);
+  put_in_plane(plane, b, b_style, input_layer + 1);
+
+  Array<Polygon> result = bop(a, b, op);
+  put_polygons(plane, result, result_style, result_layer);
+  return result;
+}
+
+/** @brief Insert Delaunay triangulation as triangle outlines.
+ *
+ *  Optionally draws sites as points on top.
+ */
+inline void put_delaunay_result(Tikz_Plane &plane,
+                                const DelaunayTriangulationBowyerWatson::Result &dt,
+                                const Tikz_Style &triangle_style = tikz_wire_style("blue"),
+                                const bool draw_sites = true,
+                                const Tikz_Style &site_style = tikz_points_style("black"),
+                                const int triangle_layer = Tikz_Plane::Layer_Default,
+                                const int site_layer = Tikz_Plane::Layer_Foreground)
+{
+  for (size_t i = 0; i < dt.triangles.size(); ++i)
+    {
+      const auto &tri = dt.triangles(i);
+      Triangle t(dt.sites(tri.i), dt.sites(tri.j), dt.sites(tri.k));
+      put_in_plane(plane, t, triangle_style, triangle_layer);
+    }
+
+  if (draw_sites)
+    put_points(plane, dt.sites, site_style, site_layer);
+}
+
+/** @brief Compute and insert Delaunay triangulation as triangle outlines. */
+[[nodiscard]] inline DelaunayTriangulationBowyerWatson::Result visualize_delaunay(
+  Tikz_Plane &plane, const DynList<Point> &points,
+  const DelaunayTriangulationBowyerWatson &algorithm = {},
+  const Tikz_Style &triangle_style = tikz_wire_style("blue"), const bool draw_sites = true,
+  const Tikz_Style &site_style = tikz_points_style("black"))
+{
+  auto dt = algorithm(points);
+  put_delaunay_result(plane, dt, triangle_style, draw_sites, site_style);
+  return dt;
+}
+
+[[nodiscard]] inline Point ray_endpoint(const Point &src, const Point &direction,
+                                        const Geom_Number &length)
+{
+  const Geom_Number &dx = direction.get_x();
+  const Geom_Number &dy = direction.get_y();
+  const Geom_Number n2 = dx * dx + dy * dy;
+  if (n2 == 0)
+    return src;
+
+  const Geom_Number n = square_root(n2);
+  const Geom_Number scale = length / n;
+  return {src.get_x() + dx * scale, src.get_y() + dy * scale};
+}
+
+/** @brief Insert Voronoi diagram structures (cells, edges, sites).
+ *
+ *  Works with `VoronoiDiagram::Result` and
+ *  `VoronoiDiagramFromDelaunay::Result`.
+ */
+template <typename VoronoiResult>
+void put_voronoi_result(Tikz_Plane &plane, const VoronoiResult &vor, const bool draw_cells = false,
+                        const Tikz_Style &cell_style = tikz_area_style("gray!50!black", "gray!15",
+                                                                       0.35),
+                        const Tikz_Style &edge_style = tikz_wire_style("black"),
+                        const Tikz_Style &unbounded_edge_style = tikz_wire_style("black", true, true),
+                        const Tikz_Style &site_style = tikz_points_style("red"),
+                        const Geom_Number &unbounded_ray_length = Geom_Number(50),
+                        const int cell_layer = Tikz_Plane::Layer_Background,
+                        const int edge_layer = Tikz_Plane::Layer_Default,
+                        const int site_layer = Tikz_Plane::Layer_Foreground)
+{
+  if (draw_cells)
+    for (size_t i = 0; i < vor.cells.size(); ++i)
+      {
+        const auto &cell = vor.cells(i);
+        if (not cell.bounded or cell.vertices.size() < 3)
+          continue;
+
+        Polygon poly = polygon_from_vertices(cell.vertices, true);
+        put_in_plane(plane, poly, cell_style, cell_layer);
+      }
+
+  for (size_t i = 0; i < vor.edges.size(); ++i)
+    if (const auto &e = vor.edges(i); e.unbounded)
+      {
+        const Point tgt = ray_endpoint(e.src, e.direction, unbounded_ray_length);
+        put_in_plane(plane, Segment(e.src, tgt), unbounded_edge_style, edge_layer);
+      }
+    else
+      put_in_plane(plane, Segment(e.src, e.tgt), edge_style, edge_layer);
+
+  put_points(plane, vor.sites, site_style, site_layer);
+}
+
+/** @brief Compute and insert Voronoi diagram for input sites.
+ *
+ *  Returns the generated Voronoi result so callers can reuse it.
+ */
+inline VoronoiDiagram::Result visualize_voronoi(
+  Tikz_Plane &plane, const DynList<Point> &sites, const VoronoiDiagram &algorithm = {},
+  const bool draw_cells = false,
+  const Tikz_Style &cell_style = tikz_area_style("gray!50!black", "gray!15", 0.35),
+  const Tikz_Style &edge_style = tikz_wire_style("black"),
+  const Tikz_Style &unbounded_edge_style = tikz_wire_style("black", true, true),
+  const Tikz_Style &site_style = tikz_points_style("red"),
+  const Geom_Number &unbounded_ray_length = Geom_Number(50))
+{
+  VoronoiDiagram::Result vor = algorithm(sites);
+  put_voronoi_result(plane, vor, draw_cells, cell_style, edge_style, unbounded_edge_style,
+                     site_style, unbounded_ray_length, Tikz_Plane::Layer_Background,
+                     Tikz_Plane::Layer_Default, Tikz_Plane::Layer_Foreground);
+  return vor;
+}
+
+/** @brief Insert Power diagram structures (cells, edges, weighted sites). */
+inline void put_power_diagram_result(
+  Tikz_Plane &plane, const PowerDiagram::Result &pd, const bool draw_cells = true,
+  const Tikz_Style &cell_style = tikz_area_style("violet", "violet!18", 0.35),
+  const Tikz_Style &edge_style = tikz_wire_style("violet"),
+  const Tikz_Style &site_style = tikz_points_style("purple"),
+  const int cell_layer = Tikz_Plane::Layer_Background,
+  const int edge_layer = Tikz_Plane::Layer_Default,
+  const int site_layer = Tikz_Plane::Layer_Foreground)
+{
+  if (draw_cells)
+    for (size_t i = 0; i < pd.cells.size(); ++i)
+      {
+        const auto &cell = pd.cells(i);
+        if (cell.vertices.size() < 3)
+          continue;
+
+        Polygon poly = polygon_from_vertices(cell.vertices, true);
+        put_in_plane(plane, poly, cell_style, cell_layer);
+      }
+
+  for (size_t i = 0; i < pd.edges.size(); ++i)
+    {
+      const auto &e = pd.edges(i);
+      put_in_plane(plane, Segment(e.src, e.tgt), edge_style, edge_layer);
+    }
+
+  for (size_t i = 0; i < pd.sites.size(); ++i)
+    put_in_plane(plane, pd.sites(i).position, site_style, site_layer);
+}
+
+/** @brief Compute and insert Power diagram for weighted sites. */
+inline PowerDiagram::Result visualize_power_diagram(
+  Tikz_Plane &plane, const Array<PowerDiagram::WeightedSite> &sites,
+  const PowerDiagram &algorithm = {}, const bool draw_cells = true,
+  const Tikz_Style &cell_style = tikz_area_style("violet", "violet!18", 0.35),
+  const Tikz_Style &edge_style = tikz_wire_style("violet"),
+  const Tikz_Style &site_style = tikz_points_style("purple"))
+{
+  PowerDiagram::Result res = algorithm(sites);
+  put_power_diagram_result(plane, res, draw_cells, cell_style, edge_style, site_style,
+                           Tikz_Plane::Layer_Background, Tikz_Plane::Layer_Default,
+                           Tikz_Plane::Layer_Foreground);
+  return res;
+}
+
+/** @brief Insert segment arrangement structures (faces, edges, vertices). */
+inline void put_segment_arrangement_result(
+  Tikz_Plane &plane, const SegmentArrangement::Result &arrangement, const bool draw_faces = true,
+  const bool draw_vertices = true, const bool draw_unbounded_face = false,
+  const Tikz_Style &face_style = tikz_area_style("teal!60!black", "teal!12", 0.30),
+  const Tikz_Style &edge_style = tikz_wire_style("teal!70!black"),
+  const Tikz_Style &vertex_style = tikz_points_style("teal!70!black"),
+  const int face_layer = Tikz_Plane::Layer_Background,
+  const int edge_layer = Tikz_Plane::Layer_Default,
+  const int vertex_layer = Tikz_Plane::Layer_Foreground, const bool color_faces_by_index = false)
+{
+  if (draw_faces)
+    {
+      size_t face_color_idx = 0;
+      for (size_t i = 0; i < arrangement.faces.size(); ++i)
         {
-          const auto & cell = pd.cells(i);
-          if (cell.vertices.size() < 3)
+          const auto &[boundary, unbounded] = arrangement.faces(i);
+          if (unbounded and not draw_unbounded_face)
             continue;
 
-          Polygon poly = polygon_from_vertices(cell.vertices, true);
-          put_in_plane(plane, poly, cell_style, cell_layer);
+          Polygon poly = polygon_from_vertex_indices(arrangement.vertices, boundary, true);
+          if (poly.size() >= 3)
+            {
+              Tikz_Style style = face_style;
+              if (color_faces_by_index)
+                {
+                  style.fill = true;
+                  style.fill_color = detail::tikz_palette_color(face_color_idx++);
+                  if (style.draw_color.empty())
+                    style.draw_color = "black";
+                }
+
+              put_in_plane(plane, poly, style, face_layer);
+            }
+        }
+    }
+
+  for (size_t i = 0; i < arrangement.edges.size(); ++i)
+    {
+      const auto &e = arrangement.edges(i);
+      if (e.src >= arrangement.vertices.size() or e.tgt >= arrangement.vertices.size())
+        continue;
+
+      put_in_plane(plane, Segment(arrangement.vertices(e.src), arrangement.vertices(e.tgt)),
+                   edge_style, edge_layer);
+    }
+
+  if (draw_vertices)
+    put_points(plane, arrangement.vertices, vertex_style, vertex_layer);
+}
+
+/** @brief Compute and insert arrangement for input segments. */
+inline SegmentArrangement::Result visualize_segment_arrangement(
+  Tikz_Plane &plane, const Array<Segment> &segments, const SegmentArrangement &algorithm = {},
+  const bool draw_faces = true, const bool draw_vertices = true,
+  const bool draw_unbounded_face = false,
+  const Tikz_Style &face_style = tikz_area_style("teal!60!black", "teal!12", 0.30),
+  const Tikz_Style &edge_style = tikz_wire_style("teal!70!black"),
+  const Tikz_Style &vertex_style = tikz_points_style("teal!70!black"),
+  const bool color_faces_by_index = false)
+{
+  SegmentArrangement::Result res = algorithm(segments);
+  put_segment_arrangement_result(plane, res, draw_faces, draw_vertices, draw_unbounded_face,
+                                 face_style, edge_style, vertex_style, Tikz_Plane::Layer_Background,
+                                 Tikz_Plane::Layer_Default, Tikz_Plane::Layer_Foreground,
+                                 color_faces_by_index);
+  return res;
+}
+
+/** @brief Draw KD-tree partitions from a debug snapshot. */
+inline void put_kdtree_partitions_result(
+  Tikz_Plane &plane, const KDTreePointSearch::DebugSnapshot &snapshot,
+  const bool draw_partition_boxes = false, const bool draw_points = true,
+  const Tikz_Style &partition_style = tikz_wire_style("gray!55", true),
+  const Tikz_Style &split_style = tikz_wire_style("blue!70"),
+  const Tikz_Style &point_style = tikz_points_style("red"),
+  const int partition_layer = Tikz_Plane::Layer_Background,
+  const int split_layer = Tikz_Plane::Layer_Default,
+  const int point_layer = Tikz_Plane::Layer_Foreground)
+{
+  for (size_t i = 0; i < snapshot.partitions.size(); ++i)
+    {
+      const auto &part = snapshot.partitions(i);
+      if (draw_partition_boxes)
+        put_in_plane(plane, part.region, partition_style, partition_layer);
+
+      if (part.is_leaf)
+        continue;
+
+      const Geom_Number x0 = part.region.get_xmin();
+      const Geom_Number x1 = part.region.get_xmax();
+      const Geom_Number y0 = part.region.get_ymin();
+      const Geom_Number y1 = part.region.get_ymax();
+      Segment split_seg = part.split_on_x
+        ? Segment(Point(part.split_value, y0), Point(part.split_value, y1))
+        : Segment(Point(x0, part.split_value), Point(x1, part.split_value));
+
+      Tikz_Style style = split_style;
+      style.draw_color = detail::tikz_palette_color(part.depth);
+      put_in_plane(plane, split_seg, style, split_layer);
+    }
+
+  if (draw_points)
+    put_points(plane, snapshot.points, point_style, point_layer);
+}
+
+/** @brief Visualize KD-tree recursive space partitions. */
+inline KDTreePointSearch::DebugSnapshot visualize_kdtree_partitions(
+  Tikz_Plane &plane, const KDTreePointSearch &kd_tree, const bool draw_partition_boxes = false,
+  const bool draw_points = true, const Tikz_Style &partition_style = tikz_wire_style("gray!55", true),
+  const Tikz_Style &split_style = tikz_wire_style("blue!70"),
+  const Tikz_Style &point_style = tikz_points_style("red"))
+{
+  const auto snapshot = kd_tree.debug_snapshot();
+  put_kdtree_partitions_result(plane, snapshot, draw_partition_boxes, draw_points, partition_style,
+                               split_style, point_style);
+  return snapshot;
+}
+
+/** @brief Draw range-tree X-axis hierarchy and optional query highlights. */
+inline void put_range_tree_result(Tikz_Plane &plane, const RangeTree2D::DebugSnapshot &snapshot,
+                                  const bool draw_points = true,
+                                  const Rectangle *query_rect = nullptr,
+                                  const DynList<Point> *query_hits = nullptr,
+                                  const Tikz_Style &split_style = tikz_wire_style("purple"),
+                                  const Tikz_Style &point_style = tikz_points_style("black"),
+                                  const Tikz_Style &query_rect_style = tikz_wire_style("red", true),
+                                  const Tikz_Style &query_hit_style = tikz_points_style("red"),
+                                  const int split_layer = Tikz_Plane::Layer_Default,
+                                  const int point_layer = Tikz_Plane::Layer_Foreground)
+{
+  if (snapshot.x_sorted_points.size() == 0)
+    return;
+
+  Geom_Number ymin = snapshot.x_sorted_points(0).get_y();
+  Geom_Number ymax = ymin;
+  for (size_t i = 1; i < snapshot.x_sorted_points.size(); ++i)
+    {
+      if (snapshot.x_sorted_points(i).get_y() < ymin)
+        ymin = snapshot.x_sorted_points(i).get_y();
+      if (snapshot.x_sorted_points(i).get_y() > ymax)
+        ymax = snapshot.x_sorted_points(i).get_y();
+    }
+
+  for (size_t i = 0; i < snapshot.nodes.size(); ++i)
+    {
+      const auto &node = snapshot.nodes(i);
+      if (node.is_leaf)
+        continue;
+
+      Tikz_Style style = split_style;
+      style.draw_color = detail::tikz_palette_color(node.tree_index);
+      put_in_plane(plane, Segment(Point(node.split_x, ymin), Point(node.split_x, ymax)), style,
+                   split_layer);
+    }
+
+  if (draw_points)
+    put_points(plane, snapshot.x_sorted_points, point_style, point_layer);
+
+  if (query_rect != nullptr)
+    put_in_plane(plane, *query_rect, query_rect_style, point_layer + 1);
+
+  if (query_hits != nullptr)
+    put_points(plane, *query_hits, query_hit_style, point_layer + 2);
+}
+
+/** @brief Visualize range-tree structure without a query overlay. */
+inline RangeTree2D::DebugSnapshot visualize_range_tree(
+  Tikz_Plane &plane, const RangeTree2D &tree, const bool draw_points = true,
+  const Tikz_Style &split_style = tikz_wire_style("purple"),
+  const Tikz_Style &point_style = tikz_points_style("black"))
+{
+  const auto snapshot = tree.debug_snapshot();
+  put_range_tree_result(plane, snapshot, draw_points, nullptr, nullptr, split_style, point_style);
+  return snapshot;
+}
+
+/// @brief Result bundle for range-tree query visualization.
+struct RangeTreeQueryVizResult
+{
+  RangeTree2D::DebugSnapshot snapshot;
+  Rectangle query_rect;
+  DynList<Point> query_hits;
+};
+
+/** @brief Visualize range-tree plus a query rectangle and matching points. */
+inline RangeTreeQueryVizResult visualize_range_tree_query(
+  Tikz_Plane &plane, const RangeTree2D &tree, const Rectangle &query_rect,
+  const bool draw_points = true, const Tikz_Style &split_style = tikz_wire_style("purple"),
+  const Tikz_Style &point_style = tikz_points_style("black"),
+  const Tikz_Style &query_rect_style = tikz_wire_style("red", true),
+  const Tikz_Style &query_hit_style = tikz_points_style("red"))
+{
+  RangeTreeQueryVizResult out;
+  out.snapshot = tree.debug_snapshot();
+  out.query_rect = query_rect;
+  out.query_hits = tree.query(query_rect.get_xmin(), query_rect.get_xmax(), query_rect.get_ymin(),
+                              query_rect.get_ymax());
+  put_range_tree_result(plane, out.snapshot, draw_points, &out.query_rect, &out.query_hits,
+                        split_style, point_style, query_rect_style, query_hit_style);
+  return out;
+}
+
+/** @brief Draw AABB tree hierarchy and optional query results. */
+inline void put_aabb_tree_result(
+  Tikz_Plane &plane, const AABBTree::DebugSnapshot &snapshot, const Rectangle *query_rect = nullptr,
+  const Array<size_t> *query_hit_ids = nullptr,
+  const Tikz_Style &node_bbox_style = tikz_wire_style("teal!70!black"),
+  const Tikz_Style &leaf_bbox_style = tikz_wire_style("blue!70"),
+  const Tikz_Style &query_rect_style = tikz_wire_style("red", true),
+  const Tikz_Style &query_hit_style = tikz_wire_style("red"),
+  const int node_layer = Tikz_Plane::Layer_Default,
+  const int query_layer = Tikz_Plane::Layer_Foreground)
+{
+  for (size_t i = 0; i < snapshot.nodes.size(); ++i)
+    {
+      const auto &node = snapshot.nodes(i);
+      Tikz_Style style = node.is_leaf ? leaf_bbox_style : node_bbox_style;
+      style.draw_color = detail::tikz_palette_color(node.depth);
+      put_in_plane(plane, node.bbox, style, node_layer);
+    }
+
+  if (query_rect != nullptr)
+    put_in_plane(plane, *query_rect, query_rect_style, query_layer);
+
+  if (query_hit_ids != nullptr)
+    for (size_t i = 0; i < snapshot.nodes.size(); ++i)
+      if (snapshot.nodes(i).is_leaf)
+        for (size_t j = 0; j < query_hit_ids->size(); ++j)
+          if (snapshot.nodes(i).user_index == (*query_hit_ids)(j))
+            {
+              put_in_plane(plane, snapshot.nodes(i).bbox, query_hit_style, query_layer + 1);
+              break;
+            }
+}
+
+/** @brief Visualize AABB tree hierarchy. */
+inline AABBTree::DebugSnapshot visualize_aabb_tree(
+  Tikz_Plane &plane, const AABBTree &tree,
+  const Tikz_Style &node_bbox_style = tikz_wire_style("teal!70!black"),
+  const Tikz_Style &leaf_bbox_style = tikz_wire_style("blue!70"))
+{
+  const auto snapshot = tree.debug_snapshot();
+  put_aabb_tree_result(plane, snapshot, nullptr, nullptr, node_bbox_style, leaf_bbox_style);
+  return snapshot;
+}
+
+/// @brief Result bundle for AABB query visualization.
+struct AABBTreeQueryVizResult
+{
+  AABBTree::DebugSnapshot snapshot;
+  Rectangle query_rect;
+  Array<size_t> query_hit_ids;
+};
+
+/** @brief Visualize AABB tree with a rectangle query overlay. */
+inline AABBTreeQueryVizResult visualize_aabb_tree_query(
+  Tikz_Plane &plane, const AABBTree &tree, const Rectangle &query_rect,
+  const Tikz_Style &node_bbox_style = tikz_wire_style("teal!70!black"),
+  const Tikz_Style &leaf_bbox_style = tikz_wire_style("blue!70"),
+  const Tikz_Style &query_rect_style = tikz_wire_style("red", true),
+  const Tikz_Style &query_hit_style = tikz_wire_style("red"))
+{
+  AABBTreeQueryVizResult out;
+  out.snapshot = tree.debug_snapshot();
+  out.query_rect = query_rect;
+  out.query_hit_ids = tree.query(query_rect);
+  put_aabb_tree_result(plane, out.snapshot, &out.query_rect, &out.query_hit_ids, node_bbox_style,
+                       leaf_bbox_style, query_rect_style, query_hit_style);
+  return out;
+}
+
+/** @brief Draw every node MBR (colored by depth) of an R-tree/R*-tree
+ *         snapshot, plus its leaf entry boxes, an optional query rectangle,
+ *         and its optional hit boxes.
+ *
+ *  @note Hits are matched by bbox equality rather than by payload/index:
+ *        `RTree::DebugSnapshot` deliberately omits `Payload` (see
+ *        `RTree::DebugSnapshot`), so this stays usable for any payload type,
+ *        including move-only ones.
+ */
+template <typename Snapshot>
+inline void put_rtree_result(Tikz_Plane &plane, const Snapshot &snapshot,
+                             const Rectangle *query_rect = nullptr,
+                             const Array<Rectangle> *query_hit_boxes = nullptr,
+                             const Tikz_Style &node_bbox_style = tikz_wire_style("teal!70!black"),
+                             const Tikz_Style &leaf_bbox_style = tikz_wire_style("blue!70"),
+                             const Tikz_Style &entry_bbox_style = tikz_wire_style("gray!55"),
+                             const Tikz_Style &query_rect_style = tikz_wire_style("red", true),
+                             const Tikz_Style &query_hit_style = tikz_wire_style("red"),
+                             const int node_layer = Tikz_Plane::Layer_Default,
+                             const int entry_layer = Tikz_Plane::Layer_Default,
+                             const int query_layer = Tikz_Plane::Layer_Foreground)
+{
+  for (size_t i = 0; i < snapshot.nodes.size(); ++i)
+    {
+      const auto &node = snapshot.nodes(i);
+      Tikz_Style style = node.is_leaf ? leaf_bbox_style : node_bbox_style;
+      style.draw_color = detail::tikz_palette_color(node.depth);
+      put_in_plane(plane, node.bbox, style, node_layer);
+
+      if (node.is_leaf)
+        for (size_t j = 0; j < node.entry_boxes.size(); ++j)
+          put_in_plane(plane, node.entry_boxes(j), entry_bbox_style, entry_layer);
+    }
+
+  if (query_rect != nullptr)
+    put_in_plane(plane, *query_rect, query_rect_style, query_layer);
+
+  if (query_hit_boxes != nullptr)
+    for (size_t i = 0; i < query_hit_boxes->size(); ++i)
+      put_in_plane(plane, (*query_hit_boxes)(i), query_hit_style, query_layer + 1);
+}
+
+/** @brief Visualize an R-tree/R*-tree hierarchy (node MBRs by depth, plus
+ *         leaf entry boxes).
+ */
+template <typename Payload, size_t MaxEntries, size_t MinEntries, RTreeVariant Variant>
+inline typename RTree<Payload, MaxEntries, MinEntries, Variant>::DebugSnapshot visualize_rtree(
+  Tikz_Plane &plane, const RTree<Payload, MaxEntries, MinEntries, Variant> &tree,
+  const Tikz_Style &node_bbox_style = tikz_wire_style("teal!70!black"),
+  const Tikz_Style &leaf_bbox_style = tikz_wire_style("blue!70"),
+  const Tikz_Style &entry_bbox_style = tikz_wire_style("gray!55"))
+{
+  const auto snapshot = tree.debug_snapshot();
+  put_rtree_result(plane, snapshot, nullptr, nullptr, node_bbox_style, leaf_bbox_style,
+                   entry_bbox_style);
+  return snapshot;
+}
+
+/// @brief Result bundle for R-tree/R*-tree query visualization.
+template <typename Payload, size_t MaxEntries, size_t MinEntries, RTreeVariant Variant>
+struct RTreeQueryVizResult
+{
+  typename RTree<Payload, MaxEntries, MinEntries, Variant>::DebugSnapshot snapshot;
+  Rectangle query_rect;
+  Array<Rectangle> query_hit_boxes;  ///< bboxes of every entry intersecting query_rect
+};
+
+/** @brief Visualize an R-tree/R*-tree with a rectangle query overlay,
+ *         highlighting every entry whose bbox intersects @p query_rect.
+ */
+template <typename Payload, size_t MaxEntries, size_t MinEntries, RTreeVariant Variant>
+inline RTreeQueryVizResult<Payload, MaxEntries, MinEntries, Variant> visualize_rtree_query(
+  Tikz_Plane &plane, const RTree<Payload, MaxEntries, MinEntries, Variant> &tree,
+  const Rectangle &query_rect, const Tikz_Style &node_bbox_style = tikz_wire_style("teal!70!black"),
+  const Tikz_Style &leaf_bbox_style = tikz_wire_style("blue!70"),
+  const Tikz_Style &entry_bbox_style = tikz_wire_style("gray!55"),
+  const Tikz_Style &query_rect_style = tikz_wire_style("red", true),
+  const Tikz_Style &query_hit_style = tikz_wire_style("red"))
+{
+  RTreeQueryVizResult<Payload, MaxEntries, MinEntries, Variant> out;
+  out.snapshot = tree.debug_snapshot();
+  out.query_rect = query_rect;
+  tree.for_each_intersecting(query_rect, [&out](const Rectangle &bbox, const Payload &)
+    {
+      out.query_hit_boxes.append(bbox);
+    });
+  put_rtree_result(plane, out.snapshot, &out.query_rect, &out.query_hit_boxes, node_bbox_style,
+                   leaf_bbox_style, entry_bbox_style, query_rect_style, query_hit_style);
+  return out;
+}
+
+/** @brief Insert a point path as connected segments and optional waypoints. */
+inline void put_path(Tikz_Plane &plane, const DynList<Point> &path,
+                     const Tikz_Style &segment_style = tikz_path_style("red"),
+                     const bool draw_waypoints = true,
+                     const Tikz_Style &waypoint_style = tikz_points_style("red"),
+                     const int segment_layer = Tikz_Plane::Layer_Foreground,
+                     const int waypoint_layer = Tikz_Plane::Layer_Overlay)
+{
+  bool has_prev = false;
+  Point prev;
+
+  for (DynList<Point>::Iterator it(path); it.has_curr(); it.next_ne())
+    {
+      const Point &curr = it.get_curr();
+      if (has_prev)
+        put_in_plane(plane, Segment(prev, curr), segment_style, segment_layer);
+
+      prev = curr;
+      has_prev = true;
+    }
+
+  if (draw_waypoints)
+    put_points(plane, path, waypoint_style, waypoint_layer);
+}
+
+/// @brief Insert an `Array<Point>` path as connected segments and waypoints.
+inline void put_path(Tikz_Plane &plane, const Array<Point> &path,
+                     const Tikz_Style &segment_style = tikz_path_style("red"),
+                     const bool draw_waypoints = true,
+                     const Tikz_Style &waypoint_style = tikz_points_style("red"),
+                     const int segment_layer = Tikz_Plane::Layer_Foreground,
+                     const int waypoint_layer = Tikz_Plane::Layer_Overlay)
+{
+  if (path.size() == 0)
+    return;
+
+  for (size_t i = 1; i < path.size(); ++i)
+    put_in_plane(plane, Segment(path(i - 1), path(i)), segment_style, segment_layer);
+
+  if (draw_waypoints)
+    put_points(plane, path, waypoint_style, waypoint_layer);
+}
+
+using FunnelPortal = detail::SPP_Portal;
+
+/** @brief Insert funnel portals as segment connectors. */
+inline void put_portals(Tikz_Plane &plane, const Array<FunnelPortal> &portals,
+                        const bool skip_degenerate = true,
+                        const Tikz_Style &portal_style = tikz_wire_style("purple", true),
+                        const int portal_layer = Tikz_Plane::Layer_Default)
+{
+  for (size_t i = 0; i < portals.size(); ++i)
+    {
+      const auto &[left, right] = portals(i);
+      if (skip_degenerate and left == right)
+        continue;
+
+      put_in_plane(plane, Segment(left, right), portal_style, portal_layer);
+    }
+}
+
+/** @brief Result bundle for shortest-path + funnel portal visualization. */
+struct ShortestPathDebugResult
+{
+  DynList<Point> path;
+  Array<FunnelPortal> portals;
+};
+
+/// @brief One SSFA (funnel) iteration snapshot.
+struct FunnelTraceStep
+{
+  size_t portal_index = 0;
+  Point portal_left;
+  Point portal_right;
+  Point apex;
+  Point left_boundary;
+  Point right_boundary;
+  Array<Point> committed_path;
+  bool tightened_left = false;
+  bool tightened_right = false;
+  bool emitted_left = false;
+  bool emitted_right = false;
+};
+
+/// @brief Full trace for shortest-path funnel processing.
+struct FunnelTraceResult
+{
+  Array<FunnelPortal> portals;
+  Array<FunnelTraceStep> steps;
+  Array<Point> final_path;
+};
+
+/** @brief Compute a full SSFA trace (portal-by-portal states).
+ *
+ *  This is useful for didactic/animation rendering.
+ */
+inline FunnelTraceResult compute_shortest_path_funnel_trace(const Polygon &polygon,
+                                                            const Point &source, const Point &target)
+{
+  FunnelTraceResult trace;
+  trace.portals = detail::shortest_path_portals(polygon, source, target);
+
+  if (trace.portals.size() == 0)
+    return trace;
+
+  Point apex = source;
+  Point fl = source;
+  Point fr = source;
+  size_t ai = 0;
+  size_t li = 0;
+  size_t ri = 0;
+
+  Array<Point> committed;
+  committed.append(source);
+
+  for (size_t i = 1; i < trace.portals.size(); ++i)
+    {
+      const Point &pr = trace.portals(i).right;
+      const Point &pl = trace.portals(i).left;
+
+      FunnelTraceStep step;
+      step.portal_index = i;
+      step.portal_left = pl;
+      step.portal_right = pr;
+      step.apex = apex;
+      step.left_boundary = fl;
+      step.right_boundary = fr;
+      step.committed_path = committed;
+
+      bool restart = false;
+
+      if (detail::spp_cross(apex, fr, pr) >= 0)
+        {
+          if (apex == fr or detail::spp_cross(apex, fl, pr) < 0)
+            {
+              fr = pr;
+              ri = i;
+              step.tightened_right = true;
+            }
+          else
+            {
+              committed.append(fl);
+              step.emitted_left = true;
+
+              apex = fl;
+              ai = li;
+              fl = apex;
+              fr = apex;
+              li = ai;
+              ri = ai;
+              i = ai;
+              restart = true;
+            }
         }
 
-    for (size_t i = 0; i < pd.edges.size(); ++i)
+      if (not restart and detail::spp_cross(apex, fl, pl) <= 0)
+        {
+          if (apex == fl or detail::spp_cross(apex, fr, pl) > 0)
+            {
+              fl = pl;
+              li = i;
+              step.tightened_left = true;
+            }
+          else
+            {
+              committed.append(fr);
+              step.emitted_right = true;
+
+              apex = fr;
+              ai = ri;
+              fl = apex;
+              fr = apex;
+              li = ai;
+              ri = ai;
+              i = ai;
+              restart = true;
+            }
+        }
+
+      step.apex = apex;
+      step.left_boundary = fl;
+      step.right_boundary = fr;
+      step.committed_path = committed;
+      trace.steps.append(step);
+
+      if (restart)
+        continue;  // this is deliberately after appending the step, so the "restart" state is visible in the trace
+    }
+
+  committed.append(target);
+  trace.final_path = committed;
+  return trace;
+}
+
+/** @brief Render one funnel-trace frame in a plane.
+ *
+ *  `step_index` is clamped to the last available step.
+ */
+inline void put_funnel_trace_step(
+  Tikz_Plane &plane, const Polygon &polygon, const Point &source, const Point &target,
+  const FunnelTraceResult &trace, size_t step_index,
+  const Tikz_Style &polygon_style = tikz_area_style("black", "gray!15", 0.22),
+  const Tikz_Style &source_style = tikz_points_style("green!50!black"),
+  const Tikz_Style &target_style = tikz_points_style("blue"),
+  const Tikz_Style &all_portals_style = tikz_wire_style("purple", true),
+  const Tikz_Style &active_portal_style = tikz_path_style("purple"),
+  const Tikz_Style &funnel_leg_style = tikz_path_style("orange!90!black"),
+  const Tikz_Style &committed_style = tikz_path_style("red"), const bool draw_waypoints = true,
+  const Tikz_Style &waypoint_style = tikz_points_style("red"),
+  const int polygon_layer = Tikz_Plane::Layer_Default,
+  const int portal_layer = Tikz_Plane::Layer_Foreground,
+  const int highlight_layer = Tikz_Plane::Layer_Overlay)
+{
+  put_in_plane(plane, polygon, polygon_style, polygon_layer);
+  put_in_plane(plane, source, source_style, highlight_layer + 1);
+  put_in_plane(plane, target, target_style, highlight_layer + 1);
+
+  put_portals(plane, trace.portals, true, all_portals_style, portal_layer);
+
+  if (trace.steps.size() == 0)
+    return;
+
+  if (step_index >= trace.steps.size())
+    step_index = trace.steps.size() - 1;
+
+  const FunnelTraceStep &step = trace.steps(step_index);
+
+  // Active portal segment.
+  if (step.portal_left != step.portal_right)
+    put_in_plane(plane, Segment(step.portal_left, step.portal_right), active_portal_style,
+                 highlight_layer);
+
+  // Current funnel legs.
+  if (step.apex != step.left_boundary)
+    put_in_plane(plane, Segment(step.apex, step.left_boundary), funnel_leg_style, highlight_layer);
+  if (step.apex != step.right_boundary)
+    put_in_plane(plane, Segment(step.apex, step.right_boundary), funnel_leg_style, highlight_layer);
+
+  // Committed path prefix.
+  put_path(plane, step.committed_path, committed_style, draw_waypoints, waypoint_style,
+           highlight_layer + 1, highlight_layer + 2);
+
+  put_in_plane(plane, step.apex, tikz_points_style("orange!90!black"), highlight_layer + 2);
+  put_in_plane(plane, step.left_boundary, tikz_points_style("orange!90!black"), highlight_layer + 2);
+  put_in_plane(plane, step.right_boundary, tikz_points_style("orange!90!black"), highlight_layer + 2);
+}
+
+/** @brief Visualize the shortest path inside a simple polygon. */
+inline DynList<Point> visualize_shortest_path_in_polygon(
+  Tikz_Plane &plane, const Polygon &polygon, const Point &source, const Point &target,
+  const ShortestPathInPolygon &algorithm = {},
+  const Tikz_Style &polygon_style = tikz_area_style("black", "gray!15", 0.25),
+  const Tikz_Style &source_style = tikz_points_style("green!50!black"),
+  const Tikz_Style &target_style = tikz_points_style("blue"),
+  const Tikz_Style &path_style = tikz_path_style("red"), const bool draw_waypoints = true,
+  const Tikz_Style &waypoint_style = tikz_points_style("red"),
+  const int polygon_layer = Tikz_Plane::Layer_Default,
+  const int path_layer = Tikz_Plane::Layer_Foreground)
+{
+  put_in_plane(plane, polygon, polygon_style, polygon_layer);
+  put_in_plane(plane, source, source_style, path_layer + 1);
+  put_in_plane(plane, target, target_style, path_layer + 1);
+
+  DynList<Point> path = algorithm(polygon, source, target);
+  put_path(plane, path, path_style, draw_waypoints, waypoint_style, path_layer, path_layer + 1);
+  return path;
+}
+
+/** @brief Visualize the shortest path plus funnel portals.
+ *
+ *  This helper draws:
+ *  - polygon, source and target points
+ *  - funnel portals (dashed segments)
+ *  - final shortest path
+ */
+inline ShortestPathDebugResult visualize_shortest_path_with_portals(
+  Tikz_Plane &plane, const Polygon &polygon, const Point &source, const Point &target,
+  const ShortestPathInPolygon &algorithm = {},
+  const Tikz_Style &polygon_style = tikz_area_style("black", "gray!15", 0.25),
+  const Tikz_Style &source_style = tikz_points_style("green!50!black"),
+  const Tikz_Style &target_style = tikz_points_style("blue"),
+  const Tikz_Style &portal_style = tikz_wire_style("purple", true),
+  const Tikz_Style &path_style = tikz_path_style("red"), const bool draw_waypoints = true,
+  const Tikz_Style &waypoint_style = tikz_points_style("red"),
+  const int polygon_layer = Tikz_Plane::Layer_Default,
+  const int portal_layer = Tikz_Plane::Layer_Foreground,
+  const int path_layer = Tikz_Plane::Layer_Overlay)
+{
+  put_in_plane(plane, polygon, polygon_style, polygon_layer);
+  put_in_plane(plane, source, source_style, portal_layer + 1);
+  put_in_plane(plane, target, target_style, portal_layer + 1);
+
+  ShortestPathDebugResult out;
+  out.portals = detail::shortest_path_portals(polygon, source, target);
+  put_portals(plane, out.portals, true, portal_style, portal_layer);
+
+  out.path = algorithm(polygon, source, target);
+  put_path(plane, out.path, path_style, draw_waypoints, waypoint_style, path_layer, path_layer + 1);
+  return out;
+}
+
+/** @brief Insert convex decomposition polygons.
+ *
+ *  Each convex part can be colored using a repeating palette.
+ */
+inline void put_convex_decomposition_result(
+  Tikz_Plane &plane, const Array<Polygon> &parts, const bool color_parts_by_index = true,
+  const Tikz_Style &part_style = tikz_area_style("blue!60!black", "blue!15", 0.40),
+  const int part_layer = Tikz_Plane::Layer_Default)
+{
+  size_t color_idx = 0;
+  for (size_t i = 0; i < parts.size(); ++i)
+    {
+      Tikz_Style style = part_style;
+      if (color_parts_by_index)
+        {
+          style.fill = true;
+          style.fill_color = detail::tikz_palette_color(color_idx++);
+          if (style.draw_color.empty())
+            style.draw_color = "black";
+        }
+
+      put_in_plane(plane, parts(i), style, part_layer);
+    }
+}
+
+/** @brief Compute and insert convex decomposition for a polygon. */
+inline Array<Polygon> visualize_convex_decomposition(
+  Tikz_Plane &plane, const Polygon &polygon, const ConvexPolygonDecomposition &algorithm = {},
+  const bool draw_input_polygon = true,
+  const Tikz_Style &input_style = tikz_wire_style("black", true),
+  const bool color_parts_by_index = true,
+  const Tikz_Style &part_style = tikz_area_style("blue!60!black", "blue!15", 0.40),
+  const int input_layer = Tikz_Plane::Layer_Default,
+  const int part_layer = Tikz_Plane::Layer_Foreground)
+{
+  if (draw_input_polygon)
+    put_in_plane(plane, polygon, input_style, input_layer);
+
+  Array<Polygon> parts = algorithm(polygon);
+  put_convex_decomposition_result(plane, parts, color_parts_by_index, part_style, part_layer);
+  return parts;
+}
+
+/** @brief Insert alpha-shape structures (kept triangles, boundary, sites). */
+inline void put_alpha_shape_result(
+  Tikz_Plane &plane, const AlphaShape::Result &alpha_shape, const bool draw_kept_triangles = false,
+  const Tikz_Style &triangle_style = tikz_wire_style("gray!55"),
+  const Tikz_Style &boundary_style = tikz_path_style("orange!90!black"),
+  const bool draw_sites = true, const Tikz_Style &site_style = tikz_points_style("black"),
+  const int triangle_layer = Tikz_Plane::Layer_Background,
+  const int boundary_layer = Tikz_Plane::Layer_Foreground,
+  const int site_layer = Tikz_Plane::Layer_Overlay)
+{
+  if (draw_kept_triangles)
+    for (size_t n = 0; n < alpha_shape.triangles.size(); ++n)
       {
-        const auto & e = pd.edges(i);
-        put_in_plane(plane, Segment(e.src, e.tgt), edge_style, edge_layer);
-      }
-
-    for (size_t i = 0; i < pd.sites.size(); ++i)
-      put_in_plane(plane, pd.sites(i).position, site_style, site_layer);
-  }
-
-  /** @brief Compute and insert Power diagram for weighted sites. */
-  inline PowerDiagram::Result visualize_power_diagram(
-      Tikz_Plane & plane,
-      const Array<PowerDiagram::WeightedSite> & sites,
-      const PowerDiagram & algorithm = {},
-      const bool draw_cells = true,
-      const Tikz_Style & cell_style = tikz_area_style("violet", "violet!18", 0.35),
-      const Tikz_Style & edge_style = tikz_wire_style("violet"),
-      const Tikz_Style & site_style = tikz_points_style("purple"))
-  {
-    PowerDiagram::Result res = algorithm(sites);
-    put_power_diagram_result(plane, res, draw_cells,
-                             cell_style, edge_style, site_style,
-                             Tikz_Plane::Layer_Background,
-                             Tikz_Plane::Layer_Default,
-                             Tikz_Plane::Layer_Foreground);
-    return res;
-  }
-
-  /** @brief Insert segment arrangement structures (faces, edges, vertices). */
-  inline void put_segment_arrangement_result(
-      Tikz_Plane & plane,
-      const SegmentArrangement::Result & arrangement,
-      const bool draw_faces = true,
-      const bool draw_vertices = true,
-      const bool draw_unbounded_face = false,
-      const Tikz_Style & face_style =
-          tikz_area_style("teal!60!black", "teal!12", 0.30),
-      const Tikz_Style & edge_style = tikz_wire_style("teal!70!black"),
-      const Tikz_Style & vertex_style = tikz_points_style("teal!70!black"),
-      const int face_layer = Tikz_Plane::Layer_Background,
-      const int edge_layer = Tikz_Plane::Layer_Default,
-      const int vertex_layer = Tikz_Plane::Layer_Foreground,
-      const bool color_faces_by_index = false)
-  {
-    if (draw_faces)
-      {
-        size_t face_color_idx = 0;
-        for (size_t i = 0; i < arrangement.faces.size(); ++i)
-          {
-            const auto & [boundary, unbounded] = arrangement.faces(i);
-            if (unbounded and not draw_unbounded_face)
-              continue;
-
-            Polygon poly =
-                polygon_from_vertex_indices(arrangement.vertices, boundary, true);
-            if (poly.size() >= 3)
-              {
-                Tikz_Style style = face_style;
-                if (color_faces_by_index)
-                  {
-                    style.fill = true;
-                    style.fill_color = detail::tikz_palette_color(face_color_idx++);
-                    if (style.draw_color.empty())
-                      style.draw_color = "black";
-                  }
-
-                put_in_plane(plane, poly, style, face_layer);
-              }
-          }
-      }
-
-    for (size_t i = 0; i < arrangement.edges.size(); ++i)
-      {
-        const auto & e = arrangement.edges(i);
-        if (e.src >= arrangement.vertices.size() or
-            e.tgt >= arrangement.vertices.size())
+        const auto &[i, j, k] = alpha_shape.triangles(n);
+        if (i >= alpha_shape.sites.size() or j >= alpha_shape.sites.size() or
+            k >= alpha_shape.sites.size())
           continue;
 
         put_in_plane(plane,
-                     Segment(arrangement.vertices(e.src), arrangement.vertices(e.tgt)),
-                     edge_style, edge_layer);
+                     Triangle(alpha_shape.sites(i), alpha_shape.sites(j), alpha_shape.sites(k)),
+                     triangle_style, triangle_layer);
       }
 
-    if (draw_vertices)
-      put_points(plane, arrangement.vertices, vertex_style, vertex_layer);
-  }
-
-  /** @brief Compute and insert arrangement for input segments. */
-  inline SegmentArrangement::Result visualize_segment_arrangement(
-      Tikz_Plane & plane,
-      const Array<Segment> & segments,
-      const SegmentArrangement & algorithm = {},
-      const bool draw_faces = true,
-      const bool draw_vertices = true,
-      const bool draw_unbounded_face = false,
-      const Tikz_Style & face_style =
-          tikz_area_style("teal!60!black", "teal!12", 0.30),
-      const Tikz_Style & edge_style = tikz_wire_style("teal!70!black"),
-      const Tikz_Style & vertex_style = tikz_points_style("teal!70!black"),
-      const bool color_faces_by_index = false)
-  {
-    SegmentArrangement::Result res = algorithm(segments);
-    put_segment_arrangement_result(plane, res,
-                                   draw_faces, draw_vertices, draw_unbounded_face,
-                                   face_style, edge_style, vertex_style,
-                                   Tikz_Plane::Layer_Background,
-                                   Tikz_Plane::Layer_Default,
-                                   Tikz_Plane::Layer_Foreground,
-                                   color_faces_by_index);
-    return res;
-  }
-
-  /** @brief Draw KD-tree partitions from a debug snapshot. */
-  inline void put_kdtree_partitions_result(
-      Tikz_Plane & plane,
-      const KDTreePointSearch::DebugSnapshot & snapshot,
-      const bool draw_partition_boxes = false,
-      const bool draw_points = true,
-      const Tikz_Style & partition_style = tikz_wire_style("gray!55", true),
-      const Tikz_Style & split_style = tikz_wire_style("blue!70"),
-      const Tikz_Style & point_style = tikz_points_style("red"),
-      const int partition_layer = Tikz_Plane::Layer_Background,
-      const int split_layer = Tikz_Plane::Layer_Default,
-      const int point_layer = Tikz_Plane::Layer_Foreground)
-  {
-    for (size_t i = 0; i < snapshot.partitions.size(); ++i)
-      {
-        const auto & part = snapshot.partitions(i);
-        if (draw_partition_boxes)
-          put_in_plane(plane, part.region, partition_style, partition_layer);
-
-        if (part.is_leaf)
-          continue;
-
-        const Geom_Number x0 = part.region.get_xmin();
-        const Geom_Number x1 = part.region.get_xmax();
-        const Geom_Number y0 = part.region.get_ymin();
-        const Geom_Number y1 = part.region.get_ymax();
-        Segment split_seg = part.split_on_x ?
-                              Segment(Point(part.split_value, y0),
-                                      Point(part.split_value, y1)) :
-                              Segment(Point(x0, part.split_value),
-                                      Point(x1, part.split_value));
-
-        Tikz_Style style = split_style;
-        style.draw_color = detail::tikz_palette_color(part.depth);
-        put_in_plane(plane, split_seg, style, split_layer);
-      }
-
-    if (draw_points)
-      put_points(plane, snapshot.points, point_style, point_layer);
-  }
-
-  /** @brief Visualize KD-tree recursive space partitions. */
-  inline KDTreePointSearch::DebugSnapshot visualize_kdtree_partitions(
-      Tikz_Plane & plane,
-      const KDTreePointSearch & kd_tree,
-      const bool draw_partition_boxes = false,
-      const bool draw_points = true,
-      const Tikz_Style & partition_style = tikz_wire_style("gray!55", true),
-      const Tikz_Style & split_style = tikz_wire_style("blue!70"),
-      const Tikz_Style & point_style = tikz_points_style("red"))
-  {
-    const auto snapshot = kd_tree.debug_snapshot();
-    put_kdtree_partitions_result(
-                                 plane, snapshot, draw_partition_boxes, draw_points,
-                                 partition_style, split_style, point_style);
-    return snapshot;
-  }
-
-  /** @brief Draw range-tree X-axis hierarchy and optional query highlights. */
-  inline void put_range_tree_result(
-      Tikz_Plane & plane,
-      const RangeTree2D::DebugSnapshot & snapshot,
-      const bool draw_points = true,
-      const Rectangle *query_rect = nullptr,
-      const DynList<Point> *query_hits = nullptr,
-      const Tikz_Style & split_style = tikz_wire_style("purple"),
-      const Tikz_Style & point_style = tikz_points_style("black"),
-      const Tikz_Style & query_rect_style = tikz_wire_style("red", true),
-      const Tikz_Style & query_hit_style = tikz_points_style("red"),
-      const int split_layer = Tikz_Plane::Layer_Default,
-      const int point_layer = Tikz_Plane::Layer_Foreground)
-  {
-    if (snapshot.x_sorted_points.size() == 0)
-      return;
-
-    Geom_Number ymin = snapshot.x_sorted_points(0).get_y();
-    Geom_Number ymax = ymin;
-    for (size_t i = 1; i < snapshot.x_sorted_points.size(); ++i)
-      {
-        if (snapshot.x_sorted_points(i).get_y() < ymin)
-          ymin = snapshot.x_sorted_points(i).get_y();
-        if (snapshot.x_sorted_points(i).get_y() > ymax)
-          ymax = snapshot.x_sorted_points(i).get_y();
-      }
-
-    for (size_t i = 0; i < snapshot.nodes.size(); ++i)
-      {
-        const auto & node = snapshot.nodes(i);
-        if (node.is_leaf)
-          continue;
-
-        Tikz_Style style = split_style;
-        style.draw_color = detail::tikz_palette_color(node.tree_index);
-        put_in_plane(plane,
-                     Segment(Point(node.split_x, ymin), Point(node.split_x, ymax)),
-                     style, split_layer);
-      }
-
-    if (draw_points)
-      put_points(plane, snapshot.x_sorted_points, point_style, point_layer);
-
-    if (query_rect != nullptr)
-      put_in_plane(plane, *query_rect, query_rect_style, point_layer + 1);
-
-    if (query_hits != nullptr)
-      put_points(plane, *query_hits, query_hit_style, point_layer + 2);
-  }
-
-  /** @brief Visualize range-tree structure without a query overlay. */
-  inline RangeTree2D::DebugSnapshot visualize_range_tree(
-      Tikz_Plane & plane,
-      const RangeTree2D & tree,
-      const bool draw_points = true,
-      const Tikz_Style & split_style = tikz_wire_style("purple"),
-      const Tikz_Style & point_style = tikz_points_style("black"))
-  {
-    const auto snapshot = tree.debug_snapshot();
-    put_range_tree_result(plane, snapshot, draw_points, nullptr, nullptr,
-                          split_style, point_style);
-    return snapshot;
-  }
-
-  /// @brief Result bundle for range-tree query visualization.
-  struct RangeTreeQueryVizResult
-  {
-    RangeTree2D::DebugSnapshot snapshot;
-    Rectangle query_rect;
-    DynList<Point> query_hits;
-  };
-
-  /** @brief Visualize range-tree plus a query rectangle and matching points. */
-  inline RangeTreeQueryVizResult visualize_range_tree_query(
-      Tikz_Plane & plane,
-      const RangeTree2D & tree,
-      const Rectangle & query_rect,
-      const bool draw_points = true,
-      const Tikz_Style & split_style = tikz_wire_style("purple"),
-      const Tikz_Style & point_style = tikz_points_style("black"),
-      const Tikz_Style & query_rect_style = tikz_wire_style("red", true),
-      const Tikz_Style & query_hit_style = tikz_points_style("red"))
-  {
-    RangeTreeQueryVizResult out;
-    out.snapshot = tree.debug_snapshot();
-    out.query_rect = query_rect;
-    out.query_hits = tree.query(query_rect.get_xmin(), query_rect.get_xmax(),
-                                query_rect.get_ymin(), query_rect.get_ymax());
-    put_range_tree_result(plane, out.snapshot, draw_points, &out.query_rect, &out.query_hits,
-                          split_style, point_style, query_rect_style, query_hit_style);
-    return out;
-  }
-
-  /** @brief Draw AABB tree hierarchy and optional query results. */
-  inline void put_aabb_tree_result(
-      Tikz_Plane & plane,
-      const AABBTree::DebugSnapshot & snapshot,
-      const Rectangle *query_rect = nullptr,
-      const Array<size_t> *query_hit_ids = nullptr,
-      const Tikz_Style & node_bbox_style = tikz_wire_style("teal!70!black"),
-      const Tikz_Style & leaf_bbox_style = tikz_wire_style("blue!70"),
-      const Tikz_Style & query_rect_style = tikz_wire_style("red", true),
-      const Tikz_Style & query_hit_style = tikz_wire_style("red"),
-      const int node_layer = Tikz_Plane::Layer_Default,
-      const int query_layer = Tikz_Plane::Layer_Foreground)
-  {
-    for (size_t i = 0; i < snapshot.nodes.size(); ++i)
-      {
-        const auto & node = snapshot.nodes(i);
-        Tikz_Style style = node.is_leaf ? leaf_bbox_style : node_bbox_style;
-        style.draw_color = detail::tikz_palette_color(node.depth);
-        put_in_plane(plane, node.bbox, style, node_layer);
-      }
-
-    if (query_rect != nullptr)
-      put_in_plane(plane, *query_rect, query_rect_style, query_layer);
-
-    if (query_hit_ids != nullptr)
-      for (size_t i = 0; i < snapshot.nodes.size(); ++i)
-        if (snapshot.nodes(i).is_leaf)
-          for (size_t j = 0; j < query_hit_ids->size(); ++j)
-            if (snapshot.nodes(i).user_index == (*query_hit_ids)(j))
-              {
-                put_in_plane(plane, snapshot.nodes(i).bbox, query_hit_style, query_layer + 1);
-                break;
-              }
-  }
-
-  /** @brief Visualize AABB tree hierarchy. */
-  inline AABBTree::DebugSnapshot visualize_aabb_tree(
-      Tikz_Plane & plane,
-      const AABBTree & tree,
-      const Tikz_Style & node_bbox_style = tikz_wire_style("teal!70!black"),
-      const Tikz_Style & leaf_bbox_style = tikz_wire_style("blue!70"))
-  {
-    const auto snapshot = tree.debug_snapshot();
-    put_aabb_tree_result(plane, snapshot, nullptr, nullptr,
-                         node_bbox_style, leaf_bbox_style);
-    return snapshot;
-  }
-
-  /// @brief Result bundle for AABB query visualization.
-  struct AABBTreeQueryVizResult
-  {
-    AABBTree::DebugSnapshot snapshot;
-    Rectangle query_rect;
-    Array<size_t> query_hit_ids;
-  };
-
-  /** @brief Visualize AABB tree with a rectangle query overlay. */
-  inline AABBTreeQueryVizResult visualize_aabb_tree_query(
-      Tikz_Plane & plane,
-      const AABBTree & tree,
-      const Rectangle & query_rect,
-      const Tikz_Style & node_bbox_style = tikz_wire_style("teal!70!black"),
-      const Tikz_Style & leaf_bbox_style = tikz_wire_style("blue!70"),
-      const Tikz_Style & query_rect_style = tikz_wire_style("red", true),
-      const Tikz_Style & query_hit_style = tikz_wire_style("red"))
-  {
-    AABBTreeQueryVizResult out;
-    out.snapshot = tree.debug_snapshot();
-    out.query_rect = query_rect;
-    out.query_hit_ids = tree.query(query_rect);
-    put_aabb_tree_result(
-                         plane, out.snapshot, &out.query_rect, &out.query_hit_ids,
-                         node_bbox_style, leaf_bbox_style, query_rect_style, query_hit_style);
-    return out;
-  }
-
-  /** @brief Insert a point path as connected segments and optional waypoints. */
-  inline void put_path(
-      Tikz_Plane & plane,
-      const DynList<Point> & path,
-      const Tikz_Style & segment_style = tikz_path_style("red"),
-      const bool draw_waypoints = true,
-      const Tikz_Style & waypoint_style = tikz_points_style("red"),
-      const int segment_layer = Tikz_Plane::Layer_Foreground,
-      const int waypoint_layer = Tikz_Plane::Layer_Overlay)
-  {
-    bool has_prev = false;
-    Point prev;
-
-    for (DynList<Point>::Iterator it(path); it.has_curr(); it.next_ne())
-      {
-        const Point & curr = it.get_curr();
-        if (has_prev)
-          put_in_plane(plane, Segment(prev, curr), segment_style, segment_layer);
-
-        prev = curr;
-        has_prev = true;
-      }
-
-    if (draw_waypoints)
-      put_points(plane, path, waypoint_style, waypoint_layer);
-  }
-
-  /// @brief Insert an `Array<Point>` path as connected segments and waypoints.
-  inline void put_path(
-      Tikz_Plane & plane,
-      const Array<Point> & path,
-      const Tikz_Style & segment_style = tikz_path_style("red"),
-      const bool draw_waypoints = true,
-      const Tikz_Style & waypoint_style = tikz_points_style("red"),
-      const int segment_layer = Tikz_Plane::Layer_Foreground,
-      const int waypoint_layer = Tikz_Plane::Layer_Overlay)
-  {
-    if (path.size() == 0)
-      return;
-
-    for (size_t i = 1; i < path.size(); ++i)
-      put_in_plane(plane, Segment(path(i - 1), path(i)), segment_style, segment_layer);
-
-    if (draw_waypoints)
-      put_points(plane, path, waypoint_style, waypoint_layer);
-  }
-
-  using FunnelPortal = detail::SPP_Portal;
-
-  /** @brief Insert funnel portals as segment connectors. */
-  inline void put_portals(
-      Tikz_Plane & plane,
-      const Array<FunnelPortal> & portals,
-      const bool skip_degenerate = true,
-      const Tikz_Style & portal_style = tikz_wire_style("purple", true),
-      const int portal_layer = Tikz_Plane::Layer_Default)
-  {
-    for (size_t i = 0; i < portals.size(); ++i)
-      {
-        const auto & [left, right] = portals(i);
-        if (skip_degenerate and left == right)
-          continue;
-
-        put_in_plane(plane, Segment(left, right), portal_style, portal_layer);
-      }
-  }
-
-  /** @brief Result bundle for shortest-path + funnel portal visualization. */
-  struct ShortestPathDebugResult
-  {
-    DynList<Point> path;
-    Array<FunnelPortal> portals;
-  };
-
-  /// @brief One SSFA (funnel) iteration snapshot.
-  struct FunnelTraceStep
-  {
-    size_t portal_index = 0;
-    Point portal_left;
-    Point portal_right;
-    Point apex;
-    Point left_boundary;
-    Point right_boundary;
-    Array<Point> committed_path;
-    bool tightened_left = false;
-    bool tightened_right = false;
-    bool emitted_left = false;
-    bool emitted_right = false;
-  };
-
-  /// @brief Full trace for shortest-path funnel processing.
-  struct FunnelTraceResult
-  {
-    Array<FunnelPortal> portals;
-    Array<FunnelTraceStep> steps;
-    Array<Point> final_path;
-  };
-
-  /** @brief Compute a full SSFA trace (portal-by-portal states).
-   *
-   *  This is useful for didactic/animation rendering.
-   */
-  inline FunnelTraceResult compute_shortest_path_funnel_trace(
-      const Polygon & polygon,
-      const Point & source,
-      const Point & target)
-  {
-    FunnelTraceResult trace;
-    trace.portals = detail::shortest_path_portals(polygon, source, target);
-
-    if (trace.portals.size() == 0)
-      return trace;
-
-    Point apex = source;
-    Point fl = source;
-    Point fr = source;
-    size_t ai = 0;
-    size_t li = 0;
-    size_t ri = 0;
-
-    Array<Point> committed;
-    committed.append(source);
-
-    for (size_t i = 1; i < trace.portals.size(); ++i)
-      {
-        const Point & pr = trace.portals(i).right;
-        const Point & pl = trace.portals(i).left;
-
-        FunnelTraceStep step;
-        step.portal_index = i;
-        step.portal_left = pl;
-        step.portal_right = pr;
-        step.apex = apex;
-        step.left_boundary = fl;
-        step.right_boundary = fr;
-        step.committed_path = committed;
-
-        bool restart = false;
-
-        if (detail::spp_cross(apex, fr, pr) >= 0)
-          {
-            if (apex == fr or detail::spp_cross(apex, fl, pr) < 0)
-              {
-                fr = pr;
-                ri = i;
-                step.tightened_right = true;
-              }
-            else
-              {
-                committed.append(fl);
-                step.emitted_left = true;
-
-                apex = fl;
-                ai = li;
-                fl = apex;
-                fr = apex;
-                li = ai;
-                ri = ai;
-                i = ai;
-                restart = true;
-              }
-          }
-
-        if (not restart and detail::spp_cross(apex, fl, pl) <= 0)
-          {
-            if (apex == fl or detail::spp_cross(apex, fr, pl) > 0)
-              {
-                fl = pl;
-                li = i;
-                step.tightened_left = true;
-              }
-            else
-              {
-                committed.append(fr);
-                step.emitted_right = true;
-
-                apex = fr;
-                ai = ri;
-                fl = apex;
-                fr = apex;
-                li = ai;
-                ri = ai;
-                i = ai;
-                restart = true;
-              }
-          }
-
-        step.apex = apex;
-        step.left_boundary = fl;
-        step.right_boundary = fr;
-        step.committed_path = committed;
-        trace.steps.append(step);
-
-        if (restart)
-          continue; // this is deliberately after appending the step, so the "restart" state is visible in the trace
-      }
-
-    committed.append(target);
-    trace.final_path = committed;
-    return trace;
-  }
-
-  /** @brief Render one funnel-trace frame in a plane.
-   *
-   *  `step_index` is clamped to the last available step.
-   */
-  inline void put_funnel_trace_step(
-      Tikz_Plane & plane,
-      const Polygon & polygon,
-      const Point & source,
-      const Point & target,
-      const FunnelTraceResult & trace,
-      size_t step_index,
-      const Tikz_Style & polygon_style = tikz_area_style("black", "gray!15", 0.22),
-      const Tikz_Style & source_style = tikz_points_style("green!50!black"),
-      const Tikz_Style & target_style = tikz_points_style("blue"),
-      const Tikz_Style & all_portals_style = tikz_wire_style("purple", true),
-      const Tikz_Style & active_portal_style = tikz_path_style("purple"),
-      const Tikz_Style & funnel_leg_style = tikz_path_style("orange!90!black"),
-      const Tikz_Style & committed_style = tikz_path_style("red"),
-      const bool draw_waypoints = true,
-      const Tikz_Style & waypoint_style = tikz_points_style("red"),
-      const int polygon_layer = Tikz_Plane::Layer_Default,
-      const int portal_layer = Tikz_Plane::Layer_Foreground,
-      const int highlight_layer = Tikz_Plane::Layer_Overlay)
-  {
-    put_in_plane(plane, polygon, polygon_style, polygon_layer);
-    put_in_plane(plane, source, source_style, highlight_layer + 1);
-    put_in_plane(plane, target, target_style, highlight_layer + 1);
-
-    put_portals(plane, trace.portals, true, all_portals_style, portal_layer);
-
-    if (trace.steps.size() == 0)
-      return;
-
-    if (step_index >= trace.steps.size())
-      step_index = trace.steps.size() - 1;
-
-    const FunnelTraceStep & step = trace.steps(step_index);
-
-    // Active portal segment.
-    if (step.portal_left != step.portal_right)
-      put_in_plane(plane, Segment(step.portal_left, step.portal_right),
-                   active_portal_style, highlight_layer);
-
-    // Current funnel legs.
-    if (step.apex != step.left_boundary)
-      put_in_plane(plane, Segment(step.apex, step.left_boundary),
-                   funnel_leg_style, highlight_layer);
-    if (step.apex != step.right_boundary)
-      put_in_plane(plane, Segment(step.apex, step.right_boundary),
-                   funnel_leg_style, highlight_layer);
-
-    // Committed path prefix.
-    put_path(plane, step.committed_path,
-             committed_style, draw_waypoints, waypoint_style,
-             highlight_layer + 1, highlight_layer + 2);
-
-    put_in_plane(plane, step.apex, tikz_points_style("orange!90!black"), highlight_layer + 2);
-    put_in_plane(plane, step.left_boundary, tikz_points_style("orange!90!black"), highlight_layer + 2);
-    put_in_plane(plane, step.right_boundary, tikz_points_style("orange!90!black"), highlight_layer + 2);
-  }
-
-  /** @brief Visualize the shortest path inside a simple polygon. */
-  inline DynList<Point> visualize_shortest_path_in_polygon(
-      Tikz_Plane & plane,
-      const Polygon & polygon,
-      const Point & source,
-      const Point & target,
-      const ShortestPathInPolygon & algorithm = {},
-      const Tikz_Style & polygon_style =
-          tikz_area_style("black", "gray!15", 0.25),
-      const Tikz_Style & source_style = tikz_points_style("green!50!black"),
-      const Tikz_Style & target_style = tikz_points_style("blue"),
-      const Tikz_Style & path_style = tikz_path_style("red"),
-      const bool draw_waypoints = true,
-      const Tikz_Style & waypoint_style = tikz_points_style("red"),
-      const int polygon_layer = Tikz_Plane::Layer_Default,
-      const int path_layer = Tikz_Plane::Layer_Foreground)
-  {
-    put_in_plane(plane, polygon, polygon_style, polygon_layer);
-    put_in_plane(plane, source, source_style, path_layer + 1);
-    put_in_plane(plane, target, target_style, path_layer + 1);
-
-    DynList<Point> path = algorithm(polygon, source, target);
-    put_path(plane, path,
-             path_style, draw_waypoints, waypoint_style,
-             path_layer, path_layer + 1);
-    return path;
-  }
-
-  /** @brief Visualize the shortest path plus funnel portals.
-   *
-   *  This helper draws:
-   *  - polygon, source and target points
-   *  - funnel portals (dashed segments)
-   *  - final shortest path
-   */
-  inline ShortestPathDebugResult visualize_shortest_path_with_portals(
-      Tikz_Plane & plane,
-      const Polygon & polygon,
-      const Point & source,
-      const Point & target,
-      const ShortestPathInPolygon & algorithm = {},
-      const Tikz_Style & polygon_style =
-          tikz_area_style("black", "gray!15", 0.25),
-      const Tikz_Style & source_style = tikz_points_style("green!50!black"),
-      const Tikz_Style & target_style = tikz_points_style("blue"),
-      const Tikz_Style & portal_style = tikz_wire_style("purple", true),
-      const Tikz_Style & path_style = tikz_path_style("red"),
-      const bool draw_waypoints = true,
-      const Tikz_Style & waypoint_style = tikz_points_style("red"),
-      const int polygon_layer = Tikz_Plane::Layer_Default,
-      const int portal_layer = Tikz_Plane::Layer_Foreground,
-      const int path_layer = Tikz_Plane::Layer_Overlay)
-  {
-    put_in_plane(plane, polygon, polygon_style, polygon_layer);
-    put_in_plane(plane, source, source_style, portal_layer + 1);
-    put_in_plane(plane, target, target_style, portal_layer + 1);
-
-    ShortestPathDebugResult out;
-    out.portals = detail::shortest_path_portals(polygon, source, target);
-    put_portals(plane, out.portals, true, portal_style, portal_layer);
-
-    out.path = algorithm(polygon, source, target);
-    put_path(plane, out.path,
-             path_style, draw_waypoints, waypoint_style,
-             path_layer, path_layer + 1);
-    return out;
-  }
-
-  /** @brief Insert convex decomposition polygons.
-   *
-   *  Each convex part can be colored using a repeating palette.
-   */
-  inline void put_convex_decomposition_result(
-      Tikz_Plane & plane,
-      const Array<Polygon> & parts,
-      const bool color_parts_by_index = true,
-      const Tikz_Style & part_style =
-          tikz_area_style("blue!60!black", "blue!15", 0.40),
-      const int part_layer = Tikz_Plane::Layer_Default)
-  {
-    size_t color_idx = 0;
-    for (size_t i = 0; i < parts.size(); ++i)
-      {
-        Tikz_Style style = part_style;
-        if (color_parts_by_index)
-          {
-            style.fill = true;
-            style.fill_color = detail::tikz_palette_color(color_idx++);
-            if (style.draw_color.empty())
-              style.draw_color = "black";
-          }
-
-        put_in_plane(plane, parts(i), style, part_layer);
-      }
-  }
-
-  /** @brief Compute and insert convex decomposition for a polygon. */
-  inline Array<Polygon> visualize_convex_decomposition(
-      Tikz_Plane & plane,
-      const Polygon & polygon,
-      const ConvexPolygonDecomposition & algorithm = {},
-      const bool draw_input_polygon = true,
-      const Tikz_Style & input_style = tikz_wire_style("black", true),
-      const bool color_parts_by_index = true,
-      const Tikz_Style & part_style =
-          tikz_area_style("blue!60!black", "blue!15", 0.40),
-      const int input_layer = Tikz_Plane::Layer_Default,
-      const int part_layer = Tikz_Plane::Layer_Foreground)
-  {
-    if (draw_input_polygon)
-      put_in_plane(plane, polygon, input_style, input_layer);
-
-    Array<Polygon> parts = algorithm(polygon);
-    put_convex_decomposition_result(plane, parts,
-                                    color_parts_by_index,
-                                    part_style,
-                                    part_layer);
-    return parts;
-  }
-
-  /** @brief Insert alpha-shape structures (kept triangles, boundary, sites). */
-  inline void put_alpha_shape_result(
-      Tikz_Plane & plane,
-      const AlphaShape::Result & alpha_shape,
-      const bool draw_kept_triangles = false,
-      const Tikz_Style & triangle_style = tikz_wire_style("gray!55"),
-      const Tikz_Style & boundary_style = tikz_path_style("orange!90!black"),
-      const bool draw_sites = true,
-      const Tikz_Style & site_style = tikz_points_style("black"),
-      const int triangle_layer = Tikz_Plane::Layer_Background,
-      const int boundary_layer = Tikz_Plane::Layer_Foreground,
-      const int site_layer = Tikz_Plane::Layer_Overlay)
-  {
-    if (draw_kept_triangles)
-      {
-        for (size_t n = 0; n < alpha_shape.triangles.size(); ++n)
-          {
-            const auto & [i, j, k] = alpha_shape.triangles(n);
-            if (i >= alpha_shape.sites.size() or
-                j >= alpha_shape.sites.size() or
-                k >= alpha_shape.sites.size())
+  for (size_t i = 0; i < alpha_shape.boundary_edges.size(); ++i)
+    put_in_plane(plane, alpha_shape.boundary_edges(i), boundary_style, boundary_layer);
+
+  if (draw_sites)
+    put_points(plane, alpha_shape.sites, site_style, site_layer);
+}
+
+/** @brief Compute and insert alpha-shape for input points. */
+inline AlphaShape::Result visualize_alpha_shape(
+  Tikz_Plane &plane, const DynList<Point> &points, const Geom_Number &alpha_squared,
+  const AlphaShape &algorithm = {}, const bool draw_kept_triangles = false,
+  const Tikz_Style &triangle_style = tikz_wire_style("gray!55"),
+  const Tikz_Style &boundary_style = tikz_path_style("orange!90!black"),
+  const bool draw_sites = true, const Tikz_Style &site_style = tikz_points_style("black"))
+{
+  AlphaShape::Result res = algorithm(points, alpha_squared);
+  put_alpha_shape_result(plane, res, draw_kept_triangles, triangle_style, boundary_style,
+                         draw_sites, site_style, Tikz_Plane::Layer_Background,
+                         Tikz_Plane::Layer_Foreground, Tikz_Plane::Layer_Overlay);
+  return res;
+}
+
+/** @brief Draw regular (weighted Delaunay) triangulation output. */
+inline void put_regular_triangulation_result(
+  Tikz_Plane &plane, const RegularTriangulationBowyerWatson::Result &rt,
+  const Tikz_Style &triangle_style = tikz_wire_style("blue!60"), const bool draw_sites = true,
+  const Tikz_Style &site_style = tikz_points_style("black"),
+  const int triangle_layer = Tikz_Plane::Layer_Default,
+  const int site_layer = Tikz_Plane::Layer_Foreground)
+{
+  for (size_t i = 0; i < rt.triangles.size(); ++i)
+    {
+      const auto &tri = rt.triangles(i);
+      Triangle t(rt.sites(tri.i).position, rt.sites(tri.j).position, rt.sites(tri.k).position);
+      put_in_plane(plane, t, triangle_style, triangle_layer);
+    }
+
+  if (draw_sites)
+    for (size_t i = 0; i < rt.sites.size(); ++i)
+      put_in_plane(plane, rt.sites(i).position, site_style, site_layer);
+}
+
+/** @brief Compute and insert regular (weighted Delaunay) triangulation. */
+[[nodiscard]] inline RegularTriangulationBowyerWatson::Result visualize_regular_triangulation(
+  Tikz_Plane &plane, const Array<RegularTriangulationBowyerWatson::WeightedSite> &weighted_sites,
+  const RegularTriangulationBowyerWatson &algorithm = {},
+  const Tikz_Style &triangle_style = tikz_wire_style("blue!60"), const bool draw_sites = true,
+  const Tikz_Style &site_style = tikz_points_style("black"))
+{
+  auto result = algorithm(weighted_sites);
+  put_regular_triangulation_result(plane, result, triangle_style, draw_sites, site_style);
+  return result;
+}
+
+/** @brief Draw closest-pair result over the full point set. */
+inline void put_closest_pair_result(Tikz_Plane &plane, const DynList<Point> &points,
+                                    const ClosestPairDivideAndConquer::Result &result,
+                                    const Tikz_Style &points_style = tikz_points_style("black"),
+                                    const Tikz_Style &pair_style = tikz_path_style("red"),
+                                    const Tikz_Style &pair_points_style = tikz_points_style("red"),
+                                    const int points_layer = Tikz_Plane::Layer_Default,
+                                    const int pair_layer = Tikz_Plane::Layer_Foreground)
+{
+  put_points(plane, points, points_style, points_layer);
+  put_in_plane(plane, Segment(result.first, result.second), pair_style, pair_layer);
+  put_in_plane(plane, result.first, pair_points_style, pair_layer + 1);
+  put_in_plane(plane, result.second, pair_points_style, pair_layer + 1);
+}
+
+/** @brief Compute and draw the closest pair from an input point set. */
+[[nodiscard]] inline ClosestPairDivideAndConquer::Result visualize_closest_pair(
+  Tikz_Plane &plane, const DynList<Point> &points, const ClosestPairDivideAndConquer &algorithm = {},
+  const Tikz_Style &points_style = tikz_points_style("black"),
+  const Tikz_Style &pair_style = tikz_path_style("red"),
+  const Tikz_Style &pair_points_style = tikz_points_style("red"))
+{
+  auto result = algorithm(points);
+  put_closest_pair_result(plane, points, result, points_style, pair_style, pair_points_style);
+  return result;
+}
+
+/// @brief Bundle of rotating-calipers results used by visualization helpers.
+struct RotatingCalipersResult
+{
+  RotatingCalipersConvexPolygon::DiameterResult diameter;
+  RotatingCalipersConvexPolygon::WidthResult width;
+};
+
+/** @brief Draw diameter and minimum-width witnesses for a convex polygon. */
+inline void put_rotating_calipers_result(
+  Tikz_Plane &plane, const Polygon &polygon, const RotatingCalipersResult &result,
+  const Tikz_Style &polygon_style = tikz_wire_style("gray!55"),
+  const Tikz_Style &diameter_style = tikz_path_style("red"),
+  const Tikz_Style &width_style = tikz_path_style("blue"),
+  const Tikz_Style &witness_style = tikz_points_style("orange!90!black"),
+  const int polygon_layer = Tikz_Plane::Layer_Default,
+  const int witness_layer = Tikz_Plane::Layer_Foreground)
+{
+  put_in_plane(plane, polygon, polygon_style, polygon_layer);
+  put_in_plane(plane, Segment(result.diameter.first, result.diameter.second), diameter_style,
+               witness_layer);
+  put_in_plane(plane, Segment(result.width.edge_first, result.width.edge_second), width_style,
+               witness_layer);
+  put_in_plane(plane, result.width.antipodal, witness_style, witness_layer + 1);
+}
+
+/** @brief Compute and draw rotating-calipers diameter and minimum width. */
+[[nodiscard]] inline RotatingCalipersResult visualize_rotating_calipers(
+  Tikz_Plane &plane, const Polygon &polygon,
+  const Tikz_Style &polygon_style = tikz_wire_style("gray!55"),
+  const Tikz_Style &diameter_style = tikz_path_style("red"),
+  const Tikz_Style &width_style = tikz_path_style("blue"),
+  const Tikz_Style &witness_style = tikz_points_style("orange!90!black"))
+{
+  RotatingCalipersResult result{RotatingCalipersConvexPolygon::diameter(polygon),
+                                RotatingCalipersConvexPolygon::minimum_width(polygon)};
+  put_rotating_calipers_result(plane, polygon, result, polygon_style, diameter_style, width_style,
+                               witness_style);
+  return result;
+}
+
+/** @brief Draw half-plane boundaries and their bounded intersection polygon. */
+inline void put_half_plane_intersection_result(
+  Tikz_Plane &plane, const Array<HalfPlaneIntersection::HalfPlane> &halfplanes,
+  const Polygon &intersection,
+  const Tikz_Style &boundary_style = tikz_wire_style("gray!60", true, true),
+  const Tikz_Style &result_style = tikz_area_style("red", "red!25", 0.50),
+  const int boundary_layer = Tikz_Plane::Layer_Default,
+  const int result_layer = Tikz_Plane::Layer_Foreground)
+{
+  for (size_t i = 0; i < halfplanes.size(); ++i)
+    put_in_plane(plane, Segment(halfplanes(i).p, halfplanes(i).q), boundary_style, boundary_layer);
+
+  if (intersection.size() > 0)
+    put_in_plane(plane, intersection, result_style, result_layer);
+}
+
+/** @brief Compute and draw bounded half-plane intersection. */
+[[nodiscard]] inline Polygon visualize_half_plane_intersection(
+  Tikz_Plane &plane, const Array<HalfPlaneIntersection::HalfPlane> &halfplanes,
+  const HalfPlaneIntersection &algorithm = {},
+  const Tikz_Style &boundary_style = tikz_wire_style("gray!60", true, true),
+  const Tikz_Style &result_style = tikz_area_style("red", "red!25", 0.50))
+{
+  Polygon intersection = algorithm(halfplanes);
+  put_half_plane_intersection_result(plane, halfplanes, intersection, boundary_style, result_style);
+  return intersection;
+}
+
+/** @brief Draw input polygons and their Minkowski sum result. */
+inline void put_minkowski_sum_result(
+  Tikz_Plane &plane, const Polygon &first, const Polygon &second, const Polygon &result,
+  const Tikz_Style &first_style = tikz_area_style("blue", "blue!14", 0.30),
+  const Tikz_Style &second_style = tikz_area_style("green!60!black", "green!16", 0.30),
+  const Tikz_Style &result_style = tikz_area_style("red", "red!26", 0.60),
+  const int input_layer = Tikz_Plane::Layer_Default,
+  const int result_layer = Tikz_Plane::Layer_Foreground)
+{
+  put_in_plane(plane, first, first_style, input_layer);
+  put_in_plane(plane, second, second_style, input_layer + 1);
+  if (result.size() > 0)
+    put_in_plane(plane, result, result_style, result_layer);
+}
+
+/** @brief Compute and draw Minkowski sum of two convex polygons. */
+[[nodiscard]] inline Polygon visualize_minkowski_sum(
+  Tikz_Plane &plane, const Polygon &first, const Polygon &second,
+  const MinkowskiSumConvex &algorithm = {},
+  const Tikz_Style &first_style = tikz_area_style("blue", "blue!14", 0.30),
+  const Tikz_Style &second_style = tikz_area_style("green!60!black", "green!16", 0.30),
+  const Tikz_Style &result_style = tikz_area_style("red", "red!26", 0.60))
+{
+  Polygon result = algorithm(first, second);
+  put_minkowski_sum_result(plane, first, second, result, first_style, second_style, result_style);
+  return result;
+}
+
+/** @brief Draw a monotone triangulation result plus polygon boundary. */
+inline void put_monotone_triangulation_result(
+  Tikz_Plane &plane, const Polygon &polygon, const DynList<Triangle> &triangles,
+  const Tikz_Style &polygon_style = tikz_wire_style("black"),
+  const Tikz_Style &triangle_style = tikz_wire_style("blue!65"),
+  const int polygon_layer = Tikz_Plane::Layer_Default,
+  const int triangle_layer = Tikz_Plane::Layer_Foreground)
+{
+  put_in_plane(plane, polygon, polygon_style, polygon_layer);
+  for (DynList<Triangle>::Iterator it(triangles); it.has_curr(); it.next_ne())
+    put_in_plane(plane, it.get_curr(), triangle_style, triangle_layer);
+}
+
+/** @brief Compute and draw triangulation via monotone partition pipeline. */
+[[nodiscard]] inline DynList<Triangle> visualize_monotone_triangulation(
+  Tikz_Plane &plane, const Polygon &polygon, const MonotonePolygonTriangulation &algorithm = {},
+  const Tikz_Style &polygon_style = tikz_wire_style("black"),
+  const Tikz_Style &triangle_style = tikz_wire_style("blue!65"))
+{
+  DynList<Triangle> triangles = algorithm(polygon);
+  put_monotone_triangulation_result(plane, polygon, triangles, polygon_style, triangle_style);
+  return triangles;
+}
+
+/** @brief Draw visibility polygon with source polygon and query point. */
+inline void put_visibility_polygon_result(
+  Tikz_Plane &plane, const Polygon &polygon, const Point &query_point,
+  const Polygon &visibility_polygon, const Tikz_Style &polygon_style = tikz_wire_style("black"),
+  const Tikz_Style &visibility_style = tikz_area_style("orange!90!black", "orange!25", 0.50),
+  const Tikz_Style &query_style = tikz_points_style("red"),
+  const int polygon_layer = Tikz_Plane::Layer_Default,
+  const int visibility_layer = Tikz_Plane::Layer_Foreground)
+{
+  put_in_plane(plane, polygon, polygon_style, polygon_layer);
+  if (visibility_polygon.size() > 0)
+    put_in_plane(plane, visibility_polygon, visibility_style, visibility_layer);
+  put_in_plane(plane, query_point, query_style, visibility_layer + 1);
+}
+
+/** @brief Compute and draw visibility polygon from a query point. */
+[[nodiscard]] inline Polygon visualize_visibility_polygon(
+  Tikz_Plane &plane, const Polygon &polygon, const Point &query_point,
+  const VisibilityPolygon &algorithm = {}, const Tikz_Style &polygon_style = tikz_wire_style("black"),
+  const Tikz_Style &visibility_style = tikz_area_style("orange!90!black", "orange!25", 0.50),
+  const Tikz_Style &query_style = tikz_points_style("red"))
+{
+  Polygon visibility_polygon = algorithm(polygon, query_point);
+  put_visibility_polygon_result(plane, polygon, query_point, visibility_polygon, polygon_style,
+                                visibility_style, query_style);
+  return visibility_polygon;
+}
+
+/** @brief Draw line segments and all sweep-line intersection points. */
+inline void put_line_sweep_result(Tikz_Plane &plane, const Array<Segment> &segments,
+                                  const Array<SweepLineSegmentIntersection::Intersection> &intersections,
+                                  const Tikz_Style &segment_style = tikz_wire_style("blue!60"),
+                                  const Tikz_Style &intersection_style = tikz_points_style("red"),
+                                  const int segment_layer = Tikz_Plane::Layer_Default,
+                                  const int intersection_layer = Tikz_Plane::Layer_Foreground)
+{
+  for (size_t i = 0; i < segments.size(); ++i)
+    put_in_plane(plane, segments(i), segment_style, segment_layer);
+
+  for (size_t i = 0; i < intersections.size(); ++i)
+    put_in_plane(plane, intersections(i).point, intersection_style, intersection_layer);
+}
+
+/** @brief Compute and draw Bentley-Ottmann line-sweep intersections. */
+[[nodiscard]] inline Array<SweepLineSegmentIntersection::Intersection> visualize_line_sweep(
+  Tikz_Plane &plane, const Array<Segment> &segments,
+  const SweepLineSegmentIntersection &algorithm = {},
+  const Tikz_Style &segment_style = tikz_wire_style("blue!60"),
+  const Tikz_Style &intersection_style = tikz_points_style("red"))
+{
+  Array<SweepLineSegmentIntersection::Intersection> intersections = algorithm(segments);
+  put_line_sweep_result(plane, segments, intersections, segment_style, intersection_style);
+  return intersections;
+}
+
+/** @brief Insert constrained Delaunay triangulation result.
+ *
+ *  Draws all triangles in wire style, constrained edges in a distinct
+ *  foreground style, and optionally sites as points.
+ */
+inline void put_cdt_result(Tikz_Plane &plane, const ConstrainedDelaunayTriangulation::Result &cdt,
+                           const Tikz_Style &triangle_style = tikz_wire_style("blue!60"),
+                           const Tikz_Style &constraint_style = tikz_path_style("red"),
+                           const bool draw_sites = true,
+                           const Tikz_Style &site_style = tikz_points_style("black"),
+                           const int triangle_layer = Tikz_Plane::Layer_Default,
+                           const int constraint_layer = Tikz_Plane::Layer_Foreground,
+                           const int site_layer = Tikz_Plane::Layer_Overlay)
+{
+  for (size_t i = 0; i < cdt.triangles.size(); ++i)
+    {
+      const auto &tri = cdt.triangles(i);
+      Triangle t(cdt.sites(tri.i), cdt.sites(tri.j), cdt.sites(tri.k));
+      put_in_plane(plane, t, triangle_style, triangle_layer);
+    }
+
+  for (size_t i = 0; i < cdt.constrained_edges.size(); ++i)
+    {
+      const auto &e = cdt.constrained_edges(i);
+      Segment s(cdt.sites(e.u), cdt.sites(e.v));
+      put_in_plane(plane, s, constraint_style, constraint_layer);
+    }
+
+  if (draw_sites)
+    put_points(plane, cdt.sites, site_style, site_layer);
+}
+
+/** @brief Compute and insert constrained Delaunay triangulation. */
+[[nodiscard]] inline ConstrainedDelaunayTriangulation::Result visualize_cdt(
+  Tikz_Plane &plane, const DynList<Point> &points, const DynList<Segment> &constraints,
+  const ConstrainedDelaunayTriangulation &algorithm = {},
+  const Tikz_Style &triangle_style = tikz_wire_style("blue!60"),
+  const Tikz_Style &constraint_style = tikz_path_style("red"), const bool draw_sites = true,
+  const Tikz_Style &site_style = tikz_points_style("black"))
+{
+  auto result = algorithm(points, constraints);
+  put_cdt_result(plane, result, triangle_style, constraint_style, draw_sites, site_style);
+  return result;
+}
+
+// ---------- Minimum Enclosing Circle visualization ----------
+
+/**
+ * @brief Draw a precomputed minimum enclosing circle result.
+ *
+ * Draws the enclosing circle as an `Ellipse` and optionally the input
+ * points on top.
+ */
+inline void put_mec_result(Tikz_Plane &plane, const MinimumEnclosingCircle::Circle &circle,
+                           const DynList<Point> &points,
+                           const Tikz_Style &circle_style = tikz_wire_style("blue!70"),
+                           const bool draw_sites = true,
+                           const Tikz_Style &site_style = tikz_points_style("black"),
+                           const int circle_layer = Tikz_Plane::Layer_Default,
+                           const int site_layer = Tikz_Plane::Layer_Overlay)
+{
+  const Geom_Number r = circle.radius();
+  put_in_plane(plane, Ellipse(circle.center, r, r), circle_style, circle_layer);
+
+  if (draw_sites)
+    put_points(plane, points, site_style, site_layer);
+}
+
+/**
+ * @brief Compute minimum enclosing circle and insert into @p plane.
+ *
+ * @return The computed circle.
+ */
+[[nodiscard]] inline MinimumEnclosingCircle::Circle visualize_mec(
+  Tikz_Plane &plane, const DynList<Point> &points, const MinimumEnclosingCircle &algorithm = {},
+  const Tikz_Style &circle_style = tikz_wire_style("blue!70"), const bool draw_sites = true,
+  const Tikz_Style &site_style = tikz_points_style("black"))
+{
+  auto circle = algorithm(points);
+  put_mec_result(plane, circle, points, circle_style, draw_sites, site_style);
+  return circle;
+}
+
+// ==========================================================================
+// Simplification visualization
+// ==========================================================================
+
+/**
+ * @brief Draw original and simplified polygons overlaid.
+ *
+ * @param plane            Target TikZ canvas.
+ * @param original         The original polygon (drawn faded).
+ * @param simplified       The simplified polygon (drawn bold).
+ * @param original_style   Style for the original polygon.
+ * @param simplified_style Style for the simplified polygon.
+ * @param draw_vertices    Whether to draw vertices of the simplified polygon.
+ * @param vertex_style     Style for simplified polygon vertices.
+ */
+inline void put_simplification_result(
+  Tikz_Plane &plane, const Polygon &original, const Polygon &simplified,
+  const Tikz_Style &original_style = tikz_wire_style("gray!50"),
+  const Tikz_Style &simplified_style = tikz_wire_style("blue!80", 1.2),
+  const bool draw_vertices = true, const Tikz_Style &vertex_style = tikz_points_style("red"))
+{
+  put_in_plane(plane, original, original_style);
+  put_in_plane(plane, simplified, simplified_style);
+  if (draw_vertices)
+    put_polygon_vertices(plane, simplified, vertex_style);
+}
+
+/**
+ * @brief Simplify a polygon with Douglas-Peucker and draw the result.
+ *
+ * @return The simplified polygon.
+ */
+[[nodiscard]] inline Polygon visualize_douglas_peucker(
+  Tikz_Plane &plane, const Polygon &poly, const Geom_Number &epsilon,
+  const DouglasPeuckerSimplification &algorithm = {},
+  const Tikz_Style &original_style = tikz_wire_style("gray!50"),
+  const Tikz_Style &simplified_style = tikz_wire_style("blue!80", 1.2),
+  const bool draw_vertices = true, const Tikz_Style &vertex_style = tikz_points_style("red"))
+{
+  Polygon simplified = algorithm.simplify_polygon(poly, epsilon);
+  put_simplification_result(plane, poly, simplified, original_style, simplified_style,
+                            draw_vertices, vertex_style);
+  return simplified;
+}
+
+/**
+ * @brief Simplify a polygon with Visvalingam-Whyatt and draw the result.
+ *
+ * @return The simplified polygon.
+ */
+[[nodiscard]] inline Polygon visualize_visvalingam_whyatt(
+  Tikz_Plane &plane, const Polygon &poly, const Geom_Number &area_threshold,
+  const VisvalingamWhyattSimplification &algorithm = {},
+  const Tikz_Style &original_style = tikz_wire_style("gray!50"),
+  const Tikz_Style &simplified_style = tikz_wire_style("green!70!black", 1.2),
+  const bool draw_vertices = true, const Tikz_Style &vertex_style = tikz_points_style("red"))
+{
+  Polygon simplified = algorithm.simplify_polygon(poly, area_threshold);
+  put_simplification_result(plane, poly, simplified, original_style, simplified_style,
+                            draw_vertices, vertex_style);
+  return simplified;
+}
+
+// ==========================================================================
+// Polygon offset visualization
+// ==========================================================================
+
+/**
+ * @brief Draw a polygon offset result overlaid on the original polygon.
+ *
+ * @param plane           Target TikZ canvas.
+ * @param original        The original polygon (drawn faded).
+ * @param result          The offset result (one or more polygons).
+ * @param original_style  Style for the original polygon.
+ * @param offset_style    Style for offset polygon(s).
+ * @param draw_vertices   Whether to draw vertices of offset polygon(s).
+ * @param vertex_style    Style for offset polygon vertices.
+ */
+inline void put_offset_result(Tikz_Plane &plane, const Polygon &original,
+                              const PolygonOffset::Result &result,
+                              const Tikz_Style &original_style = tikz_wire_style("gray!50"),
+                              const Tikz_Style &offset_style = tikz_wire_style("blue!80", 1.2),
+                              const bool draw_vertices = true,
+                              const Tikz_Style &vertex_style = tikz_points_style("red"))
+{
+  put_in_plane(plane, original, original_style);
+  for (size_t i = 0; i < result.polygons.size(); ++i)
+    {
+      put_in_plane(plane, result.polygons(i), offset_style);
+      if (draw_vertices)
+        put_polygon_vertices(plane, result.polygons(i), vertex_style);
+    }
+}
+
+/**
+ * @brief Offset a polygon and draw the result.
+ *
+ * @return The offset result.
+ */
+[[nodiscard]] inline PolygonOffset::Result visualize_polygon_offset(
+  Tikz_Plane &plane, const Polygon &poly, const Geom_Number &distance,
+  const PolygonOffset &algorithm = {}, PolygonOffset::JoinType join = PolygonOffset::JoinType::Miter,
+  const Geom_Number &miter_limit = Geom_Number(2),
+  const Tikz_Style &original_style = tikz_wire_style("gray!50"),
+  const Tikz_Style &offset_style = tikz_wire_style("blue!80", 1.2), const bool draw_vertices = true,
+  const Tikz_Style &vertex_style = tikz_points_style("red"))
+{
+  PolygonOffset::Result result = algorithm(poly, distance, join, miter_limit);
+  put_offset_result(plane, poly, result, original_style, offset_style, draw_vertices, vertex_style);
+  return result;
+}
+
+// ==========================================================================
+// Chaikin smoothing visualization
+// ==========================================================================
+
+/**
+ * @brief Draw original and smoothed polygons overlaid.
+ *
+ * @param plane           Target TikZ canvas.
+ * @param original        The original polygon (drawn faded).
+ * @param smoothed        The smoothed polygon (drawn bold).
+ * @param original_style  Style for the original polygon.
+ * @param smoothed_style  Style for the smoothed polygon.
+ * @param draw_vertices   Whether to draw vertices of the smoothed polygon.
+ * @param vertex_style    Style for smoothed polygon vertices.
+ */
+inline void put_smoothing_result(Tikz_Plane &plane, const Polygon &original, const Polygon &smoothed,
+                                 const Tikz_Style &original_style = tikz_wire_style("gray!50"),
+                                 const Tikz_Style &smoothed_style = tikz_wire_style("violet!80", 1.2),
+                                 const bool draw_vertices = true,
+                                 const Tikz_Style &vertex_style = tikz_points_style("red"))
+{
+  put_in_plane(plane, original, original_style);
+  put_in_plane(plane, smoothed, smoothed_style);
+  if (draw_vertices)
+    put_polygon_vertices(plane, smoothed, vertex_style);
+}
+
+/**
+ * @brief Smooth a polygon with Chaikin subdivision and draw the result.
+ *
+ * @return The smoothed polygon.
+ */
+[[nodiscard]] inline Polygon visualize_chaikin_smoothing(
+  Tikz_Plane &plane, const Polygon &poly, const size_t iterations,
+  const Geom_Number &ratio = Geom_Number(1, 4),
+  const Tikz_Style &original_style = tikz_wire_style("gray!50"),
+  const Tikz_Style &smoothed_style = tikz_wire_style("violet!80", 1.2),
+  const bool draw_vertices = true, const Tikz_Style &vertex_style = tikz_points_style("red"))
+{
+  Polygon smoothed = ChaikinSmoothing::smooth_polygon(poly, iterations, ratio);
+  put_smoothing_result(plane, poly, smoothed, original_style, smoothed_style, draw_vertices,
+                       vertex_style);
+  return smoothed;
+}
+
+// ==========================================================================
+// Trapezoidal Map Visualization
+// ==========================================================================
+
+/**
+ * @brief Draw the trapezoidal map result into a Tikz_Plane.
+ *
+ * - Active trapezoids are drawn as filled quadrilaterals (alternating
+ *   palette colors).
+ * - Vertical extensions from input-segment endpoints are drawn as
+ *   dashed gray lines.
+ * - Input segments are drawn in bold red.
+ * - Optional query points are color-coded by location type.
+ */
+inline void put_trapezoidal_map_result(
+  Tikz_Plane &plane, const TrapezoidalMapPointLocation::Result &res,
+  const Tikz_Style &segment_style = tikz_path_style("red"),
+  const Tikz_Style &extension_style = tikz_wire_style("gray!60", true),
+  const bool draw_trapezoids = true, const double trapezoid_opacity = 0.3,
+  const int trap_layer = Tikz_Plane::Layer_Background,
+  const int seg_layer = Tikz_Plane::Layer_Foreground, const int ext_layer = Tikz_Plane::Layer_Default)
+{
+  using Trap = TrapezoidalMapPointLocation::Trapezoid;
+  constexpr size_t NONE = TrapezoidalMapPointLocation::NONE;
+
+  // Draw filled trapezoids.
+  if (draw_trapezoids)
+    {
+      size_t color_idx = 0;
+      for (size_t i = 0; i < res.trapezoids.size(); ++i)
+        {
+          const Trap &t = res.trapezoids(i);
+          if (!not t.active)
+            continue;
+
+          // A trapezoid has 4 corners defined by:
+          //   top-left: intersection of left vertical with top segment
+          //   top-right: intersection of right vertical with top segment
+          //   bot-right: intersection of right vertical with bottom segment
+          //   bot-left: intersection of left vertical with bottom segment
+          // For simplicity, approximate corners using the endpoints
+          // and the x-coordinates of the left/right boundary points.
+          const Point &lp = res.points(t.leftp);
+          const Point &rp = res.points(t.rightp);
+          const Segment &top_seg = res.segments(t.top);
+          const Segment &bot_seg = res.segments(t.bottom);
+
+          // Compute y-coordinates at left and right x-boundaries.
+          auto y_at_x = [](const Segment &seg, const Geom_Number &x) -> Geom_Number
+            {
+              const Geom_Number &x1 = seg.get_src_point().get_x();
+              const Geom_Number &x2 = seg.get_tgt_point().get_x();
+              const Geom_Number &y1 = seg.get_src_point().get_y();
+              const Geom_Number &y2 = seg.get_tgt_point().get_y();
+              if (x1 == x2)
+                return (y1 + y2) / 2;
+              return y1 + (y2 - y1) * (x - x1) / (x2 - x1);
+            };
+
+          const Geom_Number lx = lp.get_x();
+          const Geom_Number rx = rp.get_x();
+          if (lx == rx)
+            {
+              ++color_idx;
               continue;
+            }  // degenerate
 
-            put_in_plane(plane,
-                         Triangle(alpha_shape.sites(i),
-                                  alpha_shape.sites(j),
-                                  alpha_shape.sites(k)),
-                         triangle_style, triangle_layer);
-          }
-      }
+          const Point tl_corner(lx, y_at_x(top_seg, lx));
+          const Point tr_corner(rx, y_at_x(top_seg, rx));
+          const Point br_corner(rx, y_at_x(bot_seg, rx));
+          const Point bl_corner(lx, y_at_x(bot_seg, lx));
 
-    for (size_t i = 0; i < alpha_shape.boundary_edges.size(); ++i)
-      put_in_plane(plane, alpha_shape.boundary_edges(i), boundary_style, boundary_layer);
+          // Draw as 4 segments (avoids Polygon self-intersection checks
+          // that can fail when corners are collinear).
+          Tikz_Style ts;
+          ts.draw_color = detail::tikz_palette_color(color_idx);
+          ts.fill_color = detail::tikz_palette_color(color_idx);
+          ts.opacity = trapezoid_opacity;
 
-    if (draw_sites)
-      put_points(plane, alpha_shape.sites, site_style, site_layer);
-  }
+          // Build polygon with try/catch — skip if degenerate.
+          try
+            {
+              Polygon quad;
+              quad.add_vertex(bl_corner);
+              quad.add_vertex(br_corner);
+              quad.add_vertex(tr_corner);
+              quad.add_vertex(tl_corner);
+              quad.close();
+              ts.fill = true;
+              put_in_plane(plane, quad, ts, trap_layer);
+            }
+          catch (...)
+            {
+              // Degenerate quad — draw edges instead.
+              put_in_plane(plane, Segment(bl_corner, br_corner), ts, trap_layer);
+              put_in_plane(plane, Segment(br_corner, tr_corner), ts, trap_layer);
+              put_in_plane(plane, Segment(tr_corner, tl_corner), ts, trap_layer);
+              put_in_plane(plane, Segment(tl_corner, bl_corner), ts, trap_layer);
+            }
+          ++color_idx;
+        }
+    }
 
-  /** @brief Compute and insert alpha-shape for input points. */
-  inline AlphaShape::Result visualize_alpha_shape(
-      Tikz_Plane & plane,
-      const DynList<Point> & points,
-      const Geom_Number & alpha_squared,
-      const AlphaShape & algorithm = {},
-      const bool draw_kept_triangles = false,
-      const Tikz_Style & triangle_style = tikz_wire_style("gray!55"),
-      const Tikz_Style & boundary_style = tikz_path_style("orange!90!black"),
-      const bool draw_sites = true,
-      const Tikz_Style & site_style = tikz_points_style("black"))
-  {
-    AlphaShape::Result res = algorithm(points, alpha_squared);
-    put_alpha_shape_result(plane, res,
-                           draw_kept_triangles,
-                           triangle_style,
-                           boundary_style,
-                           draw_sites,
-                           site_style,
-                           Tikz_Plane::Layer_Background,
-                           Tikz_Plane::Layer_Foreground,
-                           Tikz_Plane::Layer_Overlay);
-    return res;
-  }
+  // Draw vertical extensions from input endpoints.
+  for (size_t i = 0; i < res.num_input_points; ++i)
+    {
+      // Find the topmost and bottommost trapezoid boundaries at this point.
+      // For simplicity, draw a short vertical dashed line through each
+      // input point spanning the local trapezoid.
+      const Point &p = res.points(i);
+      // Walk the trapezoids to find the vertical extent at p.
+      Geom_Number top_y = p.get_y();
+      Geom_Number bot_y = p.get_y();
+      for (size_t j = 0; j < res.trapezoids.size(); ++j)
+        {
+          const Trap &t = res.trapezoids(j);
+          if (not t.active)
+            continue;
+          if (t.leftp == NONE or t.rightp == NONE)
+            continue;
+          const Point &lp = res.points(t.leftp);
+          const Point &rp = res.points(t.rightp);
+          if (p.get_x() < lp.get_x() or p.get_x() > rp.get_x())
+            continue;
+          // This trapezoid covers x-coordinate of p.
+          auto y_at_x = [](const Segment &seg, const Geom_Number &x) -> Geom_Number
+            {
+              const Geom_Number &x1 = seg.get_src_point().get_x();
+              const Geom_Number &x2 = seg.get_tgt_point().get_x();
+              const Geom_Number &y1 = seg.get_src_point().get_y();
+              const Geom_Number &y2 = seg.get_tgt_point().get_y();
+              if (x1 == x2)
+                return (y1 + y2) / 2;
+              return y1 + (y2 - y1) * (x - x1) / (x2 - x1);
+            };
+          const Geom_Number ty = y_at_x(res.segments(t.top), p.get_x());
+          const Geom_Number by = y_at_x(res.segments(t.bottom), p.get_x());
+          if (ty > top_y)
+            top_y = ty;
+          if (by < bot_y)
+            bot_y = by;
+        }
+      if (top_y > bot_y)
+        put_in_plane(plane, Segment(Point(p.get_x(), bot_y), Point(p.get_x(), top_y)),
+                     extension_style, ext_layer);
+    }
 
-  /** @brief Draw regular (weighted Delaunay) triangulation output. */
-  inline void put_regular_triangulation_result(
-      Tikz_Plane & plane,
-      const RegularTriangulationBowyerWatson::Result & rt,
-      const Tikz_Style & triangle_style = tikz_wire_style("blue!60"),
-      const bool draw_sites = true,
-      const Tikz_Style & site_style = tikz_points_style("black"),
-      const int triangle_layer = Tikz_Plane::Layer_Default,
-      const int site_layer = Tikz_Plane::Layer_Foreground)
-  {
-    for (size_t i = 0; i < rt.triangles.size(); ++i)
-      {
-        const auto & tri = rt.triangles(i);
-        Triangle t(rt.sites(tri.i).position,
-                   rt.sites(tri.j).position,
-                   rt.sites(tri.k).position);
-        put_in_plane(plane, t, triangle_style, triangle_layer);
-      }
+  // Draw input segments.
+  for (size_t i = 0; i < res.num_input_segments; ++i)
+    put_in_plane(plane, res.segments(i), segment_style, seg_layer);
+}
 
-    if (draw_sites)
-      for (size_t i = 0; i < rt.sites.size(); ++i)
-        put_in_plane(plane, rt.sites(i).position, site_style, site_layer);
-  }
+/**
+ * @brief Build a trapezoidal map and draw it.
+ *
+ * Convenience wrapper that constructs the map and draws it in one call.
+ */
+[[nodiscard]] inline TrapezoidalMapPointLocation::Result visualize_trapezoidal_map(
+  Tikz_Plane &plane, const Array<Segment> &segments,
+  const Tikz_Style &segment_style = tikz_path_style("red"),
+  const Tikz_Style &extension_style = tikz_wire_style("gray!60", true),
+  const bool draw_trapezoids = true, const double trapezoid_opacity = 0.3)
+{
+  const TrapezoidalMapPointLocation tm;
+  auto result = tm(segments);
+  put_trapezoidal_map_result(plane, result, segment_style, extension_style, draw_trapezoids,
+                             trapezoid_opacity);
+  return result;
+}
 
-  /** @brief Compute and insert regular (weighted Delaunay) triangulation. */
-  [[nodiscard]] inline RegularTriangulationBowyerWatson::Result
-  visualize_regular_triangulation(
-      Tikz_Plane & plane,
-      const Array<RegularTriangulationBowyerWatson::WeightedSite> & weighted_sites,
-      const RegularTriangulationBowyerWatson & algorithm = {},
-      const Tikz_Style & triangle_style = tikz_wire_style("blue!60"),
-      const bool draw_sites = true,
-      const Tikz_Style & site_style = tikz_points_style("black"))
-  {
-    auto result = algorithm(weighted_sites);
-    put_regular_triangulation_result(
-                                     plane, result, triangle_style, draw_sites, site_style);
-    return result;
-  }
+/**
+ * @brief Build a trapezoidal map from a polygon and draw it.
+ */
+[[nodiscard]] inline TrapezoidalMapPointLocation::Result visualize_trapezoidal_map(
+  Tikz_Plane &plane, const Polygon &polygon, const Tikz_Style &segment_style = tikz_path_style("red"),
+  const Tikz_Style &extension_style = tikz_wire_style("gray!60", true),
+  const bool draw_trapezoids = true, const double trapezoid_opacity = 0.3)
+{
+  TrapezoidalMapPointLocation tm;
+  auto result = tm(polygon);
+  put_trapezoidal_map_result(plane, result, segment_style, extension_style, draw_trapezoids,
+                             trapezoid_opacity);
+  return result;
+}
+}  // namespace Aleph
 
-  /** @brief Draw closest-pair result over the full point set. */
-  inline void put_closest_pair_result(
-      Tikz_Plane & plane,
-      const DynList<Point> & points,
-      const ClosestPairDivideAndConquer::Result & result,
-      const Tikz_Style & points_style = tikz_points_style("black"),
-      const Tikz_Style & pair_style = tikz_path_style("red"),
-      const Tikz_Style & pair_points_style = tikz_points_style("red"),
-      const int points_layer = Tikz_Plane::Layer_Default,
-      const int pair_layer = Tikz_Plane::Layer_Foreground)
-  {
-    put_points(plane, points, points_style, points_layer);
-    put_in_plane(plane, Segment(result.first, result.second), pair_style, pair_layer);
-    put_in_plane(plane, result.first, pair_points_style, pair_layer + 1);
-    put_in_plane(plane, result.second, pair_points_style, pair_layer + 1);
-  }
-
-  /** @brief Compute and draw the closest pair from an input point set. */
-  [[nodiscard]] inline ClosestPairDivideAndConquer::Result
-  visualize_closest_pair(
-      Tikz_Plane & plane,
-      const DynList<Point> & points,
-      const ClosestPairDivideAndConquer & algorithm = {},
-      const Tikz_Style & points_style = tikz_points_style("black"),
-      const Tikz_Style & pair_style = tikz_path_style("red"),
-      const Tikz_Style & pair_points_style = tikz_points_style("red"))
-  {
-    auto result = algorithm(points);
-    put_closest_pair_result(
-                            plane, points, result,
-                            points_style, pair_style, pair_points_style);
-    return result;
-  }
-
-  /// @brief Bundle of rotating-calipers results used by visualization helpers.
-  struct RotatingCalipersResult
-  {
-    RotatingCalipersConvexPolygon::DiameterResult diameter;
-    RotatingCalipersConvexPolygon::WidthResult width;
-  };
-
-  /** @brief Draw diameter and minimum-width witnesses for a convex polygon. */
-  inline void put_rotating_calipers_result(
-      Tikz_Plane & plane,
-      const Polygon & polygon,
-      const RotatingCalipersResult & result,
-      const Tikz_Style & polygon_style = tikz_wire_style("gray!55"),
-      const Tikz_Style & diameter_style = tikz_path_style("red"),
-      const Tikz_Style & width_style = tikz_path_style("blue"),
-      const Tikz_Style & witness_style = tikz_points_style("orange!90!black"),
-      const int polygon_layer = Tikz_Plane::Layer_Default,
-      const int witness_layer = Tikz_Plane::Layer_Foreground)
-  {
-    put_in_plane(plane, polygon, polygon_style, polygon_layer);
-    put_in_plane(plane, Segment(result.diameter.first, result.diameter.second),
-                 diameter_style, witness_layer);
-    put_in_plane(plane, Segment(result.width.edge_first, result.width.edge_second),
-                 width_style, witness_layer);
-    put_in_plane(plane, result.width.antipodal, witness_style, witness_layer + 1);
-  }
-
-  /** @brief Compute and draw rotating-calipers diameter and minimum width. */
-  [[nodiscard]] inline RotatingCalipersResult
-  visualize_rotating_calipers(
-      Tikz_Plane & plane,
-      const Polygon & polygon,
-      const Tikz_Style & polygon_style = tikz_wire_style("gray!55"),
-      const Tikz_Style & diameter_style = tikz_path_style("red"),
-      const Tikz_Style & width_style = tikz_path_style("blue"),
-      const Tikz_Style & witness_style = tikz_points_style("orange!90!black"))
-  {
-    RotatingCalipersResult result{
-          RotatingCalipersConvexPolygon::diameter(polygon),
-          RotatingCalipersConvexPolygon::minimum_width(polygon)
-        };
-    put_rotating_calipers_result(
-                                 plane, polygon, result, polygon_style, diameter_style, width_style, witness_style);
-    return result;
-  }
-
-  /** @brief Draw half-plane boundaries and their bounded intersection polygon. */
-  inline void put_half_plane_intersection_result(
-      Tikz_Plane & plane,
-      const Array<HalfPlaneIntersection::HalfPlane> & halfplanes,
-      const Polygon & intersection,
-      const Tikz_Style & boundary_style = tikz_wire_style("gray!60", true, true),
-      const Tikz_Style & result_style = tikz_area_style("red", "red!25", 0.50),
-      const int boundary_layer = Tikz_Plane::Layer_Default,
-      const int result_layer = Tikz_Plane::Layer_Foreground)
-  {
-    for (size_t i = 0; i < halfplanes.size(); ++i)
-      put_in_plane(plane,
-                   Segment(halfplanes(i).p, halfplanes(i).q),
-                   boundary_style, boundary_layer);
-
-    if (intersection.size() > 0)
-      put_in_plane(plane, intersection, result_style, result_layer);
-  }
-
-  /** @brief Compute and draw bounded half-plane intersection. */
-  [[nodiscard]] inline Polygon
-  visualize_half_plane_intersection(
-      Tikz_Plane & plane,
-      const Array<HalfPlaneIntersection::HalfPlane> & halfplanes,
-      const HalfPlaneIntersection & algorithm = {},
-      const Tikz_Style & boundary_style = tikz_wire_style("gray!60", true, true),
-      const Tikz_Style & result_style = tikz_area_style("red", "red!25", 0.50))
-  {
-    Polygon intersection = algorithm(halfplanes);
-    put_half_plane_intersection_result(
-                                       plane, halfplanes, intersection, boundary_style, result_style);
-    return intersection;
-  }
-
-  /** @brief Draw input polygons and their Minkowski sum result. */
-  inline void put_minkowski_sum_result(
-      Tikz_Plane & plane,
-      const Polygon & first,
-      const Polygon & second,
-      const Polygon & result,
-      const Tikz_Style & first_style = tikz_area_style("blue", "blue!14", 0.30),
-      const Tikz_Style & second_style = tikz_area_style("green!60!black", "green!16", 0.30),
-      const Tikz_Style & result_style = tikz_area_style("red", "red!26", 0.60),
-      const int input_layer = Tikz_Plane::Layer_Default,
-      const int result_layer = Tikz_Plane::Layer_Foreground)
-  {
-    put_in_plane(plane, first, first_style, input_layer);
-    put_in_plane(plane, second, second_style, input_layer + 1);
-    if (result.size() > 0)
-      put_in_plane(plane, result, result_style, result_layer);
-  }
-
-  /** @brief Compute and draw Minkowski sum of two convex polygons. */
-  [[nodiscard]] inline Polygon
-  visualize_minkowski_sum(
-      Tikz_Plane & plane,
-      const Polygon & first,
-      const Polygon & second,
-      const MinkowskiSumConvex & algorithm = {},
-      const Tikz_Style & first_style = tikz_area_style("blue", "blue!14", 0.30),
-      const Tikz_Style & second_style = tikz_area_style("green!60!black", "green!16", 0.30),
-      const Tikz_Style & result_style = tikz_area_style("red", "red!26", 0.60))
-  {
-    Polygon result = algorithm(first, second);
-    put_minkowski_sum_result(
-                             plane, first, second, result, first_style, second_style, result_style);
-    return result;
-  }
-
-  /** @brief Draw a monotone triangulation result plus polygon boundary. */
-  inline void put_monotone_triangulation_result(
-      Tikz_Plane & plane,
-      const Polygon & polygon,
-      const DynList<Triangle> & triangles,
-      const Tikz_Style & polygon_style = tikz_wire_style("black"),
-      const Tikz_Style & triangle_style = tikz_wire_style("blue!65"),
-      const int polygon_layer = Tikz_Plane::Layer_Default,
-      const int triangle_layer = Tikz_Plane::Layer_Foreground)
-  {
-    put_in_plane(plane, polygon, polygon_style, polygon_layer);
-    for (DynList<Triangle>::Iterator it(triangles); it.has_curr(); it.next_ne())
-      put_in_plane(plane, it.get_curr(), triangle_style, triangle_layer);
-  }
-
-  /** @brief Compute and draw triangulation via monotone partition pipeline. */
-  [[nodiscard]] inline DynList<Triangle>
-  visualize_monotone_triangulation(
-      Tikz_Plane & plane,
-      const Polygon & polygon,
-      const MonotonePolygonTriangulation & algorithm = {},
-      const Tikz_Style & polygon_style = tikz_wire_style("black"),
-      const Tikz_Style & triangle_style = tikz_wire_style("blue!65"))
-  {
-    DynList<Triangle> triangles = algorithm(polygon);
-    put_monotone_triangulation_result(
-                                      plane, polygon, triangles, polygon_style, triangle_style);
-    return triangles;
-  }
-
-  /** @brief Draw visibility polygon with source polygon and query point. */
-  inline void put_visibility_polygon_result(
-      Tikz_Plane & plane,
-      const Polygon & polygon,
-      const Point & query_point,
-      const Polygon & visibility_polygon,
-      const Tikz_Style & polygon_style = tikz_wire_style("black"),
-      const Tikz_Style & visibility_style = tikz_area_style("orange!90!black", "orange!25", 0.50),
-      const Tikz_Style & query_style = tikz_points_style("red"),
-      const int polygon_layer = Tikz_Plane::Layer_Default,
-      const int visibility_layer = Tikz_Plane::Layer_Foreground)
-  {
-    put_in_plane(plane, polygon, polygon_style, polygon_layer);
-    if (visibility_polygon.size() > 0)
-      put_in_plane(plane, visibility_polygon, visibility_style, visibility_layer);
-    put_in_plane(plane, query_point, query_style, visibility_layer + 1);
-  }
-
-  /** @brief Compute and draw visibility polygon from a query point. */
-  [[nodiscard]] inline Polygon
-  visualize_visibility_polygon(
-      Tikz_Plane & plane,
-      const Polygon & polygon,
-      const Point & query_point,
-      const VisibilityPolygon & algorithm = {},
-      const Tikz_Style & polygon_style = tikz_wire_style("black"),
-      const Tikz_Style & visibility_style = tikz_area_style("orange!90!black", "orange!25", 0.50),
-      const Tikz_Style & query_style = tikz_points_style("red"))
-  {
-    Polygon visibility_polygon = algorithm(polygon, query_point);
-    put_visibility_polygon_result(
-                                  plane, polygon, query_point, visibility_polygon,
-                                  polygon_style, visibility_style, query_style);
-    return visibility_polygon;
-  }
-
-  /** @brief Draw line segments and all sweep-line intersection points. */
-  inline void put_line_sweep_result(
-      Tikz_Plane & plane,
-      const Array<Segment> & segments,
-      const Array<SweepLineSegmentIntersection::Intersection> & intersections,
-      const Tikz_Style & segment_style = tikz_wire_style("blue!60"),
-      const Tikz_Style & intersection_style = tikz_points_style("red"),
-      const int segment_layer = Tikz_Plane::Layer_Default,
-      const int intersection_layer = Tikz_Plane::Layer_Foreground)
-  {
-    for (size_t i = 0; i < segments.size(); ++i)
-      put_in_plane(plane, segments(i), segment_style, segment_layer);
-
-    for (size_t i = 0; i < intersections.size(); ++i)
-      put_in_plane(plane, intersections(i).point, intersection_style, intersection_layer);
-  }
-
-  /** @brief Compute and draw Bentley-Ottmann line-sweep intersections. */
-  [[nodiscard]] inline Array<SweepLineSegmentIntersection::Intersection>
-  visualize_line_sweep(
-      Tikz_Plane & plane,
-      const Array<Segment> & segments,
-      const SweepLineSegmentIntersection & algorithm = {},
-      const Tikz_Style & segment_style = tikz_wire_style("blue!60"),
-      const Tikz_Style & intersection_style = tikz_points_style("red"))
-  {
-    Array<SweepLineSegmentIntersection::Intersection> intersections = algorithm(segments);
-    put_line_sweep_result(
-                          plane, segments, intersections, segment_style, intersection_style);
-    return intersections;
-  }
-
-  /** @brief Insert constrained Delaunay triangulation result.
-   *
-   *  Draws all triangles in wire style, constrained edges in a distinct
-   *  foreground style, and optionally sites as points.
-   */
-  inline void put_cdt_result(
-      Tikz_Plane & plane,
-      const ConstrainedDelaunayTriangulation::Result & cdt,
-      const Tikz_Style & triangle_style = tikz_wire_style("blue!60"),
-      const Tikz_Style & constraint_style = tikz_path_style("red"),
-      const bool draw_sites = true,
-      const Tikz_Style & site_style = tikz_points_style("black"),
-      const int triangle_layer = Tikz_Plane::Layer_Default,
-      const int constraint_layer = Tikz_Plane::Layer_Foreground,
-      const int site_layer = Tikz_Plane::Layer_Overlay)
-  {
-    for (size_t i = 0; i < cdt.triangles.size(); ++i)
-      {
-        const auto & tri = cdt.triangles(i);
-        Triangle t(cdt.sites(tri.i), cdt.sites(tri.j), cdt.sites(tri.k));
-        put_in_plane(plane, t, triangle_style, triangle_layer);
-      }
-
-    for (size_t i = 0; i < cdt.constrained_edges.size(); ++i)
-      {
-        const auto & e = cdt.constrained_edges(i);
-        Segment s(cdt.sites(e.u), cdt.sites(e.v));
-        put_in_plane(plane, s, constraint_style, constraint_layer);
-      }
-
-    if (draw_sites)
-      put_points(plane, cdt.sites, site_style, site_layer);
-  }
-
-  /** @brief Compute and insert constrained Delaunay triangulation. */
-  [[nodiscard]] inline ConstrainedDelaunayTriangulation::Result
-  visualize_cdt(
-      Tikz_Plane & plane,
-      const DynList<Point> & points,
-      const DynList<Segment> & constraints,
-      const ConstrainedDelaunayTriangulation & algorithm = {},
-      const Tikz_Style & triangle_style = tikz_wire_style("blue!60"),
-      const Tikz_Style & constraint_style = tikz_path_style("red"),
-      const bool draw_sites = true,
-      const Tikz_Style & site_style = tikz_points_style("black"))
-  {
-    auto result = algorithm(points, constraints);
-    put_cdt_result(plane, result,
-                   triangle_style, constraint_style,
-                   draw_sites, site_style);
-    return result;
-  }
-
-  // ---------- Minimum Enclosing Circle visualization ----------
-
-  /**
-   * @brief Draw a precomputed minimum enclosing circle result.
-   *
-   * Draws the enclosing circle as an `Ellipse` and optionally the input
-   * points on top.
-   */
-  inline void put_mec_result(
-      Tikz_Plane & plane,
-      const MinimumEnclosingCircle::Circle & circle,
-      const DynList<Point> & points,
-      const Tikz_Style & circle_style = tikz_wire_style("blue!70"),
-      const bool draw_sites = true,
-      const Tikz_Style & site_style = tikz_points_style("black"),
-      const int circle_layer = Tikz_Plane::Layer_Default,
-      const int site_layer = Tikz_Plane::Layer_Overlay)
-  {
-    const Geom_Number r = circle.radius();
-    put_in_plane(plane, Ellipse(circle.center, r, r),
-                 circle_style, circle_layer);
-
-    if (draw_sites)
-      put_points(plane, points, site_style, site_layer);
-  }
-
-  /**
-   * @brief Compute minimum enclosing circle and insert into @p plane.
-   *
-   * @return The computed circle.
-   */
-  [[nodiscard]] inline MinimumEnclosingCircle::Circle
-  visualize_mec(
-      Tikz_Plane & plane,
-      const DynList<Point> & points,
-      const MinimumEnclosingCircle & algorithm = {},
-      const Tikz_Style & circle_style = tikz_wire_style("blue!70"),
-      const bool draw_sites = true,
-      const Tikz_Style & site_style = tikz_points_style("black"))
-  {
-    auto circle = algorithm(points);
-    put_mec_result(plane, circle, points,
-                   circle_style, draw_sites, site_style);
-    return circle;
-  }
-
-  // ==========================================================================
-  // Simplification visualization
-  // ==========================================================================
-
-  /**
-   * @brief Draw original and simplified polygons overlaid.
-   *
-   * @param plane            Target TikZ canvas.
-   * @param original         The original polygon (drawn faded).
-   * @param simplified       The simplified polygon (drawn bold).
-   * @param original_style   Style for the original polygon.
-   * @param simplified_style Style for the simplified polygon.
-   * @param draw_vertices    Whether to draw vertices of the simplified polygon.
-   * @param vertex_style     Style for simplified polygon vertices.
-   */
-  inline void put_simplification_result(
-      Tikz_Plane & plane,
-      const Polygon & original,
-      const Polygon & simplified,
-      const Tikz_Style & original_style = tikz_wire_style("gray!50"),
-      const Tikz_Style & simplified_style = tikz_wire_style("blue!80", 1.2),
-      const bool draw_vertices = true,
-      const Tikz_Style & vertex_style = tikz_points_style("red"))
-  {
-    put_in_plane(plane, original, original_style);
-    put_in_plane(plane, simplified, simplified_style);
-    if (draw_vertices)
-      put_polygon_vertices(plane, simplified, vertex_style);
-  }
-
-  /**
-   * @brief Simplify a polygon with Douglas-Peucker and draw the result.
-   *
-   * @return The simplified polygon.
-   */
-  [[nodiscard]] inline Polygon visualize_douglas_peucker(
-      Tikz_Plane & plane,
-      const Polygon & poly,
-      const Geom_Number & epsilon,
-      const DouglasPeuckerSimplification & algorithm = {},
-      const Tikz_Style & original_style = tikz_wire_style("gray!50"),
-      const Tikz_Style & simplified_style = tikz_wire_style("blue!80", 1.2),
-      const bool draw_vertices = true,
-      const Tikz_Style & vertex_style = tikz_points_style("red"))
-  {
-    Polygon simplified = algorithm.simplify_polygon(poly, epsilon);
-    put_simplification_result(plane, poly, simplified,
-                              original_style, simplified_style,
-                              draw_vertices, vertex_style);
-    return simplified;
-  }
-
-  /**
-   * @brief Simplify a polygon with Visvalingam-Whyatt and draw the result.
-   *
-   * @return The simplified polygon.
-   */
-  [[nodiscard]] inline Polygon visualize_visvalingam_whyatt(
-      Tikz_Plane & plane,
-      const Polygon & poly,
-      const Geom_Number & area_threshold,
-      const VisvalingamWhyattSimplification & algorithm = {},
-      const Tikz_Style & original_style = tikz_wire_style("gray!50"),
-      const Tikz_Style & simplified_style = tikz_wire_style("green!70!black", 1.2),
-      const bool draw_vertices = true,
-      const Tikz_Style & vertex_style = tikz_points_style("red"))
-  {
-    Polygon simplified = algorithm.simplify_polygon(poly, area_threshold);
-    put_simplification_result(plane, poly, simplified,
-                              original_style, simplified_style,
-                              draw_vertices, vertex_style);
-    return simplified;
-  }
-
-  // ==========================================================================
-  // Polygon offset visualization
-  // ==========================================================================
-
-  /**
-   * @brief Draw a polygon offset result overlaid on the original polygon.
-   *
-   * @param plane           Target TikZ canvas.
-   * @param original        The original polygon (drawn faded).
-   * @param result          The offset result (one or more polygons).
-   * @param original_style  Style for the original polygon.
-   * @param offset_style    Style for offset polygon(s).
-   * @param draw_vertices   Whether to draw vertices of offset polygon(s).
-   * @param vertex_style    Style for offset polygon vertices.
-   */
-  inline void put_offset_result(
-      Tikz_Plane & plane,
-      const Polygon & original,
-      const PolygonOffset::Result & result,
-      const Tikz_Style & original_style = tikz_wire_style("gray!50"),
-      const Tikz_Style & offset_style = tikz_wire_style("blue!80", 1.2),
-      const bool draw_vertices = true,
-      const Tikz_Style & vertex_style = tikz_points_style("red"))
-  {
-    put_in_plane(plane, original, original_style);
-    for (size_t i = 0; i < result.polygons.size(); ++i)
-      {
-        put_in_plane(plane, result.polygons(i), offset_style);
-        if (draw_vertices)
-          put_polygon_vertices(plane, result.polygons(i), vertex_style);
-      }
-  }
-
-  /**
-   * @brief Offset a polygon and draw the result.
-   *
-   * @return The offset result.
-   */
-  [[nodiscard]] inline PolygonOffset::Result visualize_polygon_offset(
-      Tikz_Plane & plane,
-      const Polygon & poly,
-      const Geom_Number & distance,
-      const PolygonOffset & algorithm = {},
-      PolygonOffset::JoinType join = PolygonOffset::JoinType::Miter,
-      const Geom_Number & miter_limit = Geom_Number(2),
-      const Tikz_Style & original_style = tikz_wire_style("gray!50"),
-      const Tikz_Style & offset_style = tikz_wire_style("blue!80", 1.2),
-      const bool draw_vertices = true,
-      const Tikz_Style & vertex_style = tikz_points_style("red"))
-  {
-    PolygonOffset::Result result = algorithm(poly, distance, join, miter_limit);
-    put_offset_result(plane, poly, result,
-                      original_style, offset_style,
-                      draw_vertices, vertex_style);
-    return result;
-  }
-
-  // ==========================================================================
-  // Chaikin smoothing visualization
-  // ==========================================================================
-
-  /**
-   * @brief Draw original and smoothed polygons overlaid.
-   *
-   * @param plane           Target TikZ canvas.
-   * @param original        The original polygon (drawn faded).
-   * @param smoothed        The smoothed polygon (drawn bold).
-   * @param original_style  Style for the original polygon.
-   * @param smoothed_style  Style for the smoothed polygon.
-   * @param draw_vertices   Whether to draw vertices of the smoothed polygon.
-   * @param vertex_style    Style for smoothed polygon vertices.
-   */
-  inline void put_smoothing_result(
-      Tikz_Plane & plane,
-      const Polygon & original,
-      const Polygon & smoothed,
-      const Tikz_Style & original_style = tikz_wire_style("gray!50"),
-      const Tikz_Style & smoothed_style = tikz_wire_style("violet!80", 1.2),
-      const bool draw_vertices = true,
-      const Tikz_Style & vertex_style = tikz_points_style("red"))
-  {
-    put_in_plane(plane, original, original_style);
-    put_in_plane(plane, smoothed, smoothed_style);
-    if (draw_vertices)
-      put_polygon_vertices(plane, smoothed, vertex_style);
-  }
-
-  /**
-   * @brief Smooth a polygon with Chaikin subdivision and draw the result.
-   *
-   * @return The smoothed polygon.
-   */
-  [[nodiscard]] inline Polygon visualize_chaikin_smoothing(
-      Tikz_Plane & plane,
-      const Polygon & poly,
-      const size_t iterations,
-      const Geom_Number & ratio = Geom_Number(1, 4),
-      const Tikz_Style & original_style = tikz_wire_style("gray!50"),
-      const Tikz_Style & smoothed_style = tikz_wire_style("violet!80", 1.2),
-      const bool draw_vertices = true,
-      const Tikz_Style & vertex_style = tikz_points_style("red"))
-  {
-    Polygon smoothed = ChaikinSmoothing::smooth_polygon(poly, iterations, ratio);
-    put_smoothing_result(plane, poly, smoothed,
-                         original_style, smoothed_style,
-                         draw_vertices, vertex_style);
-    return smoothed;
-  }
-
-  // ==========================================================================
-  // Trapezoidal Map Visualization
-  // ==========================================================================
-
-  /**
-   * @brief Draw the trapezoidal map result into a Tikz_Plane.
-   *
-   * - Active trapezoids are drawn as filled quadrilaterals (alternating
-   *   palette colors).
-   * - Vertical extensions from input-segment endpoints are drawn as
-   *   dashed gray lines.
-   * - Input segments are drawn in bold red.
-   * - Optional query points are color-coded by location type.
-   */
-  inline void put_trapezoidal_map_result(
-      Tikz_Plane & plane,
-      const TrapezoidalMapPointLocation::Result & res,
-      const Tikz_Style & segment_style = tikz_path_style("red"),
-      const Tikz_Style & extension_style = tikz_wire_style("gray!60", true),
-      const bool draw_trapezoids = true,
-      const double trapezoid_opacity = 0.3,
-      const int trap_layer = Tikz_Plane::Layer_Background,
-      const int seg_layer = Tikz_Plane::Layer_Foreground,
-      const int ext_layer = Tikz_Plane::Layer_Default)
-  {
-    using Trap = TrapezoidalMapPointLocation::Trapezoid;
-    constexpr size_t NONE = TrapezoidalMapPointLocation::NONE;
-
-    // Draw filled trapezoids.
-    if (draw_trapezoids)
-      {
-        size_t color_idx = 0;
-        for (size_t i = 0; i < res.trapezoids.size(); ++i)
-          {
-            const Trap & t = res.trapezoids(i);
-            if (! t.active) continue;
-
-            // A trapezoid has 4 corners defined by:
-            //   top-left: intersection of left vertical with top segment
-            //   top-right: intersection of right vertical with top segment
-            //   bot-right: intersection of right vertical with bottom segment
-            //   bot-left: intersection of left vertical with bottom segment
-            // For simplicity, approximate corners using the endpoints
-            // and the x-coordinates of the left/right boundary points.
-            const Point & lp = res.points(t.leftp);
-            const Point & rp = res.points(t.rightp);
-            const Segment & top_seg = res.segments(t.top);
-            const Segment & bot_seg = res.segments(t.bottom);
-
-            // Compute y-coordinates at left and right x-boundaries.
-            auto y_at_x = [](const Segment & seg, const Geom_Number & x)
-              -> Geom_Number
-              {
-                const Geom_Number & x1 = seg.get_src_point().get_x();
-                const Geom_Number & x2 = seg.get_tgt_point().get_x();
-                const Geom_Number & y1 = seg.get_src_point().get_y();
-                const Geom_Number & y2 = seg.get_tgt_point().get_y();
-                if (x1 == x2) return (y1 + y2) / 2;
-                return y1 + (y2 - y1) * (x - x1) / (x2 - x1);
-              };
-
-            const Geom_Number lx = lp.get_x();
-            const Geom_Number rx = rp.get_x();
-            if (lx == rx)
-              {
-                ++color_idx;
-                continue;
-              } // degenerate
-
-            const Point tl_corner(lx, y_at_x(top_seg, lx));
-            const Point tr_corner(rx, y_at_x(top_seg, rx));
-            const Point br_corner(rx, y_at_x(bot_seg, rx));
-            const Point bl_corner(lx, y_at_x(bot_seg, lx));
-
-            // Draw as 4 segments (avoids Polygon self-intersection checks
-            // that can fail when corners are collinear).
-            Tikz_Style ts;
-            ts.draw_color = detail::tikz_palette_color(color_idx);
-            ts.fill_color = detail::tikz_palette_color(color_idx);
-            ts.opacity = trapezoid_opacity;
-
-            // Build polygon with try/catch — skip if degenerate.
-            try
-              {
-                Polygon quad;
-                quad.add_vertex(bl_corner);
-                quad.add_vertex(br_corner);
-                quad.add_vertex(tr_corner);
-                quad.add_vertex(tl_corner);
-                quad.close();
-                ts.fill = true;
-                put_in_plane(plane, quad, ts, trap_layer);
-              }
-            catch (...)
-              {
-                // Degenerate quad — draw edges instead.
-                put_in_plane(plane, Segment(bl_corner, br_corner),
-                             ts, trap_layer);
-                put_in_plane(plane, Segment(br_corner, tr_corner),
-                             ts, trap_layer);
-                put_in_plane(plane, Segment(tr_corner, tl_corner),
-                             ts, trap_layer);
-                put_in_plane(plane, Segment(tl_corner, bl_corner),
-                             ts, trap_layer);
-              }
-            ++color_idx;
-          }
-      }
-
-    // Draw vertical extensions from input endpoints.
-    for (size_t i = 0; i < res.num_input_points; ++i)
-      {
-        // Find the topmost and bottommost trapezoid boundaries at this point.
-        // For simplicity, draw a short vertical dashed line through each
-        // input point spanning the local trapezoid.
-        const Point & p = res.points(i);
-        // Walk the trapezoids to find the vertical extent at p.
-        Geom_Number top_y = p.get_y();
-        Geom_Number bot_y = p.get_y();
-        for (size_t j = 0; j < res.trapezoids.size(); ++j)
-          {
-            const Trap & t = res.trapezoids(j);
-            if (! t.active) continue;
-            if (t.leftp == NONE or t.rightp == NONE) continue;
-            const Point & lp = res.points(t.leftp);
-            const Point & rp = res.points(t.rightp);
-            if (p.get_x() < lp.get_x() or p.get_x() > rp.get_x())
-              continue;
-            // This trapezoid covers x-coordinate of p.
-            auto y_at_x = [](const Segment & seg, const Geom_Number & x)
-              -> Geom_Number
-              {
-                const Geom_Number & x1 = seg.get_src_point().get_x();
-                const Geom_Number & x2 = seg.get_tgt_point().get_x();
-                const Geom_Number & y1 = seg.get_src_point().get_y();
-                const Geom_Number & y2 = seg.get_tgt_point().get_y();
-                if (x1 == x2) return (y1 + y2) / 2;
-                return y1 + (y2 - y1) * (x - x1) / (x2 - x1);
-              };
-            const Geom_Number ty = y_at_x(res.segments(t.top), p.get_x());
-            const Geom_Number by = y_at_x(res.segments(t.bottom), p.get_x());
-            if (ty > top_y) top_y = ty;
-            if (by < bot_y) bot_y = by;
-          }
-        if (top_y > bot_y)
-          put_in_plane(plane, Segment(Point(p.get_x(), bot_y),
-                                      Point(p.get_x(), top_y)),
-                       extension_style, ext_layer);
-      }
-
-    // Draw input segments.
-    for (size_t i = 0; i < res.num_input_segments; ++i)
-      put_in_plane(plane, res.segments(i), segment_style, seg_layer);
-  }
-
-  /**
-   * @brief Build a trapezoidal map and draw it.
-   *
-   * Convenience wrapper that constructs the map and draws it in one call.
-   */
-  [[nodiscard]] inline TrapezoidalMapPointLocation::Result
-  visualize_trapezoidal_map(
-      Tikz_Plane & plane,
-      const Array<Segment> & segments,
-      const Tikz_Style & segment_style = tikz_path_style("red"),
-      const Tikz_Style & extension_style = tikz_wire_style("gray!60", true),
-      const bool draw_trapezoids = true,
-      const double trapezoid_opacity = 0.3)
-  {
-    const TrapezoidalMapPointLocation tm;
-    auto result = tm(segments);
-    put_trapezoidal_map_result(plane, result, segment_style, extension_style,
-                               draw_trapezoids, trapezoid_opacity);
-    return result;
-  }
-
-  /**
-   * @brief Build a trapezoidal map from a polygon and draw it.
-   */
-  [[nodiscard]] inline TrapezoidalMapPointLocation::Result
-  visualize_trapezoidal_map(
-      Tikz_Plane & plane,
-      const Polygon & polygon,
-      const Tikz_Style & segment_style = tikz_path_style("red"),
-      const Tikz_Style & extension_style = tikz_wire_style("gray!60", true),
-      const bool draw_trapezoids = true,
-      const double trapezoid_opacity = 0.3)
-  {
-    TrapezoidalMapPointLocation tm;
-    auto result = tm(polygon);
-    put_trapezoidal_map_result(plane, result, segment_style, extension_style,
-                               draw_trapezoids, trapezoid_opacity);
-    return result;
-  }
-} // namespace Aleph
-
-# endif // TIKZGEOM_ALGORITHMS_H
+#endif  // TIKZGEOM_ALGORITHMS_H

--- a/tikzgeom_algorithms.H
+++ b/tikzgeom_algorithms.H
@@ -172,7 +172,7 @@ constexpr size_t SPP_NONE = ~static_cast<size_t>(0);
       if (cur == dst)
         break;
 
-      for (unsigned long nb : tris(cur).adj)
+      for (size_t nb : tris(cur).adj)
         if (nb != SPP_NONE and parent(nb) == SPP_NONE)
           {
             parent(nb) = cur;
@@ -264,7 +264,7 @@ constexpr size_t SPP_NONE = ~static_cast<size_t>(0);
       int sc = 0;
       bool found[3] = {false, false, false};
       for (int a = 0; a < 3; ++a)
-        for (const unsigned long b : tris(sleeve(i + 1)).v)
+        for (const size_t b : tris(sleeve(i + 1)).v)
           if (tris(sleeve(i)).v[a] == b)
             {
               found[a] = true;

--- a/tikzgeom_algorithms.H
+++ b/tikzgeom_algorithms.H
@@ -359,6 +359,24 @@ inline Tikz_Style tikz_path_style(const std::string &color = "red", const bool w
   return s;
 }
 
+/** @brief Creates a solid wireframe style with an explicit line width.
+ *
+ *  Used to visually distinguish a "result" outline (e.g. a simplified,
+ *  offset, or smoothed polygon) from a faded original, without relying on
+ *  `dashed`. `tikz_wire_style(color, width)` would silently set `dashed`
+ *  instead (its second parameter is a bool), which is why this exists.
+ *
+ *  @param color The stroke color.
+ *  @param width_mm Line width in millimeters (see `Tikz_Style::line_width_mm`).
+ *  @return A solid, non-dashed @ref Tikz_Style with the given line width.
+ */
+inline Tikz_Style tikz_bold_wire_style(const std::string &color, const double width_mm = 1.2)
+{
+  Tikz_Style s = tikz_wire_style(color);
+  s.line_width_mm = width_mm;
+  return s;
+}
+
 /** @brief Creates a style for drawing filled polygons.
  *
  *  This style is used for representing areas, like polygon intersections or
@@ -1897,7 +1915,7 @@ inline void put_mec_result(Tikz_Plane &plane, const MinimumEnclosingCircle::Circ
 inline void put_simplification_result(
   Tikz_Plane &plane, const Polygon &original, const Polygon &simplified,
   const Tikz_Style &original_style = tikz_wire_style("gray!50"),
-  const Tikz_Style &simplified_style = tikz_wire_style("blue!80", 1.2),
+  const Tikz_Style &simplified_style = tikz_bold_wire_style("blue!80"),
   const bool draw_vertices = true, const Tikz_Style &vertex_style = tikz_points_style("red"))
 {
   put_in_plane(plane, original, original_style);
@@ -1915,7 +1933,7 @@ inline void put_simplification_result(
   Tikz_Plane &plane, const Polygon &poly, const Geom_Number &epsilon,
   const DouglasPeuckerSimplification &algorithm = {},
   const Tikz_Style &original_style = tikz_wire_style("gray!50"),
-  const Tikz_Style &simplified_style = tikz_wire_style("blue!80", 1.2),
+  const Tikz_Style &simplified_style = tikz_bold_wire_style("blue!80"),
   const bool draw_vertices = true, const Tikz_Style &vertex_style = tikz_points_style("red"))
 {
   Polygon simplified = algorithm.simplify_polygon(poly, epsilon);
@@ -1933,7 +1951,7 @@ inline void put_simplification_result(
   Tikz_Plane &plane, const Polygon &poly, const Geom_Number &area_threshold,
   const VisvalingamWhyattSimplification &algorithm = {},
   const Tikz_Style &original_style = tikz_wire_style("gray!50"),
-  const Tikz_Style &simplified_style = tikz_wire_style("green!70!black", 1.2),
+  const Tikz_Style &simplified_style = tikz_bold_wire_style("green!70!black"),
   const bool draw_vertices = true, const Tikz_Style &vertex_style = tikz_points_style("red"))
 {
   Polygon simplified = algorithm.simplify_polygon(poly, area_threshold);
@@ -1960,7 +1978,7 @@ inline void put_simplification_result(
 inline void put_offset_result(Tikz_Plane &plane, const Polygon &original,
                               const PolygonOffset::Result &result,
                               const Tikz_Style &original_style = tikz_wire_style("gray!50"),
-                              const Tikz_Style &offset_style = tikz_wire_style("blue!80", 1.2),
+                              const Tikz_Style &offset_style = tikz_bold_wire_style("blue!80"),
                               const bool draw_vertices = true,
                               const Tikz_Style &vertex_style = tikz_points_style("red"))
 {
@@ -1983,7 +2001,7 @@ inline void put_offset_result(Tikz_Plane &plane, const Polygon &original,
   const PolygonOffset &algorithm = {}, PolygonOffset::JoinType join = PolygonOffset::JoinType::Miter,
   const Geom_Number &miter_limit = Geom_Number(2),
   const Tikz_Style &original_style = tikz_wire_style("gray!50"),
-  const Tikz_Style &offset_style = tikz_wire_style("blue!80", 1.2), const bool draw_vertices = true,
+  const Tikz_Style &offset_style = tikz_bold_wire_style("blue!80"), const bool draw_vertices = true,
   const Tikz_Style &vertex_style = tikz_points_style("red"))
 {
   PolygonOffset::Result result = algorithm(poly, distance, join, miter_limit);
@@ -2008,7 +2026,7 @@ inline void put_offset_result(Tikz_Plane &plane, const Polygon &original,
  */
 inline void put_smoothing_result(Tikz_Plane &plane, const Polygon &original, const Polygon &smoothed,
                                  const Tikz_Style &original_style = tikz_wire_style("gray!50"),
-                                 const Tikz_Style &smoothed_style = tikz_wire_style("violet!80", 1.2),
+                                 const Tikz_Style &smoothed_style = tikz_bold_wire_style("violet!80"),
                                  const bool draw_vertices = true,
                                  const Tikz_Style &vertex_style = tikz_points_style("red"))
 {
@@ -2027,7 +2045,7 @@ inline void put_smoothing_result(Tikz_Plane &plane, const Polygon &original, con
   Tikz_Plane &plane, const Polygon &poly, const size_t iterations,
   const Geom_Number &ratio = Geom_Number(1, 4),
   const Tikz_Style &original_style = tikz_wire_style("gray!50"),
-  const Tikz_Style &smoothed_style = tikz_wire_style("violet!80", 1.2),
+  const Tikz_Style &smoothed_style = tikz_bold_wire_style("violet!80"),
   const bool draw_vertices = true, const Tikz_Style &vertex_style = tikz_points_style("red"))
 {
   Polygon smoothed = ChaikinSmoothing::smooth_polygon(poly, iterations, ratio);
@@ -2068,7 +2086,7 @@ inline void put_trapezoidal_map_result(
       for (size_t i = 0; i < res.trapezoids.size(); ++i)
         {
           const Trap &t = res.trapezoids(i);
-          if (!not t.active)
+          if (not t.active)
             continue;
 
           // A trapezoid has 4 corners defined by:

--- a/tpl_r_tree.H
+++ b/tpl_r_tree.H
@@ -131,6 +131,31 @@ public:
     Payload value;   ///< User payload associated with @ref bbox.
   };
 
+  /** @brief One node of a @ref debug_snapshot, independent of `Payload`.
+   *
+   *  Unlike `AABBTree::DebugNode`, an R-tree node may have more than two
+   *  children, so @ref children lists every child by index into the
+   *  enclosing @ref DebugSnapshot::nodes rather than a fixed left/right pair.
+   */
+  struct DebugNode
+  {
+    Rectangle bbox;          ///< Tight MBR of this node.
+    bool is_leaf = false;    ///< True for leaf nodes (see @ref entry_boxes).
+    size_t depth = 0;        ///< Root is 0, increasing towards the leaves.
+    Array<size_t> children;  ///< Indices into `DebugSnapshot::nodes` (internal nodes).
+    Array<Rectangle> entry_boxes;  ///< Data-entry boxes stored here (leaves only).
+  };
+
+  /** @brief Full tree structure captured for visualization/debugging.
+   *  @note Intentionally omits `Payload`: it is available regardless of
+   *        whether `Payload` is copyable or even movable-only usable that way.
+   */
+  struct DebugSnapshot
+  {
+    Array<DebugNode> nodes;             ///< Every node, in preorder.
+    size_t root = std::numeric_limits<size_t>::max();  ///< Index of the root in @ref nodes.
+  };
+
 private:
   struct Node;
 
@@ -1081,6 +1106,53 @@ public:
     if (not verify_rec(*root_, 1, true, leaf_depth, count, mbr))
       return false;
     return count == size_ and leaf_depth == height_;
+  }
+
+  /** @brief Capture the full tree structure for visualization/debugging.
+   *  @return A @ref DebugSnapshot with every node in preorder; empty
+   *          (`nodes` empty, `root` unset) when the tree `is_empty()`.
+   *  @par Complexity O(n).
+   *  @throws std::bad_alloc if node allocation fails.
+   */
+  [[nodiscard]] DebugSnapshot debug_snapshot() const
+  {
+    DebugSnapshot snap;
+    if (root_ == nullptr)
+      return snap;
+
+    // Each `snap.nodes(out_idx)` access below is by index, re-fetched after
+    // every recursive call: `Array::append` may reallocate the backing
+    // storage, so a reference taken before recursing could dangle.
+    auto dfs = [&](const auto &self, const Node &node, const size_t depth) -> size_t
+      {
+        const size_t out_idx = snap.nodes.size();
+        snap.nodes.append(DebugNode{});
+        snap.nodes(out_idx).is_leaf = node.leaf;
+        snap.nodes(out_idx).depth = depth;
+
+        if (node.leaf)
+          {
+            Array<Rectangle> boxes;
+            boxes.reserve(node.data.size());
+            for (size_t i = 0; i < node.data.size(); ++i)
+              boxes.append(node.data(i).bbox);
+            snap.nodes(out_idx).entry_boxes = std::move(boxes);
+          }
+        else
+          {
+            Array<size_t> child_indices;
+            child_indices.reserve(node.children.size());
+            for (size_t i = 0; i < node.children.size(); ++i)
+              child_indices.append(self(self, *node.children(i).child, depth + 1));
+            snap.nodes(out_idx).children = std::move(child_indices);
+          }
+
+        snap.nodes(out_idx).bbox = compute_mbr(node);
+        return out_idx;
+      };
+
+    snap.root = dfs(dfs, *root_, 0);
+    return snap;
   }
 };
 

--- a/tpl_r_tree.H
+++ b/tpl_r_tree.H
@@ -142,8 +142,8 @@ public:
     Rectangle bbox;          ///< Tight MBR of this node.
     bool is_leaf = false;    ///< True for leaf nodes (see @ref entry_boxes).
     size_t depth = 0;        ///< Root is 0, increasing towards the leaves.
-    Array<size_t> children;  ///< Indices into `DebugSnapshot::nodes` (internal nodes).
-    Array<Rectangle> entry_boxes;  ///< Data-entry boxes stored here (leaves only).
+    Array<size_t> children = Array<size_t>(0);  ///< Indices into `DebugSnapshot::nodes` (internal nodes).
+    Array<Rectangle> entry_boxes = Array<Rectangle>(0);  ///< Data-entry boxes stored here (leaves only).
   };
 
   /** @brief Full tree structure captured for visualization/debugging.
@@ -170,8 +170,8 @@ private:
   struct Node
   {
     bool leaf = true;
-    Array<Entry> data;      ///< Data entries (used iff @ref leaf).
-    Array<Child> children;  ///< Child entries (used iff not @ref leaf).
+    Array<Entry> data = Array<Entry>(0);      ///< Data entries (used iff @ref leaf).
+    Array<Child> children = Array<Child>(0);  ///< Child entries (used iff not @ref leaf).
   };
 
   std::unique_ptr<Node> root_;
@@ -309,10 +309,8 @@ private:
   [[nodiscard]] static Array<EntryT> quadratic_split(Array<EntryT> &entries)
   {
     const size_t n = entries.size();
-    Array<EntryT> group1;
-    Array<EntryT> group2;
-    group1.reserve(n);
-    group2.reserve(n);
+    Array<EntryT> group1(n);
+    Array<EntryT> group2(n);
 
     Array<EntryT> items = std::move(entries);
     entries = Array<EntryT>();
@@ -428,10 +426,8 @@ private:
   [[nodiscard]] static Array<EntryT> rstar_split(Array<EntryT> &entries)
   {
     const size_t n = entries.size();
-    Array<EntryT> group1;
-    Array<EntryT> group2;
-    group1.reserve(n);
-    group2.reserve(n);
+    Array<EntryT> group1(n);
+    Array<EntryT> group2(n);
 
     Array<EntryT> items = std::move(entries);
     entries = Array<EntryT>();
@@ -567,8 +563,7 @@ private:
     if (p > MaxEntries + 1 - MinEntries)
       p = MaxEntries + 1 - MinEntries;
 
-    Array<Entry> kept;
-    kept.reserve(n - p);
+    Array<Entry> kept(n - p);
     rstar_reinsert_buffer_.reserve(rstar_reinsert_buffer_.size() + p);
     for (size_t k = p; k < n; ++k)
       kept.append(std::move(node.data(order[k])));
@@ -709,8 +704,7 @@ private:
         for (size_t i = 0; i < node.data.size(); ++i)
           if (node.data(i).bbox == bbox and node.data(i).value == value)
             {
-              Array<Entry> kept;
-              kept.reserve(node.data.size() - 1);
+              Array<Entry> kept(node.data.size() - 1);
               for (size_t j = 0; j < node.data.size(); ++j)
                 if (j != i)
                   kept.append(std::move(node.data(j)));
@@ -738,8 +732,7 @@ private:
                                  std::numeric_limits<size_t>::max() - orphan_count)
               << "RTree: orphan collection would overflow";
             orphans.reserve(orphans.size() + orphan_count);
-            Array<Child> kept;
-            kept.reserve(node.children.size() - 1);
+            Array<Child> kept(node.children.size() - 1);
             collect_data_entries(*c.child, orphans);
             for (size_t j = 0; j < node.children.size(); ++j)
               if (j != i)
@@ -1132,16 +1125,14 @@ public:
 
         if (node.leaf)
           {
-            Array<Rectangle> boxes;
-            boxes.reserve(node.data.size());
+            Array<Rectangle> boxes(node.data.size());
             for (size_t i = 0; i < node.data.size(); ++i)
               boxes.append(node.data(i).bbox);
             snap.nodes(out_idx).entry_boxes = std::move(boxes);
           }
         else
           {
-            Array<size_t> child_indices;
-            child_indices.reserve(node.children.size());
+            Array<size_t> child_indices(node.children.size());
             for (size_t i = 0; i < node.children.size(); ++i)
               child_indices.append(self(self, *node.children(i).child, depth + 1));
             snap.nodes(out_idx).children = std::move(child_indices);


### PR DESCRIPTION
…ithms

Se añade soporte para visualizar la estructura jerárquica de árboles R y R* (con sus MBR y cajas de entrada) en un plano TikZ, incluyendo consultas de intersección con rectángulos. Se implementan las funciones put_rtree_result, visualize_rtree y visualize_rtree_query, y se extiende la clase RTree (tpl_r_tree.H) con DebugNode, DebugSnapshot y el método debug_snapshot(). Se agregan pruebas unitarias y ejemplos completos de galería que incluyen quadtree y árboles R/R*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nuevas funcionalidades**
  - Añadido un ejemplo de galería TikZ con 20 visualizaciones de algoritmos de geometría computacional y estadísticas.
  - Ampliado el ejemplo de estructuras de árbol para visualizar QuadTree, RTree y RStarTree con consultas y métricas.
  - Incorporada una herramienta pública para inspeccionar la estructura interna de los árboles R mediante instantáneas de depuración.
- **Cambios visibles en visualizaciones**
  - Ajustados los estilos por defecto de líneas “wire” para que el ancho se aplique correctamente en simplificación, offset y suavizado.
- **Pruebas**
  - Añadidas comprobaciones estructurales para árboles R y RStarTree.
  - Añadidas pruebas para visualizaciones de consultas y árboles espaciales en TikZ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->